### PR TITLE
basic list functionality

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,12 +1,26 @@
 use clap::{Args, Parser, Subcommand};
 use std::path::PathBuf;
+use thiserror::Error;
 
 use crate::{
     config::Config,
-    installed_packages::InstalledPackageStorage,
+    installed_packages::{InstalledPackageStorage, InstalledPackagesError},
     installer::{error::InstallerError, installer::Installer},
     repositories::manager::RepositoryManager,
+    verifier::{get_packages, VerifierError},
 };
+
+#[derive(Error, Debug)]
+pub enum CommandError {
+    #[error("Error in installer: {0}")]
+    InstallerError(#[from] InstallerError),
+
+    #[error("Error while retrieving installed packages info: {0}")]
+    InstalledPackagesError(#[from] InstalledPackagesError),
+
+    #[error("Cannot read install directory: {0}")]
+    VerifierError(#[from] VerifierError),
+}
 
 #[derive(Parser, Debug)]
 #[command(name = "Packit", version, about)]
@@ -59,25 +73,16 @@ struct ListArgs {
 }
 
 /// Reads and handles the command.
-pub fn handle_command(manager: &RepositoryManager, config: &Config) -> Result<(), InstallerError> {
+pub fn handle_command(manager: &RepositoryManager, config: &Config) -> Result<(), CommandError> {
     let info_directory = config.install_directory.to_string() + "/info.toml";
     let mut installed_storage = InstalledPackageStorage::from(&info_directory)?;
     let command = Cli::parse();
 
+    // Handle commands with user specified arguments
     match command.command {
-        Commands::Install(args) => {
-            // Handle the install command with user specified arguments
-            let mut installer = Installer::new(&config, &mut installed_storage);
-            installer.install(manager, &args.package_name, args.version)?;
-        },
-        Commands::Uninstall(args) => {
-            // Handle the uninstall command with user specified arguments
-            let mut installer = Installer::new(&config, &mut installed_storage);
-            installer.uninstall(&args.package_name, args.version)?;
-        },
-        Commands::List(args) => {
-            handle_list(args)?;
-        },
+        Commands::Install(args) => Installer::new(&config, &mut installed_storage).install(manager, &args.package_name, args.version)?,
+        Commands::Uninstall(args) => Installer::new(&config, &mut installed_storage).uninstall(&args.package_name, args.version)?,
+        Commands::List(args) => handle_list(args, &installed_storage, &config)?,
     }
 
     // Save changes
@@ -87,6 +92,16 @@ pub fn handle_command(manager: &RepositoryManager, config: &Config) -> Result<()
 }
 
 /// Handles the list command with user specified arguments.
-fn handle_list(args: ListArgs) -> Result<(), InstallerError> {
-    todo!()
+fn handle_list(args: ListArgs, installed_storage: &InstalledPackageStorage, config: &Config) -> Result<(), VerifierError> {
+    if args.use_dir {
+        for package in get_packages(&config)? {
+            println!("{}", package);
+        }
+    } else {
+        for package in &installed_storage.installed_packages {
+            println!("{} {}", package.name, package.version);
+        }
+    }
+
+    Ok(())
 }

--- a/src/verifier.rs
+++ b/src/verifier.rs
@@ -1,3 +1,14 @@
+use std::fs;
+use thiserror::Error;
+
+use crate::config::Config;
+
+#[derive(Error, Debug)]
+pub enum VerifierError {
+    #[error("Cannot read install directory: {0}")]
+    IOError(#[from] std::io::Error),
+}
+
 /// TODO: Verifies if a specific package works
 pub fn verify_package() {}
 
@@ -6,6 +17,33 @@ pub fn verify_package() {}
 /// TODO: Implement
 pub fn package_exists(package_name: &String, version: &Option<String>) -> bool {
     true
+}
+
+/// Gets the installed packages, by actually checking the install directory.
+pub fn get_packages(config: &Config) -> Result<Vec<String>, VerifierError> {
+    // Look inside the packit install directory for package installations
+    let mut packages: Vec<String> = Vec::new();
+    let directory = fs::read_dir(&config.install_directory)?;
+    for package_entry in directory {
+        let package_entry = package_entry?;
+        let path = package_entry.path();
+        if path.is_file() {
+            continue;
+        }
+
+        // Look inside the package installation for multiple versions
+        let package_name = package_entry.file_name();
+        for version_entry in fs::read_dir(path)? {
+            let version_entry = version_entry?;
+            if version_entry.path().is_file() {
+                continue;
+            }
+
+            packages.push(package_name.to_str().unwrap().to_string() + " " + version_entry.file_name().to_str().unwrap());
+        }
+    }
+
+    Ok(packages)
 }
 
 // TODO: Make a method that syncs info.toml and actuall directory (in case of out of sync)


### PR DESCRIPTION
Basic list functionality to list installed packages. It also implements part of the verifier, which checks the install directory instead of the info.toml file (when the -u flag is used). 