### PR TITLE
Refactor installer

### DIFF
--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -6,7 +6,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
     error_handling::HandleError,
-    installer::{types::PackageId, Installer},
+    installer::{types::PackageId, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };
@@ -39,7 +39,12 @@ impl HandleCommand for InstallArgs {
         let register_dir = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        let mut installer = Installer::new(&config, &mut register, &manager);
+        let installer_options = InstallerOptions::default()
+            .build_source(self.build)
+            .skip_symlinking(self.skip_symlinking)
+            .skip_active(self.skip_active)
+            .keep_build(self.keep_build);
+        let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)
 
@@ -62,14 +67,7 @@ impl HandleCommand for InstallArgs {
 
         // Install all packages
         for (package_name, version) in packages {
-            if let Err(error) = installer.install(
-                &package_name,
-                version.as_ref(),
-                self.build,
-                self.skip_symlinking,
-                self.skip_active,
-                self.keep_build,
-            ) {
+            if let Err(error) = installer.install(&package_name, version.as_ref()) {
                 error!(error, "Cannot install package {package_name}");
             }
         }

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -5,10 +5,10 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    error_handling::HandleError,
     installer::{types::PackageId, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -6,7 +6,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
     error_handling::HandleError,
-    installer::{installer::Installer, types::PackageId},
+    installer::{types::PackageId, Installer},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::{Config, Repository},
     error_handling::HandleError,
-    installer::installer::Installer,
+    installer::Installer,
     platforms::TARGET_ARCHITECTURE,
     repositories::{manager::RepositoryManager, provider},
     storage::package_register::PackageRegister,

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -3,11 +3,11 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::{Config, Repository},
-    error_handling::HandleError,
     installer::Symlinker,
     platforms::TARGET_ARCHITECTURE,
     repositories::{manager::RepositoryManager, provider},
     storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::{Config, Repository},
     error_handling::HandleError,
-    installer::Installer,
+    installer::{Installer, InstallerOptions},
     platforms::TARGET_ARCHITECTURE,
     repositories::{manager::RepositoryManager, provider},
     storage::package_register::PackageRegister,
@@ -84,7 +84,7 @@ impl HandleCommand for LinkArgs {
         let install_path = package_version.install_path.clone();
 
         // Create symlinks
-        Installer::new(config, &mut register, manager)
+        Installer::new(config, &mut register, manager, InstallerOptions::default())
             .create_symlinks(&install_path)
             .unwrap_or_exit_msg("Unable to link package", 1);
 

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::{Config, Repository},
     error_handling::HandleError,
-    installer::{Installer, InstallerOptions},
+    installer::Symlinker,
     platforms::TARGET_ARCHITECTURE,
     repositories::{manager::RepositoryManager, provider},
     storage::package_register::PackageRegister,
@@ -21,7 +21,7 @@ pub struct LinkArgs {
 }
 
 impl HandleCommand for LinkArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+    fn handle(&self, config: &Config, _: &RepositoryManager) {
         let register_path = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
@@ -84,9 +84,7 @@ impl HandleCommand for LinkArgs {
         let install_path = package_version.install_path.clone();
 
         // Create symlinks
-        Installer::new(config, &mut register, manager, InstallerOptions::default())
-            .create_symlinks(&install_path)
-            .unwrap_or_exit_msg("Unable to link package", 1);
+        Symlinker::new(config).create_symlinks(&install_path).unwrap_or_exit_msg("Unable to link package", 1);
 
         let package = register
             .get_package_mut(&self.package_name)

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, error_handling::HandleError, repositories::manager::RepositoryManager,
-    storage::package_register::PackageRegister, verifier::get_packages,
+    cli::commands::HandleCommand, config::Config, repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit, verifier::get_packages,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -3,10 +3,10 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::Config,
-    error_handling::HandleError,
     installer::{types::Version, Symlinker},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::Config,
     error_handling::HandleError,
-    installer::{types::Version, Installer, InstallerOptions},
+    installer::{types::Version, Symlinker},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };
@@ -23,7 +23,7 @@ pub struct SwitchArgs {
 }
 
 impl HandleCommand for SwitchArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+    fn handle(&self, config: &Config, _: &RepositoryManager) {
         let register_path = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
@@ -53,8 +53,9 @@ impl HandleCommand for SwitchArgs {
         let should_symlink = !self.skip_symlinking && package.symlinked;
 
         // Set package version to active
-        let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());
-        installer.set_active(&package_id, should_symlink).unwrap_or_exit_msg("Cannot switch active package", 1);
+        Symlinker::new(config)
+            .set_active(&mut register, &package_id, should_symlink)
+            .unwrap_or_exit_msg("Cannot switch active package", 1);
 
         // Save package register
         register.save_to(&register_path).unwrap_or_exit(1);

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::Config,
     error_handling::HandleError,
-    installer::{installer::Installer, types::Version},
+    installer::{types::Version, Installer},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::Config,
     error_handling::HandleError,
-    installer::{types::Version, Installer},
+    installer::{types::Version, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };
@@ -53,7 +53,7 @@ impl HandleCommand for SwitchArgs {
         let should_symlink = !self.skip_symlinking && package.symlinked;
 
         // Set package version to active
-        let mut installer = Installer::new(&config, &mut register, &manager);
+        let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());
         installer.set_active(&package_id, should_symlink).unwrap_or_exit_msg("Cannot switch active package", 1);
 
         // Save package register

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::commands::HandleCommand,
     config::Config,
     error_handling::HandleError,
-    installer::{types::Version, Installer},
+    installer::{types::Version, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };
@@ -24,7 +24,9 @@ impl HandleCommand for UninstallArgs {
         let register_dir = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        Installer::new(config, &mut register, manager).uninstall(&self.package_name, self.version.as_ref()).unwrap_or_exit(1);
+        Installer::new(config, &mut register, manager, InstallerOptions::default())
+            .uninstall(&self.package_name, self.version.as_ref())
+            .unwrap_or_exit(1);
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -4,7 +4,7 @@ use crate::{
     cli::commands::HandleCommand,
     config::Config,
     error_handling::HandleError,
-    installer::{installer::Installer, types::Version},
+    installer::{types::Version, Installer},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
 };

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -3,10 +3,10 @@ use clap::Args;
 use crate::{
     cli::commands::HandleCommand,
     config::Config,
-    error_handling::HandleError,
     installer::{types::Version, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,12 +1,8 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand,
-    config::Config,
-    error_handling::HandleError,
-    installer::{Installer, InstallerOptions},
-    repositories::manager::RepositoryManager,
-    storage::package_register::PackageRegister,
+    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::Symlinker,
+    repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
 };
 
 #[derive(Args, Debug)]
@@ -16,7 +12,7 @@ pub struct UnlinkArgs {
 }
 
 impl HandleCommand for UnlinkArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+    fn handle(&self, config: &Config, _: &RepositoryManager) {
         let register_path = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
@@ -32,8 +28,8 @@ impl HandleCommand for UnlinkArgs {
         }
 
         // Unlink package
-        Installer::new(config, &mut register, manager, InstallerOptions::default())
-            .unlink_package(&self.package_name)
+        Symlinker::new(config)
+            .unlink_package(&mut register, &self.package_name)
             .unwrap_or_exit_msg("Unable to unlink package", 1);
 
         // Save package register

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,8 +1,12 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::Installer,
-    repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
+    cli::commands::HandleCommand,
+    config::Config,
+    error_handling::HandleError,
+    installer::{Installer, InstallerOptions},
+    repositories::manager::RepositoryManager,
+    storage::package_register::PackageRegister,
 };
 
 #[derive(Args, Debug)]
@@ -28,7 +32,7 @@ impl HandleCommand for UnlinkArgs {
         }
 
         // Unlink package
-        Installer::new(config, &mut register, manager)
+        Installer::new(config, &mut register, manager, InstallerOptions::default())
             .unlink_package(&self.package_name)
             .unwrap_or_exit_msg("Unable to unlink package", 1);
 

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,8 +1,8 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::Symlinker,
-    repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
+    cli::commands::HandleCommand, config::Config, installer::Symlinker, repositories::manager::RepositoryManager,
+    storage::package_register::PackageRegister, utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,7 +1,7 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::installer::Installer,
+    cli::commands::HandleCommand, config::Config, error_handling::HandleError, installer::Installer,
     repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
 };
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -176,7 +176,7 @@ impl<'a> Installer<'a> {
         // Get build version of package
         match url {
             Some(url) => self.download_prebuild(&url, &install_directory)?,
-            None => self.build_package(
+            None => Builder::new(self.config, self.register, self.repository_manager).build(
                 &node.package_metadata,
                 &node.version_metadata,
                 &node.repository_id,
@@ -370,20 +370,6 @@ impl<'a> Installer<'a> {
                 Some(&build_dependency.version_metadata.version),
             )?;
         }
-
-        Ok(())
-    }
-
-    fn build_package(
-        &mut self,
-        package: &PackageMetadata,
-        package_version: &PackageVersion,
-        repository_id: &str,
-        destination_dir: impl AsRef<Path>,
-    ) -> Result<()> {
-        // Build package if we did not find a prebuild
-        let builder = Builder::new(self.config, self.register, self.repository_manager);
-        builder.build(&package, &package_version, &repository_id, &destination_dir)?;
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -8,6 +8,7 @@ use crate::{
     installer::{
         builder::Builder,
         error::{InstallerError, Result},
+        options::InstallerOptions,
         scripts,
         types::{Dependency, PackageId, Version},
     },
@@ -30,6 +31,7 @@ pub struct Installer<'a> {
     config: &'a Config,
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
+    options: InstallerOptions,
 }
 
 /// A helper struct for the installer to move around nodes from the dependency trees
@@ -42,24 +44,22 @@ struct DependencyNode {
 
 impl<'a> Installer<'a> {
     /// Creates new installer
-    pub fn new(config: &'a Config, register: &'a mut PackageRegister, repository_manager: &'a RepositoryManager) -> Self {
+    pub fn new(
+        config: &'a Config,
+        register: &'a mut PackageRegister,
+        repository_manager: &'a RepositoryManager,
+        options: InstallerOptions,
+    ) -> Self {
         Self {
             config,
             register,
             repository_manager,
+            options,
         }
     }
 
     /// Installs the given package and its dependencies.
-    pub fn install(
-        &mut self,
-        package_name: &str,
-        version: Option<&Version>,
-        build_source: bool,
-        skip_symlinking: bool,
-        skip_active: bool,
-        keep_build: bool,
-    ) -> Result<()> {
+    pub fn install(&mut self, package_name: &str, version: Option<&Version>) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
@@ -95,29 +95,22 @@ impl<'a> Installer<'a> {
         let mut flattened_dependencies = self.get_flattened_dependencies(&mut root)?;
         flattened_dependencies.insert(0, root);
 
-        self.install_nodes(&mut flattened_dependencies, build_source, skip_symlinking, skip_active, keep_build)?;
+        self.install_nodes(&mut flattened_dependencies)?;
 
         Ok(())
     }
 
-    fn install_nodes(
-        &mut self,
-        nodes: &mut Vec<DependencyNode>,
-        should_build: bool,
-        skip_symlinking: bool,
-        skip_active: bool,
-        keep_build: bool,
-    ) -> Result<()> {
+    fn install_nodes(&mut self, nodes: &mut Vec<DependencyNode>) -> Result<()> {
         let mut all_dependencies = Vec::new();
         let mut dependency_ids = Vec::new();
         for node in nodes {
             let package_id = PackageId::new(&node.package_metadata.name, &node.version_metadata.version);
-            if !should_build {
+            if !self.options.build_source {
                 let prebuild_url = self.repository_manager.get_prebuild_url(&node.repository_id, &package_id);
 
                 // Install the package with a prebuild if possible
                 if let Some(url) = prebuild_url {
-                    self.install_package(node, Some(&url), skip_symlinking, skip_active)?;
+                    self.install_package(node, Some(&url))?;
                     continue;
                 }
 
@@ -131,11 +124,11 @@ impl<'a> Installer<'a> {
             // Get and install the build dependencies first
             let build_dependencies = self.get_flattened_build_dependencies(node)?;
             for build_node in build_dependencies.iter().rev() {
-                self.install_package(build_node, None, skip_symlinking, skip_active)?;
+                self.install_package(build_node, None)?;
             }
 
             // Build the current dependency node
-            self.install_package(node, None, skip_symlinking, skip_active)?;
+            self.install_package(node, None)?;
 
             // Save the current build dependencies and the current node id
             all_dependencies.extend(build_dependencies);
@@ -143,14 +136,14 @@ impl<'a> Installer<'a> {
         }
 
         // Remove build dependencies if --keep-build not used
-        if !keep_build {
+        if !self.options.keep_build {
             self.remove_build_dependencies(&all_dependencies, &dependency_ids)?;
         }
 
         Ok(())
     }
 
-    fn install_package(&mut self, node: &DependencyNode, url: Option<&str>, skip_symlinking: bool, skip_active: bool) -> Result<()> {
+    fn install_package(&mut self, node: &DependencyNode, url: Option<&str>) -> Result<()> {
         // Create the package id and install directory
         let package_id = PackageId::new(&node.package_metadata.name, &node.version_metadata.version);
         let install_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
@@ -210,7 +203,7 @@ impl<'a> Installer<'a> {
             scripts::run_post_script(script_file, &install_directory, self.config, &script_args)?;
         }
 
-        self.determine_active(node, &package_id, target, skip_symlinking, skip_active)?;
+        self.determine_active(node, &package_id, target)?;
 
         // Download and run test script if it exists
         let script_path = node.version_metadata.get_test_script_path(TARGET_ARCHITECTURE)?;
@@ -313,22 +306,15 @@ impl<'a> Installer<'a> {
         Ok(dependencies)
     }
 
-    fn determine_active(
-        &mut self,
-        node: &DependencyNode,
-        package_id: &PackageId,
-        target: &PackageTarget,
-        skip_symlinking: bool,
-        skip_active: bool,
-    ) -> Result<()> {
+    fn determine_active(&mut self, node: &DependencyNode, package_id: &PackageId, target: &PackageTarget) -> Result<()> {
         // Check if symlinking should be skipped
-        let mut should_symlink = !skip_symlinking
+        let mut should_symlink = !self.options.skip_symlinking
             && !match target.skip_symlinking {
                 Some(skip_symlinking) => skip_symlinking,
                 None => node.version_metadata.skip_symlinking,
             };
 
-        let mut should_set_active = !skip_active;
+        let mut should_set_active = !self.options.skip_active;
 
         // Check if we have a previous active install
         if let Some(installed_package) = self.register.get_package(&package_id.name) {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -10,6 +10,7 @@ use crate::{
         error::{InstallerError, Result},
         options::InstallerOptions,
         scripts,
+        symlinker::Symlinker,
         types::{Dependency, PackageId, Version},
     },
     platforms::{symlink, TARGET_ARCHITECTURE},
@@ -343,7 +344,7 @@ impl<'a> Installer<'a> {
 
         // If package is installed succesfully, set it to active
         if should_set_active {
-            self.set_active(&package_id, should_symlink)?;
+            Symlinker::new(self.config).set_active(self.register, &package_id, should_symlink)?;
         }
 
         Ok(())
@@ -431,7 +432,7 @@ impl<'a> Installer<'a> {
 
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
-            self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+            Symlinker::new(self.config).remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
         }
 
         // Change active package when uninstalled package is currently active
@@ -441,7 +442,7 @@ impl<'a> Installer<'a> {
             other_versions.sort_by_key(|x| &x.package_id.version);
 
             if let Some(newest) = other_versions.last() {
-                self.set_active(&newest.package_id.clone(), installed_package.symlinked)?;
+                Symlinker::new(self.config).set_active(self.register, &newest.package_id.clone(), installed_package.symlinked)?;
             }
         }
 
@@ -479,7 +480,7 @@ impl<'a> Installer<'a> {
         // Check if package was symlinked
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
-                self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+                Symlinker::new(self.config).remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
             }
         }
 
@@ -509,98 +510,6 @@ impl<'a> Installer<'a> {
         }
     }
 
-    pub fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
-        let prefix_dir = Path::new(&self.config.prefix_directory);
-
-        // Symlink directories bin, include, lib and share
-        for dir_name in vec!["bin", "include", "lib", "share"] {
-            let package_dir_path = package_directory.join(dir_name);
-            let prefix_dir_path = prefix_dir.join(dir_name);
-
-            self.create_folder_symlinks(&package_dir_path, &prefix_dir_path, true)?;
-        }
-
-        Ok(())
-    }
-
-    fn create_folder_symlinks(&self, source_dir: &Path, destination_dir: &Path, keep_subdirectories: bool) -> Result<()> {
-        // Create destination if it does not exist
-        if !destination_dir.exists() {
-            fs::create_dir_all(&destination_dir)?;
-        }
-
-        // Skip symlinking if source does not exist
-        if !source_dir.exists() {
-            return Ok(());
-        }
-
-        // Symlink files
-        for file in fs::read_dir(source_dir)? {
-            let file = file?;
-
-            let destination = destination_dir.join(file.file_name());
-
-            // Handle directories
-            if file.file_type()?.is_dir() {
-                // If we want to keep subdirectories, create the symlinks for the subdirectory
-                // TODO: Handle subdirectories properly
-                if keep_subdirectories {
-                    self.create_folder_symlinks(&file.path(), &destination, true)?;
-                } else {
-                    dbg!("Skipping subdirectory", file);
-                }
-
-                continue;
-            }
-
-            // Check if file already exists
-            if fs::exists(&destination)? {
-                warning!("Symlink {:?} already exists in {:?}", file.file_name(), destination_dir);
-                continue;
-            }
-
-            // Symlink file in destination directory
-            symlink::create_symlink(&file.path(), &destination)?;
-        }
-
-        Ok(())
-    }
-
-    /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match).
-    fn remove_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<()> {
-        for file in fs::read_dir(search_dir)? {
-            let file = file?;
-            let file_type = file.file_type()?;
-
-            if file_type.is_dir() {
-                self.remove_symlinks(&file.path(), destination_dir)?;
-
-                // Remove the directory if it is empty after removing symlinks
-                if fs::read_dir(file.path())?.next().is_none() {
-                    fs::remove_dir(file.path())?;
-                }
-            }
-
-            if file_type.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
-                symlink::remove_symlink(&file.path())?
-            }
-        }
-
-        Ok(())
-    }
-
-    fn can_write_prefix_dir(&self) -> Result<bool> {
-        if !fs::exists(&self.config.prefix_directory)? {
-            return Ok(false);
-        }
-
-        let metadata = fs::metadata(&self.config.prefix_directory)?;
-        let permissions = metadata.permissions();
-
-        // TODO: Use something else then readonly, because it can be different for super user and group
-        Ok(!permissions.readonly())
-    }
-
     fn get_latest_dependency_version(&self, dependency: &Dependency) -> Result<Version> {
         // Get all supported versions for the dependency
         let (_, package) = self.repository_manager.read_package(&dependency.get_name())?;
@@ -622,98 +531,15 @@ impl<'a> Installer<'a> {
         Ok(current_highest.ok_or(InstallerError::SupportError(dependency.to_string()))?)
     }
 
-    /// Sets a package to active and create the appropiate symlinks for it
-    pub fn set_active(&mut self, package_id: &PackageId, should_symlink: bool) -> Result<()> {
-        // Get package to set to active
-        let package_version = match self.register.get_package_version(package_id) {
-            Some(package) => package,
-            None => {
-                warning!("Cannot get installed package from installed storage... Please check installation with 'pit list'");
-                return Ok(());
-            },
-        };
-
-        let global_active_path = Path::new(&self.config.prefix_directory).join("active");
-        let active_path = global_active_path.join(&package_version.package_id.name);
-
-        let package_install_path = package_version.install_path.clone();
-
-        // Remove old symlinks
-        let package_directory = self.config.prefix_directory.join("packages").join(&package_id.name);
-        self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
-
-        // Create active symlink
-        fs::create_dir_all(global_active_path)?;
-        symlink::create_symlink(&package_install_path, &active_path)?;
-
-        // Only create new symlinks if we should symlink
-        if should_symlink {
-            self.create_symlinks(Path::new(&package_install_path))?;
+    fn can_write_prefix_dir(&self) -> Result<bool> {
+        if !fs::exists(&self.config.prefix_directory)? {
+            return Ok(false);
         }
 
-        // Updates the active version and sets its symlinked state
-        match self.register.get_package_mut(&package_id.name) {
-            Some(package) => {
-                package.active_version = package_id.version.clone();
-                package.symlinked = should_symlink;
-            },
-            None => {
-                return Err(InstallerError::PackageNotFound {
-                    package_name: package_id.name.clone(),
-                    version: None,
-                })
-            },
-        }
+        let metadata = fs::metadata(&self.config.prefix_directory)?;
+        let permissions = metadata.permissions();
 
-        // Save package storage
-        self.register.save_to(&PackageRegister::get_default_path())?;
-
-        Ok(())
-    }
-
-    pub fn unlink_package(&mut self, package_name: &str) -> Result<()> {
-        let package = self.register.get_package(&package_name).ok_or(InstallerError::PackageNotFound {
-            package_name: package_name.into(),
-            version: None,
-        })?;
-
-        // Check if the package is already symlinked
-        if !package.symlinked {
-            return Ok(());
-        }
-
-        // Get active package version
-        let package_version = package.get_package_version(&package.active_version).ok_or(InstallerError::PackageNotFound {
-            package_name: package_name.into(),
-            version: Some(package.active_version.to_string()),
-        })?;
-
-        let install_path = package_version.install_path.clone();
-
-        // Remove all symlinks except for those in the active directory
-        for entry in fs::read_dir(&self.config.prefix_directory)? {
-            let entry = entry?;
-
-            if entry.file_type()?.is_dir() && entry.file_name() != "active" {
-                self.remove_symlinks(&entry.path(), &install_path)?;
-            }
-        }
-
-        // Update symlinked state in package register
-        match self.register.get_package_mut(&package_name) {
-            Some(package) => package.symlinked = false,
-            None => {
-                warning!("Cannot get installed package after changing symlinks, please try running pit fix to fix your installation");
-                return Err(InstallerError::PackageNotFound {
-                    package_name: package_name.into(),
-                    version: None,
-                });
-            },
-        };
-
-        // Save package register
-        self.register.save_to(&PackageRegister::get_default_path())?;
-
-        Ok(())
+        // TODO: Use something else then readonly, because it can be different for super user and group
+        Ok(!permissions.readonly())
     }
 }

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -4,9 +4,12 @@ pub mod error;
 mod installer;
 mod options;
 pub mod scripts;
+mod symlinker;
 pub mod types;
 mod unpack;
 
 pub use self::installer::Installer;
 
 pub use self::options::InstallerOptions;
+
+pub use self::symlinker::Symlinker;

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,7 +1,9 @@
 pub(self) mod build_env;
 mod builder;
 pub mod error;
-pub mod installer;
+mod installer;
 pub mod scripts;
 pub mod types;
 mod unpack;
+
+pub use self::installer::Installer;

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,9 +1,12 @@
-pub(self) mod build_env;
+mod build_env;
 mod builder;
 pub mod error;
 mod installer;
+mod options;
 pub mod scripts;
 pub mod types;
 mod unpack;
 
 pub use self::installer::Installer;
+
+pub use self::options::InstallerOptions;

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -1,0 +1,39 @@
+pub struct InstallerOptions {
+    pub build_source: bool,
+    pub skip_symlinking: bool,
+    pub skip_active: bool,
+    pub keep_build: bool,
+}
+
+impl Default for InstallerOptions {
+    fn default() -> Self {
+        Self {
+            build_source: false,
+            skip_symlinking: false,
+            skip_active: false,
+            keep_build: false,
+        }
+    }
+}
+
+impl InstallerOptions {
+    pub fn build_source(mut self, build_source: bool) -> Self {
+        self.build_source = build_source;
+        self
+    }
+
+    pub fn skip_symlinking(mut self, skip_symlinking: bool) -> Self {
+        self.skip_symlinking = skip_symlinking;
+        self
+    }
+
+    pub fn skip_active(mut self, skip_active: bool) -> Self {
+        self.skip_active = skip_active;
+        self
+    }
+
+    pub fn keep_build(mut self, keep_build: bool) -> Self {
+        self.keep_build = keep_build;
+        self
+    }
+}

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -1,0 +1,197 @@
+use std::{fs, path::Path};
+
+use crate::{
+    cli::display::logging::warning,
+    config::Config,
+    installer::{
+        error::{InstallerError, Result},
+        types::PackageId,
+    },
+    platforms::symlink,
+    storage::package_register::PackageRegister,
+};
+
+pub struct Symlinker<'a> {
+    config: &'a Config,
+}
+
+impl<'a> Symlinker<'a> {
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+
+    pub fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
+        let prefix_dir = Path::new(&self.config.prefix_directory);
+
+        // Symlink directories bin, include, lib and share
+        for dir_name in vec!["bin", "include", "lib", "share"] {
+            let package_dir_path = package_directory.join(dir_name);
+            let prefix_dir_path = prefix_dir.join(dir_name);
+
+            self.create_folder_symlinks(&package_dir_path, &prefix_dir_path, true)?;
+        }
+
+        Ok(())
+    }
+
+    fn create_folder_symlinks(&self, source_dir: &Path, destination_dir: &Path, keep_subdirectories: bool) -> Result<()> {
+        // Create destination if it does not exist
+        if !destination_dir.exists() {
+            fs::create_dir_all(&destination_dir)?;
+        }
+
+        // Skip symlinking if source does not exist
+        if !source_dir.exists() {
+            return Ok(());
+        }
+
+        // Symlink files
+        for file in fs::read_dir(source_dir)? {
+            let file = file?;
+
+            let destination = destination_dir.join(file.file_name());
+
+            // Handle directories
+            if file.file_type()?.is_dir() {
+                // If we want to keep subdirectories, create the symlinks for the subdirectory
+                // TODO: Handle subdirectories properly
+                if keep_subdirectories {
+                    self.create_folder_symlinks(&file.path(), &destination, true)?;
+                } else {
+                    dbg!("Skipping subdirectory", file);
+                }
+
+                continue;
+            }
+
+            // Check if file already exists
+            if fs::exists(&destination)? {
+                warning!("Symlink {:?} already exists in {:?}", file.file_name(), destination_dir);
+                continue;
+            }
+
+            // Symlink file in destination directory
+            symlink::create_symlink(&file.path(), &destination)?;
+        }
+
+        Ok(())
+    }
+
+    /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match).
+    pub(super) fn remove_symlinks(&self, search_dir: &Path, destination_dir: &Path) -> Result<()> {
+        for file in fs::read_dir(search_dir)? {
+            let file = file?;
+            let file_type = file.file_type()?;
+
+            if file_type.is_dir() {
+                self.remove_symlinks(&file.path(), destination_dir)?;
+
+                // Remove the directory if it is empty after removing symlinks
+                if fs::read_dir(file.path())?.next().is_none() {
+                    fs::remove_dir(file.path())?;
+                }
+            }
+
+            if file_type.is_symlink() && fs::read_link(file.path())?.starts_with(destination_dir) {
+                symlink::remove_symlink(&file.path())?
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Sets a package to active and create the appropiate symlinks for it
+    pub fn set_active(&self, register: &mut PackageRegister, package_id: &PackageId, should_symlink: bool) -> Result<()> {
+        // Get package to set to active
+        let package_version = match register.get_package_version(package_id) {
+            Some(package) => package,
+            None => {
+                warning!("Cannot get installed package from installed storage... Please check installation with 'pit list'");
+                return Ok(());
+            },
+        };
+
+        let global_active_path = Path::new(&self.config.prefix_directory).join("active");
+        let active_path = global_active_path.join(&package_version.package_id.name);
+
+        let package_install_path = package_version.install_path.clone();
+
+        // Remove old symlinks
+        let package_directory = self.config.prefix_directory.join("packages").join(&package_id.name);
+        self.remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
+
+        // Create active symlink
+        fs::create_dir_all(global_active_path)?;
+        symlink::create_symlink(&package_install_path, &active_path)?;
+
+        // Only create new symlinks if we should symlink
+        if should_symlink {
+            self.create_symlinks(Path::new(&package_install_path))?;
+        }
+
+        // Updates the active version and sets its symlinked state
+        match register.get_package_mut(&package_id.name) {
+            Some(package) => {
+                package.active_version = package_id.version.clone();
+                package.symlinked = should_symlink;
+            },
+            None => {
+                return Err(InstallerError::PackageNotFound {
+                    package_name: package_id.name.clone(),
+                    version: None,
+                })
+            },
+        }
+
+        // Save package storage
+        register.save_to(&PackageRegister::get_default_path())?;
+
+        Ok(())
+    }
+
+    pub fn unlink_package(&self, register: &mut PackageRegister, package_name: &str) -> Result<()> {
+        let package = register.get_package(&package_name).ok_or(InstallerError::PackageNotFound {
+            package_name: package_name.into(),
+            version: None,
+        })?;
+
+        // Check if the package is already symlinked
+        if !package.symlinked {
+            return Ok(());
+        }
+
+        // Get active package version
+        let package_version = package.get_package_version(&package.active_version).ok_or(InstallerError::PackageNotFound {
+            package_name: package_name.into(),
+            version: Some(package.active_version.to_string()),
+        })?;
+
+        let install_path = package_version.install_path.clone();
+
+        // Remove all symlinks except for those in the active directory
+        for entry in fs::read_dir(&self.config.prefix_directory)? {
+            let entry = entry?;
+
+            if entry.file_type()?.is_dir() && entry.file_name() != "active" {
+                self.remove_symlinks(&entry.path(), &install_path)?;
+            }
+        }
+
+        // Update symlinked state in package register
+        match register.get_package_mut(&package_name) {
+            Some(package) => package.symlinked = false,
+            None => {
+                warning!("Cannot get installed package after changing symlinks, please try running pit fix to fix your installation");
+                return Err(InstallerError::PackageNotFound {
+                    package_name: package_name.into(),
+                    version: None,
+                });
+            },
+        };
+
+        // Save package register
+        register.save_to(&PackageRegister::get_default_path())?;
+
+        Ok(())
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use crate::{cli::commands::Cli, config::Config, repositories::manager::Repositor
 
 mod cli;
 mod config;
-mod error_handling;
 mod installer;
 mod platforms;
 mod repositories;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod checksum;
 pub mod constants;
 pub mod env;
+pub mod unwrap_or_exit;

--- a/src/utils/unwrap_or_exit.rs
+++ b/src/utils/unwrap_or_exit.rs
@@ -2,12 +2,12 @@ use std::{error::Error, process::exit};
 
 use crate::cli::display::logging::error;
 
-pub trait HandleError<T> {
+pub trait UnwrapOrExit<T> {
     fn unwrap_or_exit_msg(self, msg: &str, exit_code: i32) -> T;
     fn unwrap_or_exit(self, exit_code: i32) -> T;
 }
 
-impl<T, E: Error> HandleError<T> for Result<T, E> {
+impl<T, E: Error> UnwrapOrExit<T> for Result<T, E> {
     fn unwrap_or_exit_msg(self, msg: &str, exit_code: i32) -> T {
         match self {
             Ok(value) => value,
@@ -29,7 +29,7 @@ impl<T, E: Error> HandleError<T> for Result<T, E> {
     }
 }
 
-impl<T> HandleError<T> for Option<T> {
+impl<T> UnwrapOrExit<T> for Option<T> {
     fn unwrap_or_exit_msg(self, msg: &str, exit_code: i32) -> T {
         match self {
             Some(value) => value,


### PR DESCRIPTION
This PR refactors the installer by splitting options into `InstallerOptions` and splitting symlink related functions into a new `Symlinker`.