### PR TITLE
Implement active packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Packit is a universal package manager, designed to streamline the experience of installing packages on your system.
 
+
 ## Install
 TODO
+
 
 ## Usage
 The general usage of Packit is: `pit <COMMAND>`.
@@ -23,8 +25,10 @@ Lists all configured repositories.
 #### `pit search <PACKAGE-NAME> [<VERSION>]`
 Searches a package with `<PACKAGE-NAME>`. If the version is given Packit will search for that specific version.
 
+
 ## File structure
 You might be interested in how (and why) Packit manages build dependencies, configs and most importantly the installs. We explain that here, ofcourse this differs a bit for each platform as they have different file structures. Luckly Packit manages this for you!
+
 
 ### Unix systems
 For these directories we use `/opt/packit`, to support usage of Packit by other users then the superuser.
@@ -32,11 +36,15 @@ For these directories we use `/opt/packit`, to support usage of Packit by other 
 #### Package install files
 The installs will go to: `/opt/packit/packages/<PACKAGE-NAME>/<PACKAGE-VERSION>/`.
 
+#### Active packages
+The currently active version of a package will be symlinked in `/opt/packit/active/<PACKAGE-NAME>`. This will link to `/opt/packit/packages/<PACKAGE-NAME>/<ACTIVE-PACKAGE-VERSION>`
+
 #### Symlinks
-The install binaries will be symlinked in: `/opt/packit/bin/<EXECUTABLE-NAME>`. So this directory needs to be present in the users path. 
+The active binaries will be symlinked in: `/opt/packit/bin/<EXECUTABLE-NAME>`. This directory needs to be present in the users `PATH` in order for installe binaries to be detected by your system.
 
 #### Packit configs
 The Packit configs are located in: `/etc/packit/`, this will include `Config.toml` and `Installed.toml`. 
+
 
 ### Windows
 There is no clear directory where packages, binaries or configs are supposed to go in Windows. For this reason we chose to use `%APPDATA%`. 
@@ -44,8 +52,11 @@ There is no clear directory where packages, binaries or configs are supposed to 
 #### Package install files
 The installs will go to: `%APPDATA%/packit/packages/<PACKAGE-NAME>/<PACKAGE-VERSION>/`.
 
+#### Active packages
+The currently active version of a package will be symlinked in `%APPDATA%/packit/active/<PACKAGE-NAME>`. This will link to `%APPDATA%/packit/packages/<PACKAGE-NAME>/<ACTIVE-PACKAGE-VERSION>`
+
 #### Symlinks
-The install binaries will be symlinked in: `%APPDATA%/packit/bin/<EXECUTABLE-NAME>`
+The active binaries will be symlinked in: `%APPDATA%/packit/bin/<EXECUTABLE-NAME>`
 
 #### Packit configs
 The Packit configs are located in: `%APPDATA%/packit/`, this will include `Config.toml` and `Installed.toml`. 

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -24,12 +24,6 @@ impl HandleCommand for InstallArgs {
         let installed_dir = InstalledPackageStorage::get_default_path();
         let mut installed_storage = InstalledPackageStorage::from(&installed_dir).unwrap_or_exit(1);
 
-        // Make sure the package doesn't already exist before installing
-        if installed_storage.get_package_versions(&self.package_name).len() >= 1 {
-            println!("Package '{}' already exists.", &self.package_name);
-            return;
-        }
-
         Installer::new(&config, &mut installed_storage, &manager).install(&self.package_name, &self.version).unwrap_or_exit(1);
 
         // Save changes

--- a/src/installed_packages.rs
+++ b/src/installed_packages.rs
@@ -43,6 +43,7 @@ pub struct InstalledPackage {
     pub dependencies: Vec<Dependency>,
     pub install_path: PathBuf,
     pub symlinked: bool,
+    pub active: bool,
 
     /// True when the package is found on the system but not installed by Packit, false otherwise
     pub external: bool,
@@ -102,6 +103,7 @@ impl InstalledPackageStorage {
         source_repository: &Repository,
         install_path: &PathBuf,
         symlinked: bool,
+        active: bool,
     ) {
         // Add global and target specific dependencies together
         let mut dependencies = package_version.dependencies.clone();
@@ -119,6 +121,7 @@ impl InstalledPackageStorage {
             dependencies,
             install_path: install_path.into(),
             symlinked,
+            active,
             external: false,
         };
 
@@ -143,6 +146,20 @@ impl InstalledPackageStorage {
         let mut result = Vec::new();
 
         for package in &self.installed_packages {
+            if package.name == package_name {
+                result.push(package);
+            }
+        }
+
+        result
+    }
+
+    /// Gets all installed versions of a certain package from the storage.
+    /// Returns a list containing all installed versions, which is empty if the package is not installed.
+    pub fn get_package_versions_mut(&mut self, package_name: &str) -> Vec<&mut InstalledPackage> {
+        let mut result = Vec::new();
+
+        for package in self.installed_packages.iter_mut() {
             if package.name == package_name {
                 result.push(package);
             }

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -55,7 +55,7 @@ pub enum InstallerError {
     #[error("Cannot execute script")]
     ScriptError(#[from] ScriptError),
 
-    #[error("Cannot execute symlink opperation")]
+    #[error("Cannot execute symlink operation")]
     SymlinkError(#[from] SymlinkError),
 
     #[error("Cannot build package")]

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -105,8 +105,30 @@ impl<'a> Installer<'a> {
             None => package_version.skip_symlinking,
         };
 
+        let mut should_set_to_active = true;
+        let mut should_symlink = !skip_symlinking;
+
+        // Check if we have a previous active install
+        if let Some(previous_active) = self.installed_storage.get_package_versions(&package_name).iter().find(|x| x.active) {
+            // Prompt user if the installed version is newer than the version currently installing
+            if previous_active.version > *version {
+                let question = format!(
+                    "A newer version ({}) of this package is currently active, do you want to change the active version to the older version ({version})?", previous_active.version
+                );
+                should_set_to_active = ask_user(&question, QuestionResponse::No)?.is_yes();
+            }
+
+            // Prompt user if the installed version is not symlinked and we're not skipping symlinking
+            if should_set_to_active && !previous_active.symlinked && !skip_symlinking {
+                let question = format!("The current active version of this package ({}) is not symlinked, do you want to proceed with symlinking the newly installed version", previous_active.version);
+                should_symlink = ask_user(&question, QuestionResponse::No)?.is_yes();
+            }
+        }
+
         // If package is installed succesfully, set it to active
-        self.set_active(&package.name, &package_version.version, !skip_symlinking)?;
+        if should_set_to_active {
+            self.set_active(&package.name, &package_version.version, should_symlink)?;
+        }
 
         // Download and run test script if it exists
         let script_path = package_version.get_test_script_path(TARGET_ARCHITECTURE)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -90,7 +90,7 @@ impl<'a> Installer<'a> {
         }
 
         // Add and save package to installed storage toml
-        self.installed_storage.add_package(&package, &package_version, source_repository, &install_directory, false);
+        self.installed_storage.add_package(&package, &package_version, source_repository, &install_directory, false, false);
         self.installed_storage.save_to(&InstalledPackageStorage::get_default_path())?;
 
         // Download and run post install script if it exists
@@ -124,6 +124,9 @@ impl<'a> Installer<'a> {
         if let Some(script_file) = scripts::download_script(self.repository_manager, &script_path, package_name, &repository_id)? {
             scripts::run_test_script(script_file, &install_directory, self.config, &script_args)?;
         }
+
+        // If package is installed succesfully, set it to active
+        self.set_active(&package.name, &package_version.version)?;
 
         Ok(())
     }
@@ -407,5 +410,44 @@ impl<'a> Installer<'a> {
         }
 
         Ok(current_highest.ok_or(InstallerError::SupportError(dependency.to_string()))?)
+    }
+
+    fn set_active(&mut self, package_name: &str, package_version: &Version) -> Result<()> {
+        // Get package to set to active
+        let package = match self.installed_storage.get_package_mut(&package_name, &package_version, false) {
+            Some(package) => package,
+            None => {
+                warning!("Cannot get installed package from installed storage... Please check installation with 'pit list'");
+                return Ok(());
+            },
+        };
+
+        let global_active_path = Path::new(&self.config.prefix_directory).join("active");
+        let active_path = global_active_path.join(&package.name);
+
+        // Create symlink
+        fs::create_dir_all(global_active_path)?;
+        symlink::create_symlink(&package.install_path, &active_path)?;
+
+        // Update package storage
+        package.active = true;
+
+        // Set all other packages to inactive
+        for installed in self.installed_storage.get_package_versions_mut(&package_name) {
+            if !installed.active {
+                continue;
+            }
+
+            if installed.version == *package_version {
+                continue;
+            }
+
+            installed.active = false;
+        }
+
+        // Save package storage
+        self.installed_storage.save_to(&InstalledPackageStorage::get_default_path())?;
+
+        Ok(())
     }
 }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -100,13 +100,12 @@ impl<'a> Installer<'a> {
         }
 
         // Check if symlinking should be skipped
-        let skip_symlinking = match target.skip_symlinking {
+        let mut should_symlink = !match target.skip_symlinking {
             Some(skip_symlinking) => skip_symlinking,
             None => package_version.skip_symlinking,
         };
 
         let mut should_set_to_active = true;
-        let mut should_symlink = !skip_symlinking;
 
         // Check if we have a previous active install
         if let Some(previous_active) = self.installed_storage.get_package_versions(&package_name).iter().find(|x| x.active) {
@@ -119,9 +118,14 @@ impl<'a> Installer<'a> {
             }
 
             // Prompt user if the installed version is not symlinked and we're not skipping symlinking
-            if should_set_to_active && !previous_active.symlinked && !skip_symlinking {
+            if should_set_to_active && !previous_active.symlinked && should_symlink {
                 let question = format!("The current active version of this package ({}) is not symlinked, do you want to proceed with symlinking the newly installed version", previous_active.version);
                 should_symlink = ask_user(&question, QuestionResponse::No)?.is_yes();
+            }
+
+            // Show warning if the not symlinking but package was previously symlinked
+            if should_set_to_active && previous_active.symlinked && !should_symlink {
+                warning!("The new active package version will not be symlinked, while the previously active version was symlinked. The package will not be automatically findable by your system anymore.");
             }
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -38,6 +38,7 @@ impl<'a> Installer<'a> {
     }
 
     /// Installs the given package and its dependencies.
+    /// TODO: Only except explicit version, not an option (move that logic outside of the install)
     pub fn install(&mut self, package_name: &str, version: &Option<Version>) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
@@ -305,7 +306,10 @@ impl<'a> Installer<'a> {
 
         // Remove active path symlink
         let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
-        symlink::remove_symlink(&active_path)?;
+        match active_path.exists() {
+            true => symlink::remove_symlink(&active_path)?,
+            false => warning!("Active symlink did not exist, was the package even installed succesfully?"),
+        }
 
         self.remove_dir_all(&directory, package_name)?;
 
@@ -455,13 +459,13 @@ impl<'a> Installer<'a> {
 
         let package_install_path = package.install_path.clone();
 
-        // Create symlink
-        fs::create_dir_all(global_active_path)?;
-        symlink::create_symlink(&package_install_path, &active_path)?;
-
         // Remove old symlinks
         let package_directory = self.config.prefix_directory.join("packages").join(package_name);
         self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
+
+        // Create active symlink
+        fs::create_dir_all(global_active_path)?;
+        symlink::create_symlink(&package_install_path, &active_path)?;
 
         // Only create new symlinks if we should symlink
         if should_symlink {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -105,28 +105,14 @@ impl<'a> Installer<'a> {
             None => package_version.skip_symlinking,
         };
 
-        // Create symlinks for package
-        if !skip_symlinking {
-            self.create_symlinks(Path::new(&install_directory))?;
-
-            // Update symlinked state in installed storage
-            match self.installed_storage.get_package_mut(&package.name, &package_version.version, false) {
-                Some(package) => {
-                    package.symlinked = true;
-                    self.installed_storage.save_to(&InstalledPackageStorage::get_default_path())?;
-                },
-                None => warning!("Cannot get installed package from installed storage... Please check installation with 'pit list'"),
-            }
-        }
+        // If package is installed succesfully, set it to active
+        self.set_active(&package.name, &package_version.version, !skip_symlinking)?;
 
         // Download and run test script if it exists
         let script_path = package_version.get_test_script_path(TARGET_ARCHITECTURE)?;
         if let Some(script_file) = scripts::download_script(self.repository_manager, &script_path, package_name, &repository_id)? {
             scripts::run_test_script(script_file, &install_directory, self.config, &script_args)?;
         }
-
-        // If package is installed succesfully, set it to active
-        self.set_active(&package.name, &package_version.version)?;
 
         Ok(())
     }
@@ -233,6 +219,17 @@ impl<'a> Installer<'a> {
             self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
         }
 
+        // Change active package when uninstalled package is currently active
+        if installed_package.active {
+            let mut other_versions = self.installed_storage.get_package_versions(package_name);
+            other_versions.retain(|x| x.version != *version);
+            other_versions.sort_by_key(|x| &x.version);
+
+            if let Some(newest) = other_versions.last() {
+                self.set_active(package_name, &newest.version.clone(), installed_package.symlinked)?;
+            }
+        }
+
         // Delete the determined directory
         self.remove_dir_all(&directory, package_name)?;
 
@@ -279,6 +276,10 @@ impl<'a> Installer<'a> {
                 break;
             }
         }
+
+        // Remove active path symlink
+        let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
+        symlink::remove_symlink(&active_path)?;
 
         self.remove_dir_all(&directory, package_name)?;
 
@@ -412,9 +413,10 @@ impl<'a> Installer<'a> {
         Ok(current_highest.ok_or(InstallerError::SupportError(dependency.to_string()))?)
     }
 
-    fn set_active(&mut self, package_name: &str, package_version: &Version) -> Result<()> {
+    /// Sets a package to active and create the appropiate symlinks for it
+    fn set_active(&mut self, package_name: &str, package_version: &Version, should_symlink: bool) -> Result<()> {
         // Get package to set to active
-        let package = match self.installed_storage.get_package_mut(&package_name, &package_version, false) {
+        let package = match self.installed_storage.get_package(&package_name, &package_version) {
             Some(package) => package,
             None => {
                 warning!("Cannot get installed package from installed storage... Please check installation with 'pit list'");
@@ -425,24 +427,29 @@ impl<'a> Installer<'a> {
         let global_active_path = Path::new(&self.config.prefix_directory).join("active");
         let active_path = global_active_path.join(&package.name);
 
+        let package_install_path = package.install_path.clone();
+
         // Create symlink
         fs::create_dir_all(global_active_path)?;
-        symlink::create_symlink(&package.install_path, &active_path)?;
+        symlink::create_symlink(&package_install_path, &active_path)?;
 
-        // Update package storage
-        package.active = true;
+        let package_directory = self.config.prefix_directory.join("packages").join(package_name);
+        self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
+
+        if should_symlink {
+            self.create_symlinks(Path::new(&package_install_path))?;
+        }
 
         // Set all other packages to inactive
         for installed in self.installed_storage.get_package_versions_mut(&package_name) {
-            if !installed.active {
-                continue;
-            }
-
             if installed.version == *package_version {
+                installed.active = true;
+                installed.symlinked = should_symlink;
                 continue;
             }
 
             installed.active = false;
+            installed.symlinked = false;
         }
 
         // Save package storage

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -459,21 +459,25 @@ impl<'a> Installer<'a> {
         fs::create_dir_all(global_active_path)?;
         symlink::create_symlink(&package_install_path, &active_path)?;
 
+        // Remove old symlinks
         let package_directory = self.config.prefix_directory.join("packages").join(package_name);
         self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
 
+        // Only create new symlinks if we should symlink
         if should_symlink {
             self.create_symlinks(Path::new(&package_install_path))?;
         }
 
-        // Set all other packages to inactive
+        // Update the installed storage according to the changes
         for installed in self.installed_storage.get_package_versions_mut(&package_name) {
+            // Update new active version in storage
             if installed.version == *package_version {
                 installed.active = true;
                 installed.symlinked = should_symlink;
                 continue;
             }
 
+            // Update other packages in storage
             installed.active = false;
             installed.symlinked = false;
         }


### PR DESCRIPTION
This pull requests implements the functionality to set packages as active. Active packages are simply accessible through `/opt/packit/active/`.

TODO:
- [x] Handle edge cases based on versioning
- [x] Implement active paths in build env
- [x] Update README