### PR TITLE
Refactor version bounds

### DIFF
--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -585,6 +585,7 @@ impl<'a> Installer<'a> {
 
     pub fn update(&mut self, optional_id: &OptionalPackageId, new_version: &Version) -> Result<()> {
         let old_package = self.get_specific_package_update(optional_id)?;
+        let new_package_id = PackageId::new(&old_package.package_id.name, new_version.clone())?;
 
         // Check if the new version is lower then the current
         if old_package.package_id.version > *new_version {
@@ -615,7 +616,7 @@ impl<'a> Installer<'a> {
                 },
             };
 
-            if !dependency.satisfied(&old_package.package_id.name, Some(new_version)) {
+            if !dependency.satisfied(&new_package_id.name, new_version) {
                 return Err(InstallerError::SatisfyError {
                     new_version: new_version.clone(),
                 });
@@ -628,7 +629,6 @@ impl<'a> Installer<'a> {
         let old_package_id = old_package.package_id.clone();
 
         // Install the newer packager first
-        let new_package_id = PackageId::new(&old_package.package_id.name, new_version.clone())?;
         self.install(&new_package_id.clone().into())?;
 
         // Add dependents to new_package

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -14,7 +14,6 @@ pub enum DependencyParserError {
     InvalidDependencyName,
 }
 
-// TODO: Dependency names should be validated like in the PackageId also implement a method which takes a version and then returns a PackageId
 #[derive(Debug, Clone)]
 pub struct Dependency {
     name: String,
@@ -95,23 +94,17 @@ impl Dependency {
         &self.name
     }
 
-    // TODO: Should only except package_id, version shouldn't be optional
-    pub fn satisfied(&self, name: &str, version: Option<&Version>) -> bool {
+    pub fn satisfied(&self, name: &str, version: &Version) -> bool {
         if self.name != name {
             return false;
         }
-
-        let version = match version {
-            Some(version) => version,
-            None => return true,
-        };
 
         if self.version_ranges.is_empty() {
             return true;
         }
 
         for range in &self.version_ranges {
-            if range.covers(version) {
+            if range.covers(&version) {
                 return true;
             }
         }
@@ -138,59 +131,51 @@ pub mod tests {
     }
 
     #[test]
-    fn satisfied_name_only() {
-        let dependency = create_dependency("Test", "3.4.1");
-
-        assert!(dependency.satisfied("Test", None));
-        assert!(!dependency.satisfied("Test Wrong", None));
-    }
-
-    #[test]
     fn satisfied_range() {
         let dependency = create_dependency("Test", "3.4.1-3.4.8");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.8").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.0").expect("Expected version"))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.9").expect("Expected version"))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.8").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.0").expect("Expected version")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.9").expect("Expected version")));
     }
 
     #[test]
     fn satisfied_lower() {
         let dependency = create_dependency("Test", "<3.4.1");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.0").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.1").expect("Expected Version."))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.0").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.1").expect("Expected Version.")));
     }
 
     #[test]
     fn satisfied_lower_equals() {
         let dependency = create_dependency("Test", "<=3.4.1");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.1").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.2").expect("Expected Version."))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.1").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.2").expect("Expected Version.")));
     }
 
     #[test]
     fn satisfied_higher() {
         let dependency = create_dependency("Test", ">3.4.1");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.2").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.1").expect("Expected Version."))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.2").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.1").expect("Expected Version.")));
     }
 
     #[test]
     fn satisfied_higher_equals() {
         let dependency = create_dependency("Test", ">=3.4.1");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.1").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("3.4.0").expect("Expected Version."))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.1").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("3.4.0").expect("Expected Version.")));
     }
 
     #[test]
     fn satisfied_equals() {
         let dependency = create_dependency("Test", "3.4.1");
 
-        assert!(dependency.satisfied("Test", Some(&Version::from_str("3.4.1").expect("Expected Version."))));
-        assert!(!dependency.satisfied("Test", Some(&Version::from_str("5").expect("Expected Version."))));
+        assert!(dependency.satisfied("Test", &Version::from_str("3.4.1").expect("Expected Version.")));
+        assert!(!dependency.satisfied("Test", &Version::from_str("5").expect("Expected Version.")));
     }
 }

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
-use crate::installer::types::{PackageId, Version, VersionBounds, VersionError};
+use crate::installer::types::{PackageId, Version, VersionBounds, VersionError, version_intervals::VersionIntervals};
 
 #[derive(Error, Debug, PartialEq)]
 pub enum DependencyParserError {
@@ -17,7 +17,7 @@ pub enum DependencyParserError {
 #[derive(Debug, Clone)]
 pub struct Dependency {
     name: String,
-    version_ranges: Vec<VersionBounds>,
+    version_intervals: VersionIntervals,
 }
 
 impl<'de> Deserialize<'de> for Dependency {
@@ -41,12 +41,11 @@ impl<'de> Deserialize<'de> for Dependency {
         // Remove @ character from version number
         let version = version.strip_prefix("@").unwrap_or("");
 
-        // TODO: Check for impossible requirements, like: >3.1|<3.1
-        let version_ranges = VersionBounds::from_str_ranges(version).map_err(de::Error::custom)?;
+        let version_intervals = VersionIntervals::from_str_intervals(version).map_err(de::Error::custom)?;
 
         Ok(Self {
             name: name.to_string(),
-            version_ranges,
+            version_intervals,
         })
     }
 }
@@ -63,13 +62,13 @@ impl Serialize for Dependency {
 impl Display for Dependency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Return only the name if the version isn't specified
-        if self.version_ranges.is_empty() {
+        if self.version_intervals.get_version_bounds().is_empty() {
             write!(f, "{}", self.name)?;
             return Ok(());
         }
 
         let mut string_version = String::new();
-        for range in &self.version_ranges {
+        for range in self.version_intervals.get_version_bounds() {
             if !string_version.is_empty() {
                 string_version.push('|');
             }
@@ -99,12 +98,12 @@ impl Dependency {
             return false;
         }
 
-        if self.version_ranges.is_empty() {
+        if self.version_intervals.get_version_bounds().is_empty() {
             return true;
         }
 
-        for range in &self.version_ranges {
-            if range.covers(&version) {
+        for bound in self.version_intervals.get_version_bounds() {
+            if bound.covers(&version) {
                 return true;
             }
         }
@@ -123,10 +122,10 @@ pub mod tests {
 
     use super::*;
 
-    pub fn create_dependency(name: &str, version_ranges: &str) -> Dependency {
+    pub fn create_dependency(name: &str, version_intervals: &str) -> Dependency {
         Dependency {
             name: name.into(),
-            version_ranges: VersionBounds::from_str_ranges(version_ranges).expect("Expected VersionBounds"),
+            version_intervals: VersionIntervals::from_str_intervals(version_intervals).expect("Expected correct version intervals."),
         }
     }
 

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -62,7 +62,7 @@ impl Serialize for Dependency {
 impl Display for Dependency {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         // Return only the name if the version isn't specified
-        if self.version_intervals.get_version_bounds().is_empty() {
+        if self.version_intervals.is_empty() {
             write!(f, "{}", self.name)?;
             return Ok(());
         }

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -98,17 +98,7 @@ impl Dependency {
             return false;
         }
 
-        if self.version_intervals.get_version_bounds().is_empty() {
-            return true;
-        }
-
-        for bound in self.version_intervals.get_version_bounds() {
-            if bound.covers(&version) {
-                return true;
-            }
-        }
-
-        false
+        self.version_intervals.covers(version)
     }
 
     pub fn to_package_id(&self, version: Version) -> PackageId {

--- a/src/installer/types/dependency.rs
+++ b/src/installer/types/dependency.rs
@@ -1,4 +1,4 @@
-use std::fmt::Display;
+use std::{fmt::Display, str::FromStr};
 
 use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
@@ -41,7 +41,7 @@ impl<'de> Deserialize<'de> for Dependency {
         // Remove @ character from version number
         let version = version.strip_prefix("@").unwrap_or("");
 
-        let version_intervals = VersionIntervals::from_str_intervals(version).map_err(de::Error::custom)?;
+        let version_intervals = VersionIntervals::from_str(version).map_err(de::Error::custom)?;
 
         Ok(Self {
             name: name.to_string(),
@@ -115,7 +115,7 @@ pub mod tests {
     pub fn create_dependency(name: &str, version_intervals: &str) -> Dependency {
         Dependency {
             name: name.into(),
-            version_intervals: VersionIntervals::from_str_intervals(version_intervals).expect("Expected correct version intervals."),
+            version_intervals: VersionIntervals::from_str(version_intervals).expect("Expected correct version intervals."),
         }
     }
 

--- a/src/installer/types/mod.rs
+++ b/src/installer/types/mod.rs
@@ -3,6 +3,7 @@ mod optional_id;
 mod package_id;
 mod version;
 mod version_bounds;
+mod version_intervals;
 
 pub use dependency::Dependency;
 
@@ -15,6 +16,8 @@ pub use version::Version;
 pub use version::VersionError;
 
 pub use version_bounds::VersionBounds;
+
+pub use version_intervals::VersionIntervals;
 
 #[cfg(test)]
 pub use dependency::tests as dependency_tests;

--- a/src/installer/types/version.rs
+++ b/src/installer/types/version.rs
@@ -20,6 +20,9 @@ pub enum VersionError {
     #[error("Multiple leading, trailing or consecutive dots are not allowed in version number.")]
     DotsError,
 
+    #[error("Invalid version interval, an interval must be ordered and not overlapping.")]
+    InvalidInterval,
+
     #[error("Couldn't parse version number")]
     ParseError(#[from] ParseIntError),
 }

--- a/src/installer/types/version_bounds.rs
+++ b/src/installer/types/version_bounds.rs
@@ -60,19 +60,6 @@ impl VersionBounds {
             _ => false,
         }
     }
-
-    /// Gets the upperbound of the current VersionBounds.
-    /// Returns Some(Version) if an upperbound exists, None if it doesn't.
-    pub fn get_upperbound(&self) -> Option<&Version> {
-        match self {
-            VersionBounds::Range(_, high) => Some(high),
-            VersionBounds::Lower(version) => Some(version),
-            VersionBounds::LowerEqual(version) => Some(version),
-            VersionBounds::Higher(_) => None,
-            VersionBounds::HigherEqual(_) => None,
-            VersionBounds::Equal(version) => Some(version),
-        }
-    }
 }
 
 #[cfg(test)]

--- a/src/installer/types/version_bounds.rs
+++ b/src/installer/types/version_bounds.rs
@@ -1,8 +1,10 @@
 use std::str::FromStr;
 
+use serde::Deserialize;
+
 use crate::installer::types::{Version, VersionError};
 
-#[derive(Debug, Clone, Hash, PartialEq, Eq)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Deserialize)]
 pub enum VersionBounds {
     Range(Version, Version),
     Lower(Version),
@@ -56,6 +58,19 @@ impl VersionBounds {
             VersionBounds::HigherEqual(higher) if version >= higher => true,
             VersionBounds::Equal(equal) if version == equal => true,
             _ => false,
+        }
+    }
+
+    /// Gets the upperbound of the current VersionBounds.
+    /// Returns Some(Version) if an upperbound exists, None if it doesn't.
+    pub fn get_upperbound(&self) -> Option<&Version> {
+        match self {
+            VersionBounds::Range(_, high) => Some(high),
+            VersionBounds::Lower(version) => Some(version),
+            VersionBounds::LowerEqual(version) => Some(version),
+            VersionBounds::Higher(_) => None,
+            VersionBounds::HigherEqual(_) => None,
+            VersionBounds::Equal(version) => Some(version),
         }
     }
 }

--- a/src/installer/types/version_bounds.rs
+++ b/src/installer/types/version_bounds.rs
@@ -47,22 +47,6 @@ impl FromStr for VersionBounds {
 }
 
 impl VersionBounds {
-    pub fn from_str_ranges(ranges: &str) -> Result<Vec<VersionBounds>, VersionError> {
-        // Check for empty input
-        if ranges.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let ranges = ranges.split('|');
-        let mut bounds = Vec::new();
-
-        for range in ranges {
-            bounds.push(VersionBounds::from_str(range)?);
-        }
-
-        Ok(bounds)
-    }
-
     pub fn covers(&self, version: &Version) -> bool {
         match self {
             VersionBounds::Range(lower, upper) if lower <= version && upper >= version => true,
@@ -137,30 +121,6 @@ mod tests {
         match version_bound {
             Ok(bound) => assert!(matches!(bound, VersionBounds::Equal(..)), "bound was {:?}", bound),
             Err(e) => panic!("Expected Ok(VersionBound (..)), got Err({e:?})"),
-        }
-    }
-
-    #[test]
-    fn from_str_ranges() {
-        let version_bounds = VersionBounds::from_str_ranges(">3.4|<6.5");
-
-        match version_bounds {
-            Ok(bounds) => {
-                assert!(bounds.len() == 2);
-                assert!(matches!(bounds.get(0), Some(VersionBounds::Higher(..))), "bound was {:?}", bounds);
-                assert!(matches!(bounds.get(1), Some(VersionBounds::Lower(..))), "bound was {:?}", bounds);
-            },
-            Err(e) => panic!("Expected Ok(Vec(VersionBound (..))), got Err({e:?})"),
-        }
-    }
-
-    #[test]
-    fn from_str_ranges_empty() {
-        let version_bounds = VersionBounds::from_str_ranges("");
-
-        match version_bounds {
-            Ok(bounds) => assert!(bounds.len() == 0),
-            Err(e) => panic!("Expected Ok([]), got Err({e:?})"),
         }
     }
 }

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -1,12 +1,23 @@
 use std::str::FromStr;
 
-use serde::Deserialize;
+use serde::{Deserialize, de};
 
 use crate::installer::types::{Version, VersionBounds, VersionError};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VersionIntervals {
     version_bounds: Vec<VersionBounds>,
+}
+
+impl<'de> Deserialize<'de> for VersionIntervals {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string: String = de::Deserialize::deserialize(deserializer)?;
+
+        Ok(Self::from_str_intervals(&string).map_err(de::Error::custom)?)
+    }
 }
 
 impl VersionIntervals {

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -8,7 +8,6 @@ pub struct VersionIntervals {
 }
 
 impl VersionIntervals {
-    // TODO: Check for impossible requirements, like: >3.1|<3.1
     pub fn from_str_intervals(intervals: &str) -> Result<Self, VersionError> {
         // Check for empty input
         if intervals.is_empty() {
@@ -24,7 +23,50 @@ impl VersionIntervals {
             version_bounds.push(VersionBounds::from_str(interval)?);
         }
 
+        // Check for impossible requirements, like: >3.1|<3.1
+        if !Self::validate_intervals(&version_bounds) {
+            return Err(VersionError::InvalidInterval);
+        }
+
         Ok(Self { version_bounds })
+    }
+
+    /// Checks if the intervals are valid, the intervals are valid if they don't overlap and are in order.
+    /// True is returned if the intervals are valid, otherwise false.
+    fn validate_intervals(version_bounds: &Vec<VersionBounds>) -> bool {
+        let mut previous: Option<&VersionBounds> = None;
+        for bound in version_bounds {
+            let valued_previous = match previous {
+                Some(previous) => previous,
+                None => {
+                    previous = Some(&bound);
+                    continue;
+                },
+            };
+
+            let low_version = match bound {
+                VersionBounds::Range(low, _) => low,
+                VersionBounds::Lower(_) => return false,
+                VersionBounds::LowerEqual(_) => return false,
+                VersionBounds::Higher(version) => version,
+                VersionBounds::HigherEqual(version) => version,
+                VersionBounds::Equal(version) => version,
+            };
+
+            match valued_previous {
+                VersionBounds::Range(_, high) if *low_version <= *high => return false,
+                VersionBounds::Lower(version) if low_version < version => return false,
+                VersionBounds::LowerEqual(version) if low_version <= version => return false,
+                VersionBounds::Higher(_) => return false,
+                VersionBounds::HigherEqual(_) => return false,
+                VersionBounds::Equal(version) if *low_version <= *version => return false,
+                _ => {},
+            }
+
+            previous = Some(bound)
+        }
+
+        true
     }
 
     pub fn covers(&self, version: &Version) -> bool {

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -1,0 +1,69 @@
+use std::str::FromStr;
+
+use crate::installer::types::{VersionBounds, VersionError};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct VersionIntervals {
+    version_bounds: Vec<VersionBounds>,
+}
+
+impl VersionIntervals {
+    // TODO: Check for impossible requirements, like: >3.1|<3.1
+    pub fn from_str_intervals(intervals: &str) -> Result<Self, VersionError> {
+        // Check for empty input
+        if intervals.is_empty() {
+            return Ok(Self {
+                version_bounds: Vec::new(),
+            });
+        }
+
+        let intervals = intervals.split('|');
+        let mut version_bounds = Vec::new();
+
+        for interval in intervals {
+            version_bounds.push(VersionBounds::from_str(interval)?);
+        }
+
+        Ok(Self { version_bounds })
+    }
+
+    pub fn get_version_bounds(&self) -> &Vec<VersionBounds> {
+        &self.version_bounds
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn from_str_ranges() {
+        let version_intervals = VersionIntervals::from_str_intervals(">3.4|<6.5");
+
+        match version_intervals {
+            Ok(intervals) => {
+                let version_bounds = intervals.get_version_bounds();
+                assert!(version_bounds.len() == 2);
+                assert!(
+                    matches!(version_bounds.get(0), Some(VersionBounds::Higher(..))),
+                    "bound was {version_bounds:?}",
+                );
+                assert!(
+                    matches!(version_bounds.get(1), Some(VersionBounds::Lower(..))),
+                    "bound was {version_bounds:?}",
+                );
+            },
+            Err(e) => panic!("Expected Ok(Vec(VersionBound (..))), got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn from_str_ranges_empty() {
+        let version_intervals = VersionIntervals::from_str_intervals("");
+
+        match version_intervals {
+            Ok(intervals) => assert!(intervals.get_version_bounds().len() == 0),
+            Err(e) => panic!("Expected Ok([]), got Err({e:?})"),
+        }
+    }
+}

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -1,8 +1,10 @@
 use std::str::FromStr;
 
+use serde::Deserialize;
+
 use crate::installer::types::{Version, VersionBounds, VersionError};
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Deserialize)]
 pub struct VersionIntervals {
     version_bounds: Vec<VersionBounds>,
 }

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -23,7 +23,7 @@ impl VersionIntervals {
             version_bounds.push(VersionBounds::from_str(interval)?);
         }
 
-        // Check for impossible requirements, like: >3.1|<3.1
+        // Check for invalid intervals
         if !Self::validate_intervals(&version_bounds) {
             return Err(VersionError::InvalidInterval);
         }
@@ -96,18 +96,26 @@ mod tests {
 
     #[test]
     fn from_str_ranges() {
-        let version_intervals = VersionIntervals::from_str_intervals(">3.4|<6.5");
+        let version_intervals = VersionIntervals::from_str_intervals("<6.6|6.7|6.8-7.10|>8");
 
         match version_intervals {
             Ok(intervals) => {
                 let version_bounds = intervals.get_version_bounds();
-                assert!(version_bounds.len() == 2);
+                assert!(version_bounds.len() == 4);
                 assert!(
-                    matches!(version_bounds.get(0), Some(VersionBounds::Higher(..))),
+                    matches!(version_bounds.get(0), Some(VersionBounds::Lower(..))),
                     "bound was {version_bounds:?}",
                 );
                 assert!(
-                    matches!(version_bounds.get(1), Some(VersionBounds::Lower(..))),
+                    matches!(version_bounds.get(1), Some(VersionBounds::Equal(..))),
+                    "bound was {version_bounds:?}",
+                );
+                assert!(
+                    matches!(version_bounds.get(2), Some(VersionBounds::Range(..))),
+                    "bound was {version_bounds:?}",
+                );
+                assert!(
+                    matches!(version_bounds.get(3), Some(VersionBounds::Higher(..))),
                     "bound was {version_bounds:?}",
                 );
             },
@@ -122,6 +130,28 @@ mod tests {
         match version_intervals {
             Ok(intervals) => assert!(intervals.get_version_bounds().len() == 0),
             Err(e) => panic!("Expected Ok([]), got Err({e:?})"),
+        }
+    }
+
+    #[test]
+    fn from_str_valid_interval() {
+        let intervals = ["3", "<6.6|6.7|6.8-7.10|>8", "<=4|4.5|5-6|>=10.1", "4-10", "32|>34", "<6.5|>6.5"];
+        for interval in intervals {
+            match VersionIntervals::from_str_intervals(interval) {
+                Ok(_) => {},
+                Err(e) => panic!("Expected Ok(..), got Err({e:?})"),
+            }
+        }
+    }
+
+    #[test]
+    fn from_str_invalid_interval() {
+        let intervals = ["3|3", "5-10|7-11", "<6.5|>=6.4", "<6.6|6.9|6.8-7.10|>8", ">4|5", "4|3"];
+        for interval in intervals {
+            match VersionIntervals::from_str_intervals(interval) {
+                Ok(interval) => panic!("Expected Err(..), got Ok({interval:?})"),
+                Err(_) => {},
+            }
         }
     }
 }

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -1,6 +1,6 @@
 use std::str::FromStr;
 
-use crate::installer::types::{VersionBounds, VersionError};
+use crate::installer::types::{Version, VersionBounds, VersionError};
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct VersionIntervals {
@@ -25,6 +25,22 @@ impl VersionIntervals {
         }
 
         Ok(Self { version_bounds })
+    }
+
+    pub fn covers(&self, version: &Version) -> bool {
+        // If version bounds are empty, version satisfies the bounds
+        if self.version_bounds.is_empty() {
+            return true;
+        }
+
+        // Check if any of the version bounds covers the version
+        for bound in &self.version_bounds {
+            if bound.covers(&version) {
+                return true;
+            }
+        }
+
+        false
     }
 
     pub fn get_version_bounds(&self) -> &Vec<VersionBounds> {

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -16,12 +16,14 @@ impl<'de> Deserialize<'de> for VersionIntervals {
     {
         let string: String = de::Deserialize::deserialize(deserializer)?;
 
-        Ok(Self::from_str_intervals(&string).map_err(de::Error::custom)?)
+        Ok(Self::from_str(&string).map_err(de::Error::custom)?)
     }
 }
 
-impl VersionIntervals {
-    pub fn from_str_intervals(intervals: &str) -> Result<Self, VersionError> {
+impl FromStr for VersionIntervals {
+    type Err = VersionError;
+
+    fn from_str(intervals: &str) -> Result<Self, Self::Err> {
         // Check for empty input
         if intervals.is_empty() {
             return Ok(Self {
@@ -43,7 +45,9 @@ impl VersionIntervals {
 
         Ok(Self { version_bounds })
     }
+}
 
+impl VersionIntervals {
     /// Checks if the intervals are valid, the intervals are valid if they don't overlap and are in order.
     /// True is returned if the intervals are valid, otherwise false.
     fn validate_intervals(version_bounds: &Vec<VersionBounds>) -> bool {
@@ -109,7 +113,7 @@ mod tests {
 
     #[test]
     fn from_str_ranges() {
-        let version_intervals = VersionIntervals::from_str_intervals("<6.6|6.7|6.8-7.10|>8");
+        let version_intervals = VersionIntervals::from_str("<6.6|6.7|6.8-7.10|>8");
 
         match version_intervals {
             Ok(intervals) => {
@@ -138,7 +142,7 @@ mod tests {
 
     #[test]
     fn from_str_ranges_empty() {
-        let version_intervals = VersionIntervals::from_str_intervals("");
+        let version_intervals = VersionIntervals::from_str("");
 
         match version_intervals {
             Ok(intervals) => assert!(intervals.get_version_bounds().len() == 0),
@@ -150,7 +154,7 @@ mod tests {
     fn from_str_valid_interval() {
         let intervals = ["3", "<6.6|6.7|6.8-7.10|>8", "<=4|4.5|5-6|>=10.1", "4-10", "32|>34", "<6.5|>6.5"];
         for interval in intervals {
-            match VersionIntervals::from_str_intervals(interval) {
+            match VersionIntervals::from_str(interval) {
                 Ok(_) => {},
                 Err(e) => panic!("Expected Ok(..), got Err({e:?})"),
             }
@@ -161,7 +165,7 @@ mod tests {
     fn from_str_invalid_interval() {
         let intervals = ["3|3", "5-10|7-11", "<6.5|>=6.4", "<6.6|6.9|6.8-7.10|>8", ">4|5", "4|3"];
         for interval in intervals {
-            match VersionIntervals::from_str_intervals(interval) {
+            match VersionIntervals::from_str(interval) {
                 Ok(interval) => panic!("Expected Err(..), got Ok({interval:?})"),
                 Err(_) => {},
             }

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -39,7 +39,7 @@ impl FromStr for VersionIntervals {
         }
 
         // Check for invalid intervals
-        if !Self::validate_intervals(&version_bounds) {
+        if !Self::bounds_valid(&version_bounds) {
             return Err(VersionError::InvalidInterval);
         }
 
@@ -50,7 +50,7 @@ impl FromStr for VersionIntervals {
 impl VersionIntervals {
     /// Checks if the intervals are valid, the intervals are valid if they don't overlap and are in order.
     /// True is returned if the intervals are valid, otherwise false.
-    fn validate_intervals(version_bounds: &Vec<VersionBounds>) -> bool {
+    fn bounds_valid(version_bounds: &Vec<VersionBounds>) -> bool {
         let mut previous: Option<&VersionBounds> = None;
         for bound in version_bounds {
             let valued_previous = match previous {
@@ -61,6 +61,9 @@ impl VersionIntervals {
                 },
             };
 
+            // In this match we return false early if the bound is a lower (or lower equal) bound.
+            // We can do this, because the first iteration never gets here. Meaning that if we have
+            // a lower bound the intervals are either not in order or are overlapping.
             let low_version = match bound {
                 VersionBounds::Range(low, _) => low,
                 VersionBounds::Lower(_) => return false,
@@ -70,6 +73,8 @@ impl VersionIntervals {
                 VersionBounds::Equal(version) => version,
             };
 
+            // Here we don't have to compare each bound type with each other bound type, again because the intervals
+            // need to be in order.
             match valued_previous {
                 VersionBounds::Range(_, high) if *low_version <= *high => return false,
                 VersionBounds::Lower(version) if low_version < version => return false,
@@ -88,7 +93,7 @@ impl VersionIntervals {
 
     pub fn covers(&self, version: &Version) -> bool {
         // If version bounds are empty, version satisfies the bounds
-        if self.version_bounds.is_empty() {
+        if self.is_empty() {
             return true;
         }
 
@@ -100,6 +105,10 @@ impl VersionIntervals {
         }
 
         false
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.version_bounds.is_empty()
     }
 
     pub fn get_version_bounds(&self) -> &Vec<VersionBounds> {

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -43,11 +43,11 @@ pub enum RepositoryError {
     #[error("The given package name is empty")]
     EmptyPackageName,
 
-    #[error("Dependency '{0}' cannot be satisfied by the current package repository.")]
-    SupportError(String),
+    #[error("Dependency '{0}' cannot be satisfied by the current package repository for the current target.")]
+    DependencySupportError(String),
 
-    #[error("Invalid version intervals, intervals must not be empty for the current targets supported versions.")]
-    EmptyIntervals,
+    #[error("No supported version for the current target could be found for package '{0}'.")]
+    SupportError(String),
 }
 
 pub(super) type Result<T> = std::result::Result<T, RepositoryError>;

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -45,6 +45,11 @@ pub enum RepositoryError {
 
     #[error("Dependency '{0}' cannot be satisfied by the current package repository.")]
     SupportError(String),
+
+    #[error(
+        "Invalid version intervals for the current targets supported versions. Intervals must not be empty and not contain a higher (equals) bound."
+    )]
+    InvalidSupportIntervals,
 }
 
 pub(super) type Result<T> = std::result::Result<T, RepositoryError>;

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -46,10 +46,8 @@ pub enum RepositoryError {
     #[error("Dependency '{0}' cannot be satisfied by the current package repository.")]
     SupportError(String),
 
-    #[error(
-        "Invalid version intervals for the current targets supported versions. Intervals must not be empty and not contain a higher (equals) bound."
-    )]
-    InvalidSupportIntervals,
+    #[error("Invalid version intervals, intervals must not be empty for the current targets supported versions.")]
+    EmptyIntervals,
 }
 
 pub(super) type Result<T> = std::result::Result<T, RepositoryError>;

--- a/src/repositories/types/package.rs
+++ b/src/repositories/types/package.rs
@@ -30,32 +30,12 @@ impl PackageMeta {
         };
 
         let supported = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
-        Ok(self.latest_version_impl(|v| !supported.covers(v))?.ok_or(RepositoryError::EmptyIntervals)?)
-    }
 
-    pub fn get_latest_dependency_version(&self, dependency: &Dependency, target: &Target) -> Result<&Version> {
-        let target = match TargetBounds::get_best_target(&target, self.supported_versions.keys().collect()) {
-            Some(target) => target,
-            None => return Err(RepositoryError::TargetError),
-        };
-
-        let supported = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
-        Ok(self
-            .latest_version_impl(|v| !dependency.satisfied(&self.name, v) || !supported.covers(v))?
-            .ok_or(RepositoryError::SupportError(dependency.to_string()))?)
-    }
-
-    /// A generic method to get the latest version of the current package.
-    /// If any of the checks are true for the current version we continue for that version.
-    fn latest_version_impl<F>(&self, checks: F) -> Result<Option<&Version>>
-    where
-        F: Fn(&Version) -> bool,
-    {
         // The versions vec isn't necessary in order, so we need to keep track of the current highest version
         let mut current_highest: Option<&Version> = None;
         for version in &self.versions {
-            // Continue if any of the checks are true
-            if checks(version) {
+            // Continue if the version is not supported by the current target
+            if !supported.covers(version) {
                 continue;
             }
 
@@ -66,6 +46,32 @@ impl PackageMeta {
             };
         }
 
-        Ok(current_highest)
+        Ok(current_highest.ok_or(RepositoryError::SupportError(self.name.to_string()))?)
+    }
+
+    pub fn get_latest_dependency_version(&self, dependency: &Dependency, target: &Target) -> Result<&Version> {
+        let target = match TargetBounds::get_best_target(&target, self.supported_versions.keys().collect()) {
+            Some(target) => target,
+            None => return Err(RepositoryError::TargetError),
+        };
+
+        let supported = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
+
+        // The versions vec isn't necessary in order, so we need to keep track of the current highest version
+        let mut current_highest: Option<&Version> = None;
+        for version in &self.versions {
+            // Continue if the dependency is not satisfied or if the version is not supported by the current target
+            if !dependency.satisfied(&self.name, version) || !supported.covers(version) {
+                continue;
+            }
+
+            current_highest = match current_highest {
+                Some(highest) if highest < version => Some(version),
+                None => Some(version),
+                _ => continue,
+            };
+        }
+
+        Ok(current_highest.ok_or(RepositoryError::DependencySupportError(dependency.to_string()))?)
     }
 }

--- a/src/repositories/types/package.rs
+++ b/src/repositories/types/package.rs
@@ -19,7 +19,7 @@ pub struct PackageMeta {
     pub description: String,
     pub homepage: Option<String>,
     pub versions: Vec<Version>,
-    pub supported_versions: HashMap<TargetBounds, VersionIntervals>, // TODO: Maybe make sure these intervals don't use higher than bounds
+    pub supported_versions: HashMap<TargetBounds, VersionIntervals>,
 }
 
 impl PackageMeta {
@@ -29,40 +29,43 @@ impl PackageMeta {
             None => return Err(RepositoryError::TargetError),
         };
 
-        let current_versions = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
-        if let Some(last_bound) = current_versions.get_version_bounds().last() {
-            return Ok(last_bound.get_upperbound().ok_or(RepositoryError::InvalidSupportIntervals)?);
-        }
-
-        Err(RepositoryError::InvalidSupportIntervals)
+        let supported = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
+        Ok(self.latest_version_impl(|v| !supported.covers(v))?.ok_or(RepositoryError::EmptyIntervals)?)
     }
 
-    pub fn get_latest_dependency_version(&self, dependency: &Dependency, target: &Target) -> Result<Version> {
+    pub fn get_latest_dependency_version(&self, dependency: &Dependency, target: &Target) -> Result<&Version> {
         let target = match TargetBounds::get_best_target(&target, self.supported_versions.keys().collect()) {
             Some(target) => target,
             None => return Err(RepositoryError::TargetError),
         };
 
-        // The supported vec isn't necessary in order, so we need to keep track of the current highest version
-        let mut current_highest: Option<Version> = None;
-        for version in &self.versions {
-            // Continue if the dependency is not satisfied
-            if !dependency.satisfied(&self.name, version) {
-                continue;
-            }
+        let supported = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
+        Ok(self
+            .latest_version_impl(|v| !dependency.satisfied(&self.name, v) || !supported.covers(v))?
+            .ok_or(RepositoryError::SupportError(dependency.to_string()))?)
+    }
 
-            // Continue if the version is not supported for the current target
-            if !self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?.covers(version) {
+    /// A generic method to get the latest version of the current package.
+    /// If any of the checks are true for the current version we continue for that version.
+    fn latest_version_impl<F>(&self, checks: F) -> Result<Option<&Version>>
+    where
+        F: Fn(&Version) -> bool,
+    {
+        // The versions vec isn't necessary in order, so we need to keep track of the current highest version
+        let mut current_highest: Option<&Version> = None;
+        for version in &self.versions {
+            // Continue if any of the checks are true
+            if checks(version) {
                 continue;
             }
 
             current_highest = match current_highest {
-                Some(highest) if highest < *version => Some(version.clone()),
-                None => Some(version.clone()),
+                Some(highest) if highest < version => Some(version),
+                None => Some(version),
                 _ => continue,
             };
         }
 
-        Ok(current_highest.ok_or(RepositoryError::SupportError(dependency.to_string()))?)
+        Ok(current_highest)
     }
 }

--- a/src/repositories/types/package.rs
+++ b/src/repositories/types/package.rs
@@ -12,6 +12,7 @@ use crate::{
 };
 
 /// Represents the package metadata, containing package information.
+/// TODO: Validate name with PackageId rules
 #[derive(Deserialize, Debug)]
 pub struct PackageMeta {
     pub name: String,
@@ -36,7 +37,7 @@ impl PackageMeta {
         // The supported vec isn't necessary in order, so we need to keep track of the current highest version
         let mut current_highest: Option<Version> = None;
         for version in &self.versions {
-            if !dependency.satisfied(&self.name, Some(&version)) {
+            if !dependency.satisfied(&self.name, &version) {
                 continue;
             }
 

--- a/src/repositories/types/package.rs
+++ b/src/repositories/types/package.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use serde::Deserialize;
 
 use crate::{
-    installer::types::{Dependency, Version},
+    installer::types::{Dependency, Version, VersionIntervals},
     platforms::Target,
     repositories::{
         error::{RepositoryError, Result},
@@ -19,25 +19,40 @@ pub struct PackageMeta {
     pub description: String,
     pub homepage: Option<String>,
     pub versions: Vec<Version>,
-    pub latest_versions: HashMap<TargetBounds, Version>,
+    pub supported_versions: HashMap<TargetBounds, VersionIntervals>, // TODO: Maybe make sure these intervals don't use higher than bounds
 }
 
 impl PackageMeta {
     pub fn get_latest_version(&self, target: &Target) -> Result<&Version> {
-        let target = match TargetBounds::get_best_target(&target, self.latest_versions.keys().collect()) {
+        let target = match TargetBounds::get_best_target(&target, self.supported_versions.keys().collect()) {
             Some(target) => target,
             None => return Err(RepositoryError::TargetError),
         };
 
-        Ok(self.latest_versions.get(target).ok_or(RepositoryError::TargetError)?)
+        let current_versions = self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?;
+        if let Some(last_bound) = current_versions.get_version_bounds().last() {
+            return Ok(last_bound.get_upperbound().ok_or(RepositoryError::InvalidSupportIntervals)?);
+        }
+
+        Err(RepositoryError::InvalidSupportIntervals)
     }
 
-    // TODO: Bug, this needs to adjust for the platform (so it should compare with get_latest_version)
-    pub fn get_latest_dependency_version(&self, dependency: &Dependency) -> Result<Version> {
+    pub fn get_latest_dependency_version(&self, dependency: &Dependency, target: &Target) -> Result<Version> {
+        let target = match TargetBounds::get_best_target(&target, self.supported_versions.keys().collect()) {
+            Some(target) => target,
+            None => return Err(RepositoryError::TargetError),
+        };
+
         // The supported vec isn't necessary in order, so we need to keep track of the current highest version
         let mut current_highest: Option<Version> = None;
         for version in &self.versions {
-            if !dependency.satisfied(&self.name, &version) {
+            // Continue if the dependency is not satisfied
+            if !dependency.satisfied(&self.name, version) {
+                continue;
+            }
+
+            // Continue if the version is not supported for the current target
+            if !self.supported_versions.get(target).ok_or(RepositoryError::TargetError)?.covers(version) {
                 continue;
             }
 

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -158,7 +158,7 @@ impl TargetBounds {
     }
 
     fn calculate_priority(&self) -> u32 {
-        if self.addition.is_none() && self.version_intervals.get_version_bounds().is_empty() {
+        if self.addition.is_none() && self.version_intervals.is_empty() {
             match self.name {
                 TargetName::Unix => return 1,
                 TargetName::Os(_) => return 2,
@@ -166,14 +166,14 @@ impl TargetBounds {
             }
         }
 
-        if self.addition.is_none() && !self.version_intervals.get_version_bounds().is_empty() {
+        if self.addition.is_none() && !self.version_intervals.is_empty() {
             match self.name {
                 TargetName::Os(_) => return 4,
                 _ => return 5,
             }
         }
 
-        if self.addition.is_some() && !self.version_intervals.get_version_bounds().is_empty() {
+        if self.addition.is_some() && !self.version_intervals.is_empty() {
             match self.name {
                 TargetName::Os(_) => return 6,
                 _ => return 7,

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -154,20 +154,7 @@ impl TargetBounds {
             OsVersion::Unknown => return false,
         };
 
-        // If version bounds are empty, target satisfies the bounds
-        if self.version_intervals.get_version_bounds().is_empty() {
-            return true;
-        }
-
-        // Check if one of the version bounds covers the os version
-        // TODO: Move to version interval struct (also the above if and also for dependency struct)
-        for interval in self.version_intervals.get_version_bounds() {
-            if interval.covers(&version) {
-                return true;
-            }
-        }
-
-        false
+        self.version_intervals.covers(version)
     }
 
     fn calculate_priority(&self) -> u32 {

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::{
     cli::display::logging::warning,
-    installer::types::{VersionBounds, VersionError},
+    installer::types::{VersionError, VersionIntervals},
     platforms::{Os, OsVersion, Target, TargetArchitecture},
 };
 
@@ -78,7 +78,7 @@ impl TargetName {
 pub struct TargetBounds {
     pub name: TargetName,
     pub addition: Option<String>,
-    pub version_bounds: Vec<VersionBounds>,
+    pub version_intervals: VersionIntervals,
 }
 
 impl<'de> Deserialize<'de> for TargetBounds {
@@ -101,7 +101,7 @@ impl FromStr for TargetBounds {
             None => (string, ""),
         };
 
-        let version_bounds = VersionBounds::from_str_ranges(version_bounds)?;
+        let version_intervals = VersionIntervals::from_str_intervals(version_bounds)?;
 
         // Split addition from name
         let (name, addition) = match name.split_once(':') {
@@ -124,7 +124,7 @@ impl FromStr for TargetBounds {
         Ok(Self {
             name: name.into(),
             addition: addition.map(|x| x.into()),
-            version_bounds,
+            version_intervals,
         })
     }
 }
@@ -155,13 +155,14 @@ impl TargetBounds {
         };
 
         // If version bounds are empty, target satisfies the bounds
-        if self.version_bounds.is_empty() {
+        if self.version_intervals.get_version_bounds().is_empty() {
             return true;
         }
 
         // Check if one of the version bounds covers the os version
-        for range in &self.version_bounds {
-            if range.covers(&version) {
+        // TODO: Move to version interval struct (also the above if and also for dependency struct)
+        for interval in self.version_intervals.get_version_bounds() {
+            if interval.covers(&version) {
                 return true;
             }
         }
@@ -170,7 +171,7 @@ impl TargetBounds {
     }
 
     fn calculate_priority(&self) -> u32 {
-        if self.addition.is_none() && self.version_bounds.is_empty() {
+        if self.addition.is_none() && self.version_intervals.get_version_bounds().is_empty() {
             match self.name {
                 TargetName::Unix => return 1,
                 TargetName::Os(_) => return 2,
@@ -178,14 +179,14 @@ impl TargetBounds {
             }
         }
 
-        if self.addition.is_none() && !self.version_bounds.is_empty() {
+        if self.addition.is_none() && !self.version_intervals.get_version_bounds().is_empty() {
             match self.name {
                 TargetName::Os(_) => return 4,
                 _ => return 5,
             }
         }
 
-        if self.addition.is_some() && !self.version_bounds.is_empty() {
+        if self.addition.is_some() && !self.version_intervals.get_version_bounds().is_empty() {
             match self.name {
                 TargetName::Os(_) => return 6,
                 _ => return 7,

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -101,7 +101,7 @@ impl FromStr for TargetBounds {
             None => (string, ""),
         };
 
-        let version_intervals = VersionIntervals::from_str_intervals(version_bounds)?;
+        let version_intervals = VersionIntervals::from_str(version_bounds)?;
 
         // Split addition from name
         let (name, addition) = match name.split_once(':') {

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -360,8 +360,7 @@ pub mod tests {
         let current_target_bounds =
             TargetBounds::from_str(&TargetArchitecture::current().to_string()).expect("Expected valid target bounds");
 
-        let version_intervals =
-            VersionIntervals::from_str_intervals(&format!("{}", package_id.version)).expect("Expected valid version intervals.");
+        let version_intervals = VersionIntervals::from_str(&format!("{}", package_id.version)).expect("Expected valid version intervals.");
 
         PackageMeta {
             name: package_id.name.to_string(),

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -244,7 +244,7 @@ impl PackageRegister {
     pub fn get_satisfying_package(&self, dependency: &Dependency) -> Option<&InstalledPackageVersion> {
         // Loop over all packages with the dependency name and check if they satisfy the dependency
         for package in self.packages.get(dependency.get_name())?.get_versions() {
-            if dependency.satisfied(&package.package_id.name, Some(&package.package_id.version)) {
+            if dependency.satisfied(&package.package_id.name, &package.package_id.version) {
                 return Some(package);
             }
         }

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -262,6 +262,7 @@ impl PackageRegister {
 pub mod tests {
     use std::str::FromStr;
 
+    use crate::installer::types::VersionIntervals;
     use crate::installer::types::dependency_tests::create_dependency;
     use crate::platforms::TargetArchitecture;
     use crate::repositories::types::{Checksum, Source, Sources, TargetBounds};
@@ -359,12 +360,15 @@ pub mod tests {
         let current_target_bounds =
             TargetBounds::from_str(&TargetArchitecture::current().to_string()).expect("Expected valid target bounds");
 
+        let version_intervals =
+            VersionIntervals::from_str_intervals(&format!("{}", package_id.version)).expect("Expected valid version intervals.");
+
         PackageMeta {
             name: package_id.name.to_string(),
             description: "-".to_string(),
             homepage: None,
             versions: vec![package_id.version.clone()],
-            latest_versions: HashMap::from([(current_target_bounds, package_id.version.clone())]),
+            supported_versions: HashMap::from([(current_target_bounds, version_intervals)]),
         }
     }
 

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -238,7 +238,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         // Use the latest version if the dependency is not yet satisfied
         let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
         let version = package_metadata.get_latest_dependency_version(&dependency, &Target::current())?;
-        let dependency_id = dependency.to_package_id(version);
+        let dependency_id = dependency.to_package_id(version.clone());
         let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
         let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;
         Self::new_from_meta_impl(&dependency_id, install_meta, manager, register, label, include_build)

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -8,6 +8,7 @@ use crate::{
         DependencyTypes, InstallMeta,
         types::{Dependency, PackageId},
     },
+    platforms::Target,
     repositories::{error::RepositoryError, manager::RepositoryManager},
     storage::package_register::PackageRegister,
 };
@@ -236,7 +237,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
 
         // Use the latest version if the dependency is not yet satisfied
         let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
-        let version = package_metadata.get_latest_dependency_version(&dependency)?;
+        let version = package_metadata.get_latest_dependency_version(&dependency, &Target::current())?;
         let dependency_id = dependency.to_package_id(version);
         let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
         let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;


### PR DESCRIPTION
This refactors the version bounds. VersionBounds are now stored in a VersionInterval struct. 
It also fixes the bug where an error is thrown if the latest satisfying version for a dependency is not supported by the current target, even though a lower supported version would also satisfy the dependency.
To fix this the package metadata now doesn't contain the latest version, but the supported versions for each target.