### PR TITLE
Feature unlink symlinks during uninstall

### DIFF
--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -1,7 +1,8 @@
 use thiserror::Error;
 
 use crate::{
-    cli::DisplayError, installed_packages::InstalledPackagesError, installer::scripts::ScriptError, repositories::error::RepositoryError,
+    cli::DisplayError, installed_packages::InstalledPackagesError, installer::scripts::ScriptError, platforms::symlink::SymlinkError,
+    repositories::error::RepositoryError,
 };
 
 /// The errors that occur during installation.
@@ -53,6 +54,9 @@ pub enum InstallerError {
 
     #[error("Cannot execute script: {0}")]
     ScriptError(#[from] ScriptError),
+
+    #[error("Cannot execute symlink opperation: {0}")]
+    SymlinkError(#[from] SymlinkError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, InstallerError>;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    cli::{self, ask_user, QuestionResponse, Spinner},
+    cli::{ask_user, QuestionResponse, Spinner},
     config::Config,
     installed_packages::InstalledPackageStorage,
     installer::{
@@ -11,7 +11,10 @@ use crate::{
     repositories::manager::RepositoryManager,
 };
 
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 /// The installer of Packit, managing the installation of packages on the system.
 pub struct Installer<'a> {
@@ -176,17 +179,11 @@ impl<'a> Installer<'a> {
         let installed_package =
             self.installed_storage.get_package(package_name, &version).expect("Expected package to exist at this point.");
 
-        // Give an error when the user tries to uninstall an external package
+        // Return an error when the user tries to uninstall an external package
         if installed_package.external {
             return Err(InstallerError::ExternalError {
                 package_name: package_name.into(),
             });
-        }
-
-        // Check if the package was symlinked
-        if installed_package.symlinked {
-            //TODO
-            cli::display_warning("Package was symlinked, symlink deletion is not yet implemented!");
         }
 
         // Remove entire package directory if there is only one version
@@ -196,6 +193,11 @@ impl<'a> Installer<'a> {
         } else {
             // The remove directory of a specific package version
             directory = self.config.prefix_directory.to_string() + "/packages/" + package_name + "/" + version;
+        }
+
+        // Check if the package was symlinked
+        if installed_package.symlinked {
+            self.remove_symlinks(Path::new(&directory))?;
         }
 
         // Delete the determined directory
@@ -234,16 +236,16 @@ impl<'a> Installer<'a> {
             });
         }
 
+        // Path to the determined directory
+        let directory = self.config.prefix_directory.to_string() + "/packages/" + package_name;
+
         // Check if package was symlinked
         for package_version in &installed_versions {
             if package_version.symlinked {
-                //TODO
-                cli::display_warning("Package was symlinked, symlink deletion is not yet implemented!");
+                self.remove_symlinks(Path::new(&directory))?;
             }
         }
 
-        // Delete the determined directory
-        let directory = self.config.prefix_directory.to_string() + "/packages/" + package_name;
         self.remove_dir_all(&directory, package_name)?;
 
         // Delete the installed package from toml
@@ -340,6 +342,32 @@ impl<'a> Installer<'a> {
         }
 
         Ok(())
+    }
+
+    fn remove_symlinks(&self, destination_dir: &Path) -> Result<()> {
+        for symlink in self.find_symlinks(destination_dir)? {
+            symlink::remove_symlink(&symlink)?;
+        }
+
+        Ok(())
+    }
+
+    /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match).
+    fn find_symlinks(&self, destination_dir: &Path) -> Result<Vec<PathBuf>> {
+        let mut symlinks = Vec::new();
+        for file in fs::read_dir(&self.config.prefix_directory)? {
+            let file = file?;
+
+            if file.file_type()?.is_dir() {
+                symlinks.extend(self.find_symlinks(destination_dir)?);
+            }
+
+            if file.file_type()?.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
+                symlinks.push(file.path());
+            }
+        }
+
+        Ok(symlinks)
     }
 
     fn can_write_prefix_dir(&self) -> Result<bool> {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -240,6 +240,7 @@ impl<'a> Installer<'a> {
         for package_version in &installed_versions {
             if package_version.symlinked {
                 self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+                break;
             }
         }
 
@@ -345,8 +346,9 @@ impl<'a> Installer<'a> {
     fn remove_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<()> {
         for file in fs::read_dir(search_dir)? {
             let file = file?;
+            let file_type = file.file_type()?;
 
-            if file.file_type()?.is_dir() {
+            if file_type.is_dir() {
                 self.remove_symlinks(&file.path(), destination_dir)?;
 
                 // Remove the directory if it is empty after removing symlinks
@@ -355,7 +357,7 @@ impl<'a> Installer<'a> {
                 }
             }
 
-            if file.file_type()?.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
+            if file_type.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
                 symlink::remove_symlink(&file.path())?
             }
         }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -345,7 +345,8 @@ impl<'a> Installer<'a> {
     }
 
     fn remove_symlinks(&self, destination_dir: &Path) -> Result<()> {
-        for symlink in self.find_symlinks(destination_dir)? {
+        let symlinks = self.find_symlinks(Path::new(&self.config.prefix_directory), destination_dir)?;
+        for symlink in symlinks {
             symlink::remove_symlink(&symlink)?;
         }
 
@@ -353,13 +354,13 @@ impl<'a> Installer<'a> {
     }
 
     /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match).
-    fn find_symlinks(&self, destination_dir: &Path) -> Result<Vec<PathBuf>> {
+    fn find_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<Vec<PathBuf>> {
         let mut symlinks = Vec::new();
-        for file in fs::read_dir(&self.config.prefix_directory)? {
+        for file in fs::read_dir(search_dir)? {
             let file = file?;
 
             if file.file_type()?.is_dir() {
-                symlinks.extend(self.find_symlinks(destination_dir)?);
+                symlinks.extend(self.find_symlinks(&file.path(), destination_dir)?);
             }
 
             if file.file_type()?.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -11,10 +11,7 @@ use crate::{
     repositories::manager::RepositoryManager,
 };
 
-use std::{
-    fs,
-    path::{Path, PathBuf},
-};
+use std::{fs, path::Path};
 
 /// The installer of Packit, managing the installation of packages on the system.
 pub struct Installer<'a> {
@@ -197,7 +194,7 @@ impl<'a> Installer<'a> {
 
         // Check if the package was symlinked
         if installed_package.symlinked {
-            self.remove_symlinks(Path::new(&directory))?;
+            self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
         }
 
         // Delete the determined directory
@@ -242,7 +239,7 @@ impl<'a> Installer<'a> {
         // Check if package was symlinked
         for package_version in &installed_versions {
             if package_version.symlinked {
-                self.remove_symlinks(Path::new(&directory))?;
+                self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
             }
         }
 
@@ -344,31 +341,26 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    fn remove_symlinks(&self, destination_dir: &Path) -> Result<()> {
-        let symlinks = self.find_symlinks(Path::new(&self.config.prefix_directory), destination_dir)?;
-        for symlink in symlinks {
-            symlink::remove_symlink(&symlink)?;
-        }
-
-        Ok(())
-    }
-
     /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match).
-    fn find_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<Vec<PathBuf>> {
-        let mut symlinks = Vec::new();
+    fn remove_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<()> {
         for file in fs::read_dir(search_dir)? {
             let file = file?;
 
             if file.file_type()?.is_dir() {
-                symlinks.extend(self.find_symlinks(&file.path(), destination_dir)?);
+                self.remove_symlinks(&file.path(), destination_dir)?;
+
+                // Remove the directory if it is empty after removing symlinks
+                if fs::read_dir(file.path())?.next().is_none() {
+                    fs::remove_dir(file.path())?;
+                }
             }
 
             if file.file_type()?.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
-                symlinks.push(file.path());
+                symlink::remove_symlink(&file.path())?
             }
         }
 
-        Ok(symlinks)
+        Ok(())
     }
 
     fn can_write_prefix_dir(&self) -> Result<bool> {

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -21,3 +21,9 @@ pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::
 pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
     panic!("Cannot create link for target, target is not supported.");
 }
+
+pub fn remove_symlink(symlink: &Path) -> Result<(), std::io::Error> {
+    std::fs::remove_file(symlink)?;
+
+    Ok(())
+}

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -1,14 +1,26 @@
 use std::path::Path;
 
+use thiserror::Error;
+
+/// The errors that occur during display.
+#[derive(Error, Debug)]
+pub enum SymlinkError {
+    #[error("Symlink IO failed: {0}")]
+    IOError(#[from] std::io::Error),
+
+    #[error("Path is not a symlink")]
+    NonSymlink,
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
-pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), SymlinkError> {
     std::os::unix::fs::symlink(source, destination)?;
 
     Ok(())
 }
 
 #[cfg(target_os = "windows")]
-pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), SymlinkError> {
     match source.is_dir() {
         true => std::os::windows::fs::symlink_dir(source, destination)?,
         false => std::os::windows::fs::symlink_file(source, destination)?,
@@ -18,11 +30,15 @@ pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::
 }
 
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), std::io::Error> {
+pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), SymlinkError> {
     panic!("Cannot create link for target, target is not supported.");
 }
 
-pub fn remove_symlink(symlink: &Path) -> Result<(), std::io::Error> {
+pub fn remove_symlink(symlink: &Path) -> Result<(), SymlinkError> {
+    if !symlink.is_symlink() {
+        return Err(SymlinkError::NonSymlink);
+    }
+
     std::fs::remove_file(symlink)?;
 
     Ok(())


### PR DESCRIPTION
Unlinks symlinks from Packit during the install by looping over all Packit directories and searching for symlinks which point to  or inside of the package that will be uninstalled.