### PR TITLE
Refactor command package versions

### DIFF
--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -1,11 +1,9 @@
-use std::str::FromStr;
-
 use clap::Args;
 
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::{types::PackageId, Installer, InstallerOptions},
+    installer::{types::OptionalPackageId, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -15,7 +13,7 @@ use crate::{
 pub struct InstallArgs {
     /// The name of the package to install, with an optional version specified with NAME@VERSION
     #[arg(num_args(0..))]
-    pub packages: Vec<String>,
+    pub packages: Vec<OptionalPackageId>,
 
     /// True to build from source locally, false to use a prebuild version
     #[arg(long, default_value = "false")]
@@ -47,28 +45,12 @@ impl HandleCommand for InstallArgs {
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)
-
-        let mut packages = Vec::new();
-
-        // Convert packages into package name and version
-        for package in &self.packages {
-            if package.contains("@") {
-                let package_id =
-                    PackageId::from_str(&package).unwrap_or_exit_msg(&format!("Package '{package}' is not a valid package identifier."), 1);
-
-                packages.push((package_id.name, Some(package_id.version)));
-                continue;
-            }
-
-            packages.push((package.into(), None));
-        }
-
         // TODO: check for duplicate packages in Vec
 
         // Install all packages
-        for (package_name, version) in packages {
-            if let Err(error) = installer.install(&package_name, version.as_ref()) {
-                error!(error, "Cannot install package {package_name}");
+        for package_id in &self.packages {
+            if let Err(error) = installer.install(&package_id) {
+                error!(error, "Cannot install package {package_id}");
             }
         }
 

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -11,7 +11,7 @@ use crate::{
 
 #[derive(Args, Debug)]
 pub struct InstallArgs {
-    /// The name of the package to install, with an optional version specified with NAME@VERSION
+    /// The name of the packages to install, with an optional version specified with NAME@VERSION
     #[arg(num_args(0..))]
     pub packages: Vec<OptionalPackageId>,
 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -4,28 +4,24 @@ use colored::Colorize;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::types::{PackageId, Version},
+    installer::types::{OptionalPackageId, PackageId},
     platforms::TARGET_ARCHITECTURE,
     repositories::{error::RepositoryError, manager::RepositoryManager},
 };
 
 #[derive(Args, Debug)]
 pub struct SearchArgs {
-    /// The name of the package to search
-    package_name: String,
-
-    /// The version of the package to search
-    #[arg(short, long)]
-    version: Option<Version>,
+    /// The name of the package to install, with an optional version specified with NAME@VERSION
+    package_id: OptionalPackageId,
 }
 
 impl HandleCommand for SearchArgs {
     /// Handles the search command, searching a certain package.
     fn handle(&self, _: &Config, manager: &RepositoryManager) {
-        let (repository_id, package) = match manager.read_package(&self.package_name) {
+        let (repository_id, package) = match manager.read_package(&self.package_id.name) {
             Ok(package) => package,
             Err(RepositoryError::PackageNotFoundError { .. }) => {
-                println!("Cannot find package {}", self.package_name);
+                println!("Cannot find package {}", self.package_id.name);
                 return;
             },
             Err(e) => {
@@ -44,13 +40,13 @@ impl HandleCommand for SearchArgs {
         };
 
         // Use the latest version if the version isn't specified
-        let version = match &self.version {
+        let version = match &self.package_id.version {
             Some(version) => version,
             None => &latest_version,
         };
 
         // Create a package id
-        let package_id = PackageId::new(&self.package_name, version);
+        let package_id = PackageId::new(&self.package_id.name, version);
 
         // Get package version info for its target
         let package_version = match manager.read_repo_package_version(&repository_id, &package_id) {

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -1,9 +1,9 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand,
+    cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::{types::Version, Installer, InstallerOptions},
+    installer::{types::OptionalPackageId, Installer, InstallerOptions},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -11,23 +11,24 @@ use crate::{
 
 #[derive(Args, Debug)]
 pub struct UninstallArgs {
-    /// The name of the package to uninstall
-    pub package_name: String,
-
-    /// The version of the package to uninstall
-    #[arg(short, long)]
-    pub version: Option<Version>,
+    /// The name of the packages to install, with an optional version specified with NAME@VERSION
+    #[arg(num_args(0..))]
+    pub packages: Vec<OptionalPackageId>,
 }
 
 impl HandleCommand for UninstallArgs {
-    // TODO: Add <package>@<version> notation for uninstall as well to be more consistant
     fn handle(&self, config: &Config, manager: &RepositoryManager) {
         let register_dir = PackageRegister::get_default_path();
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        Installer::new(config, &mut register, manager, InstallerOptions::default())
-            .uninstall(&self.package_name, self.version.as_ref())
-            .unwrap_or_exit(1);
+        let mut installer = Installer::new(config, &mut register, manager, InstallerOptions::default());
+
+        // Uninstall all specified packages
+        for package_id in &self.packages {
+            if let Err(error) = installer.uninstall(&package_id.name, package_id.version.as_ref()) {
+                error!(error, "Cannot uninstall package {package_id}");
+            }
+        }
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -25,7 +25,7 @@ impl HandleCommand for UninstallArgs {
 
         // Uninstall all specified packages
         for package_id in &self.packages {
-            if let Err(error) = installer.uninstall(&package_id.name, package_id.version.as_ref()) {
+            if let Err(error) = installer.uninstall(&package_id) {
                 error!(error, "Cannot uninstall package {package_id}");
             }
         }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -11,7 +11,7 @@ use crate::{
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
-        types::{Dependency, PackageId, Version},
+        types::{Dependency, OptionalPackageId, PackageId, Version},
     },
     platforms::{symlink, TARGET_ARCHITECTURE},
     repositories::{
@@ -60,22 +60,22 @@ impl<'a> Installer<'a> {
     }
 
     /// Installs the given package and its dependencies.
-    pub fn install(&mut self, package_name: &str, version: Option<&Version>) -> Result<()> {
+    pub fn install(&mut self, package_id: &OptionalPackageId) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
         }
 
-        let (repository_id, package_metadata) = self.repository_manager.read_package(package_name)?;
+        let (repository_id, package_metadata) = self.repository_manager.read_package(&package_id.name)?;
 
         // Use the latest version if the version isn't specified
-        let version = match version {
+        let version = match &package_id.version {
             Some(version) => version,
             None => package_metadata.get_latest_version(TARGET_ARCHITECTURE)?,
         };
 
         // Create a package id of the current package
-        let package_id = PackageId::new(&package_name, &version);
+        let package_id = PackageId::new(&package_id.name, &version);
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -360,9 +360,10 @@ impl<'a> Installer<'a> {
             // Get name and version from the current build dependency
             let name = &build_dependency.package_metadata.name;
             let version = &build_dependency.version_metadata.version;
+            let package_id = PackageId::new(name, version);
 
             // Continue if the build dependency is also a dependency in the dependency sequence
-            if dependencies.iter().any(|d| d.name == *name && d.version == *version) {
+            if dependencies.iter().any(|d| *d == package_id) {
                 continue;
             }
 
@@ -371,7 +372,7 @@ impl<'a> Installer<'a> {
                 continue;
             }
 
-            self.uninstall(&PackageId::new(&build_dependency.package_metadata.name, &build_dependency.version_metadata.version).into())?;
+            self.uninstall(&package_id.into())?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -371,10 +371,10 @@ impl<'a> Installer<'a> {
                 continue;
             }
 
-            self.uninstall(
+            self.uninstall(&OptionalPackageId::new_versioned(
                 &build_dependency.package_metadata.name,
-                Some(&build_dependency.version_metadata.version),
-            )?;
+                &build_dependency.version_metadata.version,
+            ))?;
         }
 
         Ok(())
@@ -385,25 +385,25 @@ impl<'a> Installer<'a> {
     }
 
     /// Uninstalls a package version if specified, otherwise it will uninstall the entire package directory.
-    pub fn uninstall(&mut self, package_name: &str, version: Option<&Version>) -> Result<()> {
+    pub fn uninstall(&mut self, package_id: &OptionalPackageId) -> Result<()> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
         }
 
         // Check if the current package to delete is a dependency, if so, give dependency error
-        if self.register.is_dependency(package_name, version) {
+        if self.register.is_dependency(&package_id.name, package_id.version.as_ref()) {
             return Err(InstallerError::DependencyError {
-                package_name: package_name.into(),
+                package_name: package_id.name.clone(),
             });
         }
 
         // This determines the directory to remove. If there are multiple versions and the version is
         // specified only the specified version directory will be deleted. The entire package directory
         // is deleted if the version isn't specified or if the package directory only contains one version.
-        match version {
-            Some(version) => self.uninstall_single(&PackageId::new(package_name, &version))?,
-            None => self.uninstall_all(package_name)?,
+        match &package_id.version {
+            Some(version) => self.uninstall_single(&PackageId::new(&package_id.name, &version))?,
+            None => self.uninstall_all(&package_id.name)?,
         };
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -371,10 +371,7 @@ impl<'a> Installer<'a> {
                 continue;
             }
 
-            self.uninstall(&OptionalPackageId::new_versioned(
-                &build_dependency.package_metadata.name,
-                &build_dependency.version_metadata.version,
-            ))?;
+            self.uninstall(&PackageId::new(&build_dependency.package_metadata.name, &build_dependency.version_metadata.version).into())?;
         }
 
         Ok(())

--- a/src/installer/types/mod.rs
+++ b/src/installer/types/mod.rs
@@ -6,6 +6,7 @@ mod version_bounds;
 pub use dependency::Dependency;
 pub use dependency::DependencyParserError;
 
+pub use package_id::OptionalPackageId;
 pub use package_id::PackageId;
 
 pub use version::Version;

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -82,6 +82,59 @@ impl FromStr for PackageId {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OptionalPackageId {
+    pub name: String,
+    pub version: Option<Version>,
+}
+
+impl FromStr for OptionalPackageId {
+    type Err = PackageIdError;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        // Name must have some value
+        if string.is_empty() {
+            return Err(PackageIdError::NoNameError);
+        }
+
+        if string.contains("@") {
+            let package_id = PackageId::from_str(&string)?;
+
+            return Ok(Self {
+                name: package_id.name,
+                version: Some(package_id.version),
+            });
+        }
+
+        Ok(Self {
+            name: string.into(),
+            version: None,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for OptionalPackageId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string: String = de::Deserialize::deserialize(deserializer)?;
+        Ok(Self::from_str(&string).map_err(de::Error::custom)?)
+    }
+}
+
+impl Display for OptionalPackageId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &self.name)?;
+
+        if let Some(version) = &self.version {
+            write!(f, "@{}", version)?;
+        }
+
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,5 +167,33 @@ mod tests {
         let correct_version = PackageId::new("Test", &Version::from_str("3.4.1").expect("Expected Version."));
 
         assert_eq!(correct_version.to_string(), "Test@3.4.1");
+    }
+
+    #[test]
+    fn from_str_optional() {
+        let correct_version = OptionalPackageId {
+            name: "Test".into(),
+            version: Some(Version::from_str("3.4.1").expect("Expected Version.")),
+        };
+
+        match OptionalPackageId::from_str("Test@3.4.1") {
+            Ok(id) => assert_eq!(id, correct_version),
+            Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: Some(Version(..)))), got Err({e:?})"),
+        }
+
+        let correct_version = OptionalPackageId {
+            name: "Test".into(),
+            version: None,
+        };
+
+        match OptionalPackageId::from_str("Test") {
+            Ok(id) => assert_eq!(id, correct_version),
+            Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: None)), got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn from_str_empty_optional() {
+        assert_eq!(OptionalPackageId::from_str(""), Err(PackageIdError::NoNameError));
     }
 }

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -88,18 +88,11 @@ pub struct OptionalPackageId {
     pub version: Option<Version>,
 }
 
-impl OptionalPackageId {
-    pub fn new(name: &str, version: Option<&Version>) -> Self {
+impl From<PackageId> for OptionalPackageId {
+    fn from(value: PackageId) -> Self {
         Self {
-            name: name.to_string(),
-            version: version.cloned(),
-        }
-    }
-
-    pub fn new_versioned(name: &str, version: &Version) -> Self {
-        Self {
-            name: name.to_string(),
-            version: Some(version.clone()),
+            name: value.name,
+            version: Some(value.version),
         }
     }
 }
@@ -126,16 +119,6 @@ impl FromStr for OptionalPackageId {
             name: string.into(),
             version: None,
         })
-    }
-}
-
-impl<'de> Deserialize<'de> for OptionalPackageId {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let string: String = de::Deserialize::deserialize(deserializer)?;
-        Ok(Self::from_str(&string).map_err(de::Error::custom)?)
     }
 }
 
@@ -187,13 +170,16 @@ mod tests {
 
     #[test]
     fn from_str_optional() {
-        let correct_version = OptionalPackageId::new_versioned("Test", &Version::from_str("3.4.1").expect("Expected Version."));
+        let correct_version = PackageId::new("Test", &Version::from_str("3.4.1").expect("Expected Version.")).into();
         match OptionalPackageId::from_str("Test@3.4.1") {
             Ok(id) => assert_eq!(id, correct_version),
             Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: Some(Version(..)))), got Err({e:?})"),
         }
 
-        let correct_version = OptionalPackageId::new("Test", None);
+        let correct_version = OptionalPackageId {
+            name: "Test".into(),
+            version: None,
+        };
         match OptionalPackageId::from_str("Test") {
             Ok(id) => assert_eq!(id, correct_version),
             Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: None)), got Err({e:?})"),

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -88,6 +88,22 @@ pub struct OptionalPackageId {
     pub version: Option<Version>,
 }
 
+impl OptionalPackageId {
+    pub fn new(name: &str, version: Option<&Version>) -> Self {
+        Self {
+            name: name.to_string(),
+            version: version.cloned(),
+        }
+    }
+
+    pub fn new_versioned(name: &str, version: &Version) -> Self {
+        Self {
+            name: name.to_string(),
+            version: Some(version.clone()),
+        }
+    }
+}
+
 impl FromStr for OptionalPackageId {
     type Err = PackageIdError;
 
@@ -171,21 +187,13 @@ mod tests {
 
     #[test]
     fn from_str_optional() {
-        let correct_version = OptionalPackageId {
-            name: "Test".into(),
-            version: Some(Version::from_str("3.4.1").expect("Expected Version.")),
-        };
-
+        let correct_version = OptionalPackageId::new_versioned("Test", &Version::from_str("3.4.1").expect("Expected Version."));
         match OptionalPackageId::from_str("Test@3.4.1") {
             Ok(id) => assert_eq!(id, correct_version),
             Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: Some(Version(..)))), got Err({e:?})"),
         }
 
-        let correct_version = OptionalPackageId {
-            name: "Test".into(),
-            version: None,
-        };
-
+        let correct_version = OptionalPackageId::new("Test", None);
         match OptionalPackageId::from_str("Test") {
             Ok(id) => assert_eq!(id, correct_version),
             Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'Test', version: None)), got Err({e:?})"),


### PR DESCRIPTION
This PR refactors the package version argument in the uninstall and search command by implementing a new `OptionalPackageId`. The OptionalPackageId is also implement in several functions in the installer.