### PR TITLE
Add extra commands

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,9 +1,11 @@
 mod install;
+mod link;
 mod list;
 mod repositories;
 mod search;
 mod switch;
 mod uninstall;
+mod unlink;
 
 use std::process::exit;
 
@@ -12,8 +14,8 @@ use clap::{builder::Styles, Parser, Subcommand};
 use crate::{
     cli::{
         commands::{
-            install::InstallArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs,
-            uninstall::UninstallArgs,
+            install::InstallArgs, link::LinkArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs,
+            uninstall::UninstallArgs, unlink::UnlinkArgs,
         },
         display::logging::error,
     },
@@ -48,6 +50,12 @@ enum Commands {
 
     /// Switch the active version of a package
     Switch(SwitchArgs),
+
+    /// Create symlinks for a certain package
+    Link(LinkArgs),
+
+    /// Remove symlinks for a certain package
+    Unlink(UnlinkArgs),
 }
 
 impl Cli {
@@ -79,6 +87,8 @@ impl Cli {
             Commands::Repositories(args) => args,
             Commands::Search(args) => args,
             Commands::Switch(args) => args,
+            Commands::Link(args) => args,
+            Commands::Unlink(args) => args,
         };
 
         args.handle(config, manager);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -2,6 +2,7 @@ mod install;
 mod list;
 mod repositories;
 mod search;
+mod switch;
 mod uninstall;
 
 use std::process::exit;
@@ -10,7 +11,10 @@ use clap::{builder::Styles, Parser, Subcommand};
 
 use crate::{
     cli::{
-        commands::{install::InstallArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs, uninstall::UninstallArgs},
+        commands::{
+            install::InstallArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs,
+            uninstall::UninstallArgs,
+        },
         display::logging::error,
     },
     config::Config,
@@ -41,6 +45,9 @@ enum Commands {
 
     /// Search a certain package
     Search(SearchArgs),
+
+    /// Switch the active version of a package
+    Switch(SwitchArgs),
 }
 
 impl Cli {
@@ -71,6 +78,7 @@ impl Cli {
             Commands::List(args) => args,
             Commands::Repositories(args) => args,
             Commands::Search(args) => args,
+            Commands::Switch(args) => args,
         };
 
         args.handle(config, manager);

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,3 +1,4 @@
+mod fix;
 mod install;
 mod link;
 mod list;
@@ -14,8 +15,8 @@ use clap::{builder::Styles, Parser, Subcommand};
 use crate::{
     cli::{
         commands::{
-            install::InstallArgs, link::LinkArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs,
-            uninstall::UninstallArgs, unlink::UnlinkArgs,
+            fix::FixArgs, install::InstallArgs, link::LinkArgs, list::ListArgs, repositories::RepositoryArgs, search::SearchArgs,
+            switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs,
         },
         display::logging::error,
     },
@@ -56,6 +57,9 @@ enum Commands {
 
     /// Remove symlinks for a certain package
     Unlink(UnlinkArgs),
+
+    /// Check the installation and fix problems
+    Fix(FixArgs),
 }
 
 impl Cli {
@@ -89,6 +93,7 @@ impl Cli {
             Commands::Switch(args) => args,
             Commands::Link(args) => args,
             Commands::Unlink(args) => args,
+            Commands::Fix(args) => args,
         };
 
         args.handle(config, manager);

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -1,0 +1,16 @@
+use clap::Args;
+
+use crate::{
+    cli::{commands::HandleCommand, display::logging::warning},
+    config::Config,
+    repositories::manager::RepositoryManager,
+};
+
+#[derive(Args, Debug)]
+pub struct FixArgs;
+
+impl HandleCommand for FixArgs {
+    fn handle(&self, _: &Config, _: &RepositoryManager) {
+        warning!("This command is not yet fully implemented");
+    }
+}

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -16,6 +16,10 @@ pub struct InstallArgs {
     /// The name of the package to install, with an optional version specified with NAME@VERSION
     #[arg(num_args(0..))]
     pub packages: Vec<String>,
+
+    /// True to build from source locally, false to use a prebuild version
+    #[arg(long, default_value = "false")]
+    pub build: bool,
 }
 
 impl HandleCommand for InstallArgs {
@@ -46,7 +50,7 @@ impl HandleCommand for InstallArgs {
 
         // Install all packages
         for (package_name, version) in packages {
-            if let Err(error) = installer.install(&package_name, version.as_ref()) {
+            if let Err(error) = installer.install(&package_name, version.as_ref(), self.build) {
                 error!(error, "Cannot install package {package_name}");
             }
         }

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -1,22 +1,21 @@
+use std::str::FromStr;
+
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand,
+    cli::{commands::HandleCommand, display::logging::error},
     config::Config,
     error_handling::HandleError,
-    installer::{installer::Installer, types::Version},
+    installer::{installer::Installer, types::PackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };
 
 #[derive(Args, Debug)]
 pub struct InstallArgs {
-    /// The name of the package to install
-    pub package_name: String,
-
-    /// The version of the package to install
-    #[arg(short, long)]
-    pub version: Option<Version>,
+    /// The name of the package to install, with an optional version specified with NAME@VERSION
+    #[arg(num_args(0..))]
+    pub packages: Vec<String>,
 }
 
 impl HandleCommand for InstallArgs {
@@ -24,9 +23,33 @@ impl HandleCommand for InstallArgs {
         let register_dir = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
+        let mut installer = Installer::new(&config, &mut register, &manager);
+
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)
 
-        Installer::new(&config, &mut register, &manager).install(&self.package_name, self.version.as_ref()).unwrap_or_exit(1);
+        let mut packages = Vec::new();
+
+        // Convert packages into package name and version
+        for package in &self.packages {
+            if package.contains("@") {
+                let package_id =
+                    PackageId::from_str(&package).unwrap_or_exit_msg(&format!("Package '{package}' is not a valid package identifier."), 1);
+
+                packages.push((package_id.name, Some(package_id.version)));
+                continue;
+            }
+
+            packages.push((package.into(), None));
+        }
+
+        // TODO: check for duplicate packages in Vec
+
+        // Install all packages
+        for (package_name, version) in packages {
+            if let Err(error) = installer.install(&package_name, version.as_ref()) {
+                error!(error, "Cannot install package {package_name}");
+            }
+        }
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -20,6 +20,14 @@ pub struct InstallArgs {
     /// True to build from source locally, false to use a prebuild version
     #[arg(long, default_value = "false")]
     pub build: bool,
+
+    /// True to skip symlinking the package, false to use defaults specified for the package
+    #[arg(long, default_value = "false")]
+    pub skip_symlinking: bool,
+
+    /// True to skip setting the package to active, false to use default behaviour
+    #[arg(long, default_value = "false")]
+    pub skip_active: bool,
 }
 
 impl HandleCommand for InstallArgs {
@@ -50,7 +58,7 @@ impl HandleCommand for InstallArgs {
 
         // Install all packages
         for (package_name, version) in packages {
-            if let Err(error) = installer.install(&package_name, version.as_ref(), self.build) {
+            if let Err(error) = installer.install(&package_name, version.as_ref(), self.build, self.skip_symlinking, self.skip_active) {
                 error!(error, "Cannot install package {package_name}");
             }
         }

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -1,0 +1,100 @@
+use clap::Args;
+
+use crate::{
+    cli::{commands::HandleCommand, display::logging::warning},
+    config::{Config, Repository},
+    error_handling::HandleError,
+    installer::installer::Installer,
+    platforms::TARGET_ARCHITECTURE,
+    repositories::{manager::RepositoryManager, provider},
+    storage::package_register::PackageRegister,
+};
+
+#[derive(Args, Debug)]
+pub struct LinkArgs {
+    /// The name of the package to link
+    pub package_name: String,
+
+    /// True to force linking, even when we should not link
+    #[arg(short, long, default_value = "false")]
+    pub force: bool,
+}
+
+impl HandleCommand for LinkArgs {
+    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+        let register_path = PackageRegister::get_default_path();
+        let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
+
+        // Get installed package
+        let package = register
+            .get_package(&self.package_name)
+            .unwrap_or_exit_msg(&format!("Package {} is not installed!", self.package_name), 1);
+
+        // Check if the package is already symlinked
+        if package.symlinked {
+            println!("This package is already symlinked");
+            return;
+        }
+
+        // Show warning if forced
+        if self.force {
+            warning!("Forcing symlink can cause problems, please be carefull when using --force");
+        }
+
+        // Get active package version
+        let package_version = package
+            .get_package_version(&package.active_version)
+            .unwrap_or_exit_msg("Unable to retrieve active version of package", 1);
+
+        // Check if we are allowed to symlink when not forcing
+        if !self.force {
+            let repository = Repository {
+                path: package_version.source_repository_url.clone(),
+                provider: package_version.source_repository_provider.clone(),
+            };
+
+            let provider = provider::create_repository_provider(&repository).unwrap_or_exit_msg(
+                "Cannot create provider for repository, try --force if you're sure you want to link.",
+                1,
+            );
+
+            let package_version_meta = provider.read_package_version(&self.package_name, &package.active_version).unwrap_or_exit_msg(
+                "Unable to read package metadata for package, try --force if you're sure you want to link.",
+                1,
+            );
+
+            // Skip if the package version metadata defines skip_symlinking
+            if package_version_meta.skip_symlinking {
+                println!("The package metadata defines we should not symlink this package, cancelling linking.");
+                return;
+            }
+
+            let target = package_version_meta.get_target(TARGET_ARCHITECTURE).unwrap_or_exit_msg(
+                "The metadata does not contain the current target, try --force if you're sure you want to link.",
+                1,
+            );
+
+            // Skip if the package version target metadata defines skip_symlinking
+            if let Some(true) = target.skip_symlinking {
+                println!("The package metadata defines we should not symlink this package, cancelling linking.");
+                return;
+            }
+        }
+
+        let install_path = package_version.install_path.clone();
+
+        // Create symlinks
+        Installer::new(config, &mut register, manager)
+            .create_symlinks(&install_path)
+            .unwrap_or_exit_msg("Unable to link package", 1);
+
+        let package = register
+            .get_package_mut(&self.package_name)
+            .unwrap_or_exit_msg("Unable to update symlinked status after creating symlinks", 1);
+
+        package.symlinked = true;
+
+        // Save package register
+        register.save_to(&register_path).unwrap_or_exit(1);
+    }
+}

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -1,0 +1,62 @@
+use clap::Args;
+
+use crate::{
+    cli::{commands::HandleCommand, display::logging::warning},
+    config::Config,
+    error_handling::HandleError,
+    installer::{installer::Installer, types::Version},
+    repositories::manager::RepositoryManager,
+    storage::package_register::PackageRegister,
+};
+
+#[derive(Args, Debug)]
+pub struct SwitchArgs {
+    /// The name of the package to switch
+    pub package_name: String,
+
+    /// The new active version of the package
+    pub package_version: Version,
+
+    /// True to skip symlinking the package, false to keep the current symlinked state
+    #[arg(long, default_value = "false")]
+    pub skip_symlinking: bool,
+}
+
+impl HandleCommand for SwitchArgs {
+    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+        let register_path = PackageRegister::get_default_path();
+        let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
+
+        // Get installed package
+        let package = register
+            .get_package(&self.package_name)
+            .unwrap_or_exit_msg(&format!("Package {} is not installed!", self.package_name), 1);
+
+        // Check if the package version is already active
+        if package.active_version == self.package_version {
+            println!("This version is already the active version");
+            return;
+        }
+
+        // Get installed package version
+        let package_version = package.get_package_version(&self.package_version).unwrap_or_exit_msg(
+            &format!("Package {}@{} is not installed!", self.package_name, self.package_version),
+            1,
+        );
+
+        // Show warning if skip symlinking is specified, but package was symlinked before
+        if self.skip_symlinking && package.symlinked {
+            warning!("Skipping symlinking while package was symlinked before. The package will not be automatically findable by your system anymore.");
+        }
+
+        let package_id = package_version.package_id.clone();
+        let should_symlink = !self.skip_symlinking && package.symlinked;
+
+        // Set package version to active
+        let mut installer = Installer::new(&config, &mut register, &manager);
+        installer.set_active(&package_id, should_symlink).unwrap_or_exit_msg("Cannot switch active package", 1);
+
+        // Save package register
+        register.save_to(&register_path).unwrap_or_exit(1);
+    }
+}

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,0 +1,38 @@
+use clap::Args;
+
+use crate::{
+    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::installer::Installer,
+    repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
+};
+
+#[derive(Args, Debug)]
+pub struct UnlinkArgs {
+    /// The name of the package to unlink
+    pub package_name: String,
+}
+
+impl HandleCommand for UnlinkArgs {
+    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+        let register_path = PackageRegister::get_default_path();
+        let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
+
+        // Get installed package
+        let package = register
+            .get_package(&self.package_name)
+            .unwrap_or_exit_msg(&format!("Package {} is not installed!", self.package_name), 1);
+
+        // Check if the package is already symlinked
+        if !package.symlinked {
+            println!("This package is currently not symlinked");
+            return;
+        }
+
+        // Unlink package
+        Installer::new(config, &mut register, manager)
+            .unlink_package(&self.package_name)
+            .unwrap_or_exit_msg("Unable to unlink package", 1);
+
+        // Save package register
+        register.save_to(&register_path).unwrap_or_exit(1);
+    }
+}

--- a/src/error_handling.rs
+++ b/src/error_handling.rs
@@ -28,3 +28,24 @@ impl<T, E: Error> HandleError<T> for Result<T, E> {
         }
     }
 }
+
+impl<T> HandleError<T> for Option<T> {
+    fn unwrap_or_exit_msg(self, msg: &str, exit_code: i32) -> T {
+        match self {
+            Some(value) => value,
+            None => {
+                error!(msg: msg);
+                exit(exit_code);
+            },
+        }
+    }
+
+    fn unwrap_or_exit(self, exit_code: i32) -> T {
+        match self {
+            Some(value) => value,
+            None => {
+                exit(exit_code);
+            },
+        }
+    }
+}

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -543,7 +543,7 @@ impl<'a> Installer<'a> {
 
         // Update symlinked state in package register
         match self.register.get_package_mut(&package_name) {
-            Some(package) => package.symlinked = true,
+            Some(package) => package.symlinked = false,
             None => {
                 warning!("Cannot get installed package after changing symlinks, please try running pit fix to fix your installation");
                 return Err(InstallerError::PackageNotFound {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -39,7 +39,14 @@ impl<'a> Installer<'a> {
     }
 
     /// Installs the given package and its dependencies.
-    pub fn install(&mut self, package_name: &str, version: Option<&Version>, build_source: bool) -> Result<()> {
+    pub fn install(
+        &mut self,
+        package_name: &str,
+        version: Option<&Version>,
+        build_source: bool,
+        skip_symlinking: bool,
+        skip_active: bool,
+    ) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
@@ -118,12 +125,13 @@ impl<'a> Installer<'a> {
         }
 
         // Check if symlinking should be skipped
-        let mut should_symlink = !match target.skip_symlinking {
-            Some(skip_symlinking) => skip_symlinking,
-            None => package_version.skip_symlinking,
-        };
+        let mut should_symlink = !skip_symlinking
+            && !match target.skip_symlinking {
+                Some(skip_symlinking) => skip_symlinking,
+                None => package_version.skip_symlinking,
+            };
 
-        let mut should_set_active = true;
+        let mut should_set_active = !skip_active;
 
         // Check if we have a previous active install
         if let Some(installed_package) = self.register.get_package(package_name) {
@@ -180,8 +188,8 @@ impl<'a> Installer<'a> {
             // Determine the latest supported version for the dependency
             let version = self.get_latest_dependency_version(dependency)?;
 
-            // TODO: should we pass the build option to childs?
-            self.install(dependency.get_name(), Some(&version), false)?;
+            // TODO: should we pass the options to childs? We could add these options as struct values
+            self.install(dependency.get_name(), Some(&version), false, false, false)?;
 
             // Add the dependency id to the set
             dependency_ids.insert(PackageId::new(dependency.get_name(), &version));

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -465,7 +465,7 @@ impl<'a> Installer<'a> {
     }
 
     /// Sets a package to active and create the appropiate symlinks for it
-    fn set_active(&mut self, package_id: &PackageId, should_symlink: bool) -> Result<()> {
+    pub fn set_active(&mut self, package_id: &PackageId, should_symlink: bool) -> Result<()> {
         // Get package to set to active
         let package_version = match self.register.get_package_version(package_id) {
             Some(package) => package,

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -351,7 +351,7 @@ impl<'a> Installer<'a> {
         }
     }
 
-    fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
+    pub fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
         let prefix_dir = Path::new(&self.config.prefix_directory);
 
         // Symlink directories bin, include, lib and share
@@ -508,6 +508,52 @@ impl<'a> Installer<'a> {
         }
 
         // Save package storage
+        self.register.save_to(&PackageRegister::get_default_path())?;
+
+        Ok(())
+    }
+
+    pub fn unlink_package(&mut self, package_name: &str) -> Result<()> {
+        let package = self.register.get_package(&package_name).ok_or(InstallerError::PackageNotFound {
+            package_name: package_name.into(),
+            version: None,
+        })?;
+
+        // Check if the package is already symlinked
+        if !package.symlinked {
+            return Ok(());
+        }
+
+        // Get active package version
+        let package_version = package.get_package_version(&package.active_version).ok_or(InstallerError::PackageNotFound {
+            package_name: package_name.into(),
+            version: Some(package.active_version.to_string()),
+        })?;
+
+        let install_path = package_version.install_path.clone();
+
+        // Remove all symlinks except for those in the active directory
+        for entry in fs::read_dir(&self.config.prefix_directory)? {
+            let entry = entry?;
+
+            if entry.file_type()?.is_dir() && entry.file_name() != "active" {
+                self.remove_symlinks(&entry.path(), &install_path)?;
+            }
+        }
+
+        // Update symlinked state in package register
+        match self.register.get_package_mut(&package_name) {
+            Some(package) => package.symlinked = true,
+            None => {
+                warning!("Cannot get installed package after changing symlinks, please try running pit fix to fix your installation");
+                return Err(InstallerError::PackageNotFound {
+                    package_name: package_name.into(),
+                    version: None,
+                });
+            },
+        };
+
+        // Save package register
         self.register.save_to(&PackageRegister::get_default_path())?;
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -39,7 +39,7 @@ impl<'a> Installer<'a> {
     }
 
     /// Installs the given package and its dependencies.
-    pub fn install(&mut self, package_name: &str, version: Option<&Version>) -> Result<()> {
+    pub fn install(&mut self, package_name: &str, version: Option<&Version>, build_source: bool) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
@@ -87,8 +87,14 @@ impl<'a> Installer<'a> {
         // Get source repository for installed storage before actually installing package
         let source_repository = self.config.repositories.get(&repository_id).expect("Expected repository in config");
 
+        // Get prebuild url, or skip if we should build from source
+        let prebuild_url = match build_source {
+            true => None,
+            false => self.repository_manager.get_prebuild_url(&repository_id, package_name, version),
+        };
+
         // Get build version of package
-        match self.repository_manager.get_prebuild_url(&repository_id, package_name, version) {
+        match prebuild_url {
             Some(url) => self.download_prebuild(&url, &install_directory)?,
             None => self.build_package(&package, &package_version, &target, &repository_id, &install_directory)?,
         }
@@ -174,7 +180,8 @@ impl<'a> Installer<'a> {
             // Determine the latest supported version for the dependency
             let version = self.get_latest_dependency_version(dependency)?;
 
-            self.install(dependency.get_name(), Some(&version))?;
+            // TODO: should we pass the build option to childs?
+            self.install(dependency.get_name(), Some(&version), false)?;
 
             // Add the dependency id to the set
             dependency_ids.insert(PackageId::new(dependency.get_name(), &version));

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, str::FromStr};
 
 use serde::{de, Deserialize, Serialize};
 
-use crate::installer::types::Version;
+use crate::installer::types::{Version, VersionError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PackageId {
@@ -25,20 +25,7 @@ impl<'de> Deserialize<'de> for PackageId {
         D: serde::Deserializer<'de>,
     {
         let string: String = de::Deserialize::deserialize(deserializer)?;
-        let index = string.chars().position(|c| c == '@');
-
-        let (name, version) = match index {
-            Some(index) => string.split_at(index),
-            None => panic!("Error should have version specified"),
-        };
-
-        // Remove @ character from version number
-        let version = Version::from_str(version.strip_prefix("@").unwrap_or("")).map_err(de::Error::custom)?;
-
-        Ok(Self {
-            name: name.to_string(),
-            version,
-        })
+        Ok(Self::from_str(&string).map_err(de::Error::custom)?)
     }
 }
 
@@ -55,5 +42,26 @@ impl Display for PackageId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}@{}", &self.name, &self.version)?;
         Ok(())
+    }
+}
+
+impl FromStr for PackageId {
+    type Err = VersionError;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        let index = string.chars().position(|c| c == '@');
+
+        let (name, version) = match index {
+            Some(index) => string.split_at(index),
+            None => panic!("Error should have version specified"),
+        };
+
+        // Remove @ character from version number
+        let version = Version::from_str(version.strip_prefix("@").unwrap_or(""))?;
+
+        Ok(Self {
+            name: name.to_string(),
+            version,
+        })
     }
 }


### PR DESCRIPTION
This pull requests implements extra commands and refactors the install command to allow installing multiple packages with a single command.

New commands:
|                                           |                                               |
| ------------------------ | --------------------------  |
| install --build                    | Build package from source |
| install --skip-symlinking | Skip symlinking of the newly installed package |
| install --skip-active         | Skip setting newly installed package to active |
| switch                               | Switch the current active version of a package |
| link and unlink                  | Switch the symlinked state of a package |
| fix                                      | Fix the packit installation, such as correctly setting permissions and repairing broken  register entries. Implementation will be done later. |