### PR TITLE
Refactor installer types

### DIFF
--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -39,20 +39,14 @@ impl HandleCommand for SearchArgs {
             },
         };
 
-        // Use the latest version if the version isn't specified
-        let version = match &self.optional_id.version {
-            Some(version) => version,
-            None => &latest_version,
-        };
-
         // Create a package id
-        let package_id = self.optional_id.to_package_id(version.clone());
+        let package_id = self.optional_id.versioned_or(latest_version.clone());
 
         // Get package version info for its target
         let package_version = match manager.read_repo_package_version(&repository_id, &package_id) {
             Ok(package_version) => package_version,
             Err(e) => {
-                error!(e, "Cannot read {} version {version} from repository {repository_id}", package.name);
+                error!(e, "Cannot read '{package_id}' from repository {repository_id}");
                 return;
             },
         };
@@ -61,14 +55,11 @@ impl HandleCommand for SearchArgs {
         let target = match package_version.get_target(TARGET_ARCHITECTURE) {
             Ok(target) => target,
             Err(RepositoryError::TargetError) => {
-                println!(
-                    "Package {} version {version} from repository {repository_id} does not exist for current target",
-                    package.name
-                );
+                println!("Package {package_id} from repository {repository_id} does not exist for current target");
                 return;
             },
             Err(e) => {
-                error!(e, "Cannot read {} version {version} from repository {repository_id}", package.name);
+                error!(e, "Cannot read {package_id} from repository {repository_id}");
                 return;
             },
         };

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -4,10 +4,9 @@ use colored::Colorize;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::types::{OptionalPackageId, PackageId},
+    installer::types::OptionalPackageId,
     platforms::TARGET_ARCHITECTURE,
     repositories::{error::RepositoryError, manager::RepositoryManager},
-    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 #[derive(Args, Debug)]
@@ -47,7 +46,7 @@ impl HandleCommand for SearchArgs {
         };
 
         // Create a package id
-        let package_id = PackageId::new(&self.optional_id.name, version).unwrap_or_exit(1);
+        let package_id = self.optional_id.to_package_id(version.clone());
 
         // Get package version info for its target
         let package_version = match manager.read_repo_package_version(&repository_id, &package_id) {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -57,7 +57,7 @@ impl InstallMeta {
         // Get all the data to create a dependency node
         let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
         let version = package_metadata.get_latest_dependency_version(&dependency)?;
-        let dependency_id = PackageId::new(dependency.get_name(), &version).expect("Expected valid dependency name");
+        let dependency_id = dependency.to_package_id(version);
         let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
 
         Ok(Self {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -95,14 +95,8 @@ impl<'a> Installer<'a> {
 
         let (repository_id, package_metadata) = self.repository_manager.read_package(&optional_id.name)?;
 
-        // Use the latest version if the version isn't specified
-        let version = match &optional_id.version {
-            Some(version) => version,
-            None => package_metadata.get_latest_version(TARGET_ARCHITECTURE)?,
-        };
-
         // Create a package id of the current package
-        let package_id = optional_id.to_package_id(version.clone());
+        let package_id = optional_id.versioned_or_else_try(|| package_metadata.get_latest_version(TARGET_ARCHITECTURE).cloned())?;
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {
@@ -376,10 +370,10 @@ impl<'a> Installer<'a> {
         // This determines the directory to remove. If there are multiple versions and the version is
         // specified only the specified version directory will be deleted. The entire package directory
         // is deleted if the version isn't specified or if the package directory only contains one version.
-        match &optional_id.version {
-            Some(version) => self.uninstall_single(&optional_id.to_package_id(version.clone()))?,
+        match optional_id.versioned() {
+            Some(package_id) => self.uninstall_single(&package_id)?,
             None => self.uninstall_all(&optional_id.name)?,
-        };
+        }
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -91,12 +91,28 @@ impl<'a> Installer<'a> {
             return Err(InstallerError::PermissionsError);
         }
 
-        // TODO: If version isn't specified check here if a package with the package name is already installed (otherwise a user can get two different version installed without knowing)
-
         let (repository_id, package_metadata) = self.repository_manager.read_package(&optional_id.name)?;
+        let latest_version = package_metadata.get_latest_version(TARGET_ARCHITECTURE)?;
+
+        // If the version isn't specified check if a package with this package name is already installed (otherwise a user can get two different version installed without knowing)
+        if optional_id.version.is_none() {
+            if let Some(package) = self.register.get_package(&optional_id.name) {
+                if package.get_package_version(latest_version).is_some() {
+                    println!("The latest version '{latest_version}' of '{optional_id}' is already installed.");
+                    return Ok(());
+                }
+
+                let question = format!(
+                    "The package '{optional_id}' is already installed, but a newer version '{latest_version}' is available. Do you wish to install the latest version as well?"
+                );
+                if ask_user(&question, QuestionResponse::No)?.is_no_or_invalid() {
+                    return Ok(());
+                }
+            }
+        }
 
         // Create a package id of the current package
-        let package_id = optional_id.versioned_or_else_try(|| package_metadata.get_latest_version(TARGET_ARCHITECTURE).cloned())?;
+        let package_id = optional_id.versioned_or(latest_version.clone());
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -102,7 +102,7 @@ impl<'a> Installer<'a> {
         };
 
         // Create a package id of the current package
-        let package_id = PackageId::new(&optional_id.name, &version)?;
+        let package_id = optional_id.to_package_id(version.clone());
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {
@@ -194,7 +194,7 @@ impl<'a> Installer<'a> {
         let node_value = node.get_value();
 
         // Create the package id and install directory
-        let package_id = PackageId::new(&node_value.package_metadata.name, &node_value.version_metadata.version)?;
+        let package_id = PackageId::new(&node_value.package_metadata.name, node_value.version_metadata.version.clone())?;
         let install_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
         // Return early if the package has been installed by another node in the sequence (duplicates can exist)
@@ -377,7 +377,7 @@ impl<'a> Installer<'a> {
         // specified only the specified version directory will be deleted. The entire package directory
         // is deleted if the version isn't specified or if the package directory only contains one version.
         match &optional_id.version {
-            Some(version) => self.uninstall_single(&PackageId::new(&optional_id.name, &version)?)?,
+            Some(version) => self.uninstall_single(&optional_id.to_package_id(version.clone()))?,
             None => self.uninstall_all(&optional_id.name)?,
         };
 

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -3,12 +3,15 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
-use crate::installer::types::{Version, VersionBounds, VersionError};
+use crate::installer::types::{PackageId, Version, VersionBounds, VersionError};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum DependencyParserError {
     #[error("Cannot parse version number")]
     VersionNumberError(#[from] VersionError),
+
+    #[error("Invalid dependency name, a package name cannot be empty and can only contain characters: 'a-z', 'A-Z', '0-9', '-' and '_'")]
+    InvalidDependencyName,
 }
 
 // TODO: Dependency names should be validated like in the PackageId also implement a method which takes a version and then returns a PackageId
@@ -28,13 +31,13 @@ impl<'de> Deserialize<'de> for Dependency {
 
         let (name, version) = match index {
             Some(index) => string.split_at(index),
-            None => {
-                return Ok(Self {
-                    name: string.to_string(),
-                    version_ranges: vec![],
-                });
-            },
+            None => (string.as_str(), ""),
         };
+
+        // Check for name validity
+        if !PackageId::is_valid_name(name) {
+            return Err(de::Error::custom(DependencyParserError::InvalidDependencyName));
+        }
 
         // Remove @ character from version number
         let version = version.strip_prefix("@").unwrap_or("");
@@ -119,6 +122,10 @@ impl Dependency {
         }
 
         false
+    }
+
+    pub fn to_package_id(&self, version: Version) -> PackageId {
+        PackageId::new(&self.name, &version).expect("Expected valid name from dependency.")
     }
 }
 

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -125,7 +125,7 @@ impl Dependency {
     }
 
     pub fn to_package_id(&self, version: Version) -> PackageId {
-        PackageId::new(&self.name, &version).expect("Expected valid name from dependency.")
+        PackageId::new(&self.name, version).expect("Expected valid name from dependency.")
     }
 }
 

--- a/src/installer/types/optional_id.rs
+++ b/src/installer/types/optional_id.rs
@@ -61,8 +61,25 @@ impl OptionalPackageId {
         }
     }
 
-    pub fn to_package_id(&self, version: Version) -> PackageId {
-        PackageId::new(&self.name, version).expect("Expected valid name from optional id.")
+    pub fn versioned_or(&self, version: Version) -> PackageId {
+        let version = match &self.version {
+            Some(version) => version.clone(),
+            None => version,
+        };
+
+        PackageId::new(&self.name, version).expect("Expected valid name from optional package id")
+    }
+
+    pub fn versioned_or_else_try<F, E>(&self, version_closure: F) -> Result<PackageId, E>
+    where
+        F: FnOnce() -> Result<Version, E>,
+    {
+        let version = match &self.version {
+            Some(version) => version.clone(),
+            None => version_closure()?,
+        };
+
+        Ok(PackageId::new(&self.name, version).expect("Expected valid name from optional package id"))
     }
 }
 

--- a/src/installer/types/optional_id.rs
+++ b/src/installer/types/optional_id.rs
@@ -56,9 +56,13 @@ impl Display for OptionalPackageId {
 impl OptionalPackageId {
     pub fn versioned(&self) -> Option<PackageId> {
         match &self.version {
-            Some(version) => Some(PackageId::new(&self.name, &version).expect("Expected valid name from optional package id")),
+            Some(version) => Some(PackageId::new(&self.name, version.clone()).expect("Expected valid name from optional package id")),
             None => None,
         }
+    }
+
+    pub fn to_package_id(&self, version: Version) -> PackageId {
+        PackageId::new(&self.name, version).expect("Expected valid name from optional id.")
     }
 }
 
@@ -71,7 +75,7 @@ mod tests {
     #[test]
     fn from_str_optional() {
         let version = Version::from_str("3.4.1").expect("Expected Version.");
-        let correct_version = PackageId::new("test", &version).expect("Expected valid package id").into();
+        let correct_version = PackageId::new("test", version).expect("Expected valid package id").into();
         match OptionalPackageId::from_str("test@3.4.1") {
             Ok(id) => assert_eq!(id, correct_version),
             Err(e) => panic!("Expected Ok(OptionalPackageId(name: 'test', version: Some(Version(..)))), got Err({e:?})"),

--- a/src/installer/types/optional_id.rs
+++ b/src/installer/types/optional_id.rs
@@ -69,18 +69,6 @@ impl OptionalPackageId {
 
         PackageId::new(&self.name, version).expect("Expected valid name from optional package id")
     }
-
-    pub fn versioned_or_else_try<F, E>(&self, version_closure: F) -> Result<PackageId, E>
-    where
-        F: FnOnce() -> Result<Version, E>,
-    {
-        let version = match &self.version {
-            Some(version) => version.clone(),
-            None => version_closure()?,
-        };
-
-        Ok(PackageId::new(&self.name, version).expect("Expected valid name from optional package id"))
-    }
 }
 
 #[cfg(test)]

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -25,14 +25,14 @@ pub struct PackageId {
 const VALID_PACKAGE_NAME: &str = r"^[a-zA-Z0-9\-_]+$";
 
 impl PackageId {
-    pub fn new(name: &str, version: &Version) -> Result<Self, PackageIdError> {
+    pub fn new(name: &str, version: Version) -> Result<Self, PackageIdError> {
         if !PackageId::is_valid_name(name) {
             return Err(PackageIdError::InvalidPackageName);
         }
 
         Ok(Self {
             name: name.to_string(),
-            version: version.clone(),
+            version,
         })
     }
 
@@ -105,7 +105,7 @@ mod tests {
     #[test]
     fn from_str() {
         let version = Version::from_str("3.4.1").expect("Expected Version.");
-        let correct_version = PackageId::new("test", &version).expect("Expected valid package name");
+        let correct_version = PackageId::new("test", version).expect("Expected valid package name");
 
         match PackageId::from_str("test@3.4.1") {
             Ok(id) => assert_eq!(id, correct_version),
@@ -140,7 +140,7 @@ mod tests {
     #[test]
     fn valid_format() {
         let version = Version::from_str("3.4.1").expect("Expected Version.");
-        let correct_version = PackageId::new("test", &version).expect("Expected valid package name");
+        let correct_version = PackageId::new("test", version).expect("Expected valid package name");
 
         assert_eq!(correct_version.to_string(), "test@3.4.1");
     }

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -92,7 +92,7 @@ impl PackageRegister {
         active: bool,
     ) -> Result<(), RegisterError> {
         let installed_package_version = InstalledPackageVersion {
-            package_id: PackageId::new(&package.name, &package_version.version)?,
+            package_id: PackageId::new(&package.name, package_version.version.clone())?,
             license: package_version.license.clone(),
             source_repository_url: source_repository.path.clone(),
             source_repository_provider: source_repository.provider.clone(),

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -199,7 +199,7 @@ impl Node<InstallMeta, DependencyTypes> {
     ) -> Result<Node<InstallMeta, DependencyTypes>, TreeError> {
         let install_meta = InstallMeta::new(manager, dependency)?;
         let latest_version = install_meta.package_metadata.get_latest_version(TARGET_ARCHITECTURE)?;
-        let dependency_id = PackageId::new(dependency.get_name(), latest_version).expect("Expected valid dependency");
+        let dependency_id = dependency.to_package_id(latest_version.clone());
         Self::new_from_meta_impl(&dependency_id, install_meta, manager, label, include_build)
     }
 }

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -198,7 +198,7 @@ impl<'a> Verifier<'a> {
 
                 // Get the version, and create the package id
                 let version = Version::from_str(file_version.file_name().to_str().ok_or(VerifierError::InvalidUnicodeError)?)?;
-                let package_id = PackageId::new(package_name, &version)?;
+                let package_id = PackageId::new(package_name, version)?;
 
                 // Check if the package version also exists in the register, if not add it to missing
                 if register.get_package_version(&package_id).is_none() {


### PR DESCRIPTION
Add name checks and to_package_id method to the dependency struct. 
Also add a versioned_or method to the optional package id to get the package id.