### PR TITLE
General refactor and small bugfixes 

### DIFF
--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -16,17 +16,13 @@ use std::process::exit;
 
 use clap::{Parser, Subcommand, builder::Styles};
 
-use crate::{
-    cli::{
-        commands::{
-            check::CheckArgs, fix::FixArgs, info::InfoArgs, install::InstallArgs, link::LinkArgs, list::ListArgs, package::PackageArgs,
-            repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs,
-            update::UpdateArgs,
-        },
-        display::logging::error,
+use crate::cli::{
+    commands::{
+        check::CheckArgs, fix::FixArgs, info::InfoArgs, install::InstallArgs, link::LinkArgs, list::ListArgs, package::PackageArgs,
+        repositories::RepositoryArgs, search::SearchArgs, switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs,
+        update::UpdateArgs,
     },
-    config::Config,
-    repositories::manager::RepositoryManager,
+    display::logging::error,
 };
 
 #[derive(Parser, Debug)]
@@ -99,7 +95,7 @@ impl Cli {
     }
 
     /// Reads and handles the command.
-    pub fn handle_command(&self, manager: &RepositoryManager, config: &Config) {
+    pub fn handle_command(&self) {
         // Handle commands with user specified arguments
         let args: &dyn HandleCommand = match &self.command {
             Commands::Install(args) => args,
@@ -117,10 +113,10 @@ impl Cli {
             Commands::Update(args) => args,
         };
 
-        args.handle(config, manager);
+        args.handle();
     }
 }
 
 trait HandleCommand {
-    fn handle(&self, config: &Config, manager: &RepositoryManager);
+    fn handle(&self);
 }

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -6,7 +6,6 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
     installer::types::PackageId,
-    repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
     verifier::Verifier,
@@ -19,11 +18,11 @@ pub struct CheckArgs {
 }
 
 impl HandleCommand for CheckArgs {
-    // TODO: We can never verify Packit files, because they are loaded before the command execution
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
-        let mut verifier = Verifier::new(config);
+        let mut verifier = Verifier::new(&config);
 
         // Check if the package exists before checking it with the verifier
         if let Some(package_id) = &self.package {

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -16,12 +16,14 @@ use crate::{
 pub struct FixArgs;
 
 impl HandleCommand for FixArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
-        let mut verifier = Verifier::new(config);
+        let mut verifier = Verifier::new(&config);
 
-        let mut repairer = Repairer::new(config, manager);
+        let mut repairer = Repairer::new(&config, &manager);
 
         // Retrieve and fix the issues one by one
         while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit(1) {

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -18,7 +18,7 @@ pub struct FixArgs;
 impl HandleCommand for FixArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
         let mut verifier = Verifier::new(&config);

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -34,6 +34,9 @@ impl HandleCommand for FixArgs {
 
             // Repair the found issues
             repairer.fix(issue, &mut register).unwrap_or_exit(1);
+
+            // Save register after the fix
+            register.save_to(&register_dir).unwrap_or_exit(1);
         }
 
         // Return correct message based on found issues

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -6,7 +6,6 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
     installer::types::{OptionalPackageId, PackageId},
-    repositories::manager::RepositoryManager,
     storage::{installed_package::InstalledPackage, package_register::PackageRegister},
     utils::{tree::Node, unwrap_or_exit::UnwrapOrExit},
 };
@@ -26,8 +25,9 @@ pub struct InfoArgs {
 }
 
 impl HandleCommand for InfoArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Get package information

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -33,8 +33,10 @@ pub struct InstallArgs {
 }
 
 impl HandleCommand for InstallArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         let installer_options = InstallerOptions::default()

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -35,7 +35,7 @@ pub struct InstallArgs {
 impl HandleCommand for InstallArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -5,7 +5,7 @@ use crate::{
     config::{Config, Repository},
     installer::{Symlinker, types::PackageName},
     platforms::Target,
-    repositories::{manager::RepositoryManager, provider, types::PackageVersionMeta},
+    repositories::{provider, types::PackageVersionMeta},
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -21,8 +21,9 @@ pub struct LinkArgs {
 }
 
 impl HandleCommand for LinkArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_path = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_path = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package
@@ -87,7 +88,7 @@ impl HandleCommand for LinkArgs {
         let install_path = package_version.install_path.clone();
 
         // Create symlinks
-        Symlinker::new(config).create_symlinks(&install_path).unwrap_or_exit_msg("Unable to link package", 1);
+        Symlinker::new(&config).create_symlinks(&install_path).unwrap_or_exit_msg("Unable to link package", 1);
 
         let package = register
             .get_package_mut(&self.package_name)

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,8 +1,7 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, repositories::manager::RepositoryManager, storage::package_register::PackageRegister,
-    utils::unwrap_or_exit::UnwrapOrExit,
+    cli::commands::HandleCommand, config::Config, storage::package_register::PackageRegister, utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 // TODO: Expand command to list updateable packages
@@ -10,8 +9,9 @@ use crate::{
 pub struct ListArgs {}
 
 impl HandleCommand for ListArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         for package in register.iterate_all() {

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -6,7 +6,7 @@ use crate::{
 
 // TODO: Expand command to list updateable packages
 #[derive(Args, Debug)]
-pub struct ListArgs {}
+pub struct ListArgs;
 
 impl HandleCommand for ListArgs {
     fn handle(&self) {

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -7,7 +7,6 @@ use crate::{
     config::Config,
     installer::types::PackageId,
     packager::{self},
-    repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -22,8 +21,9 @@ pub struct PackageArgs {
 }
 
 impl HandleCommand for PackageArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         let package_version = match register.get_package_version(&self.package_id) {
@@ -34,6 +34,6 @@ impl HandleCommand for PackageArgs {
             },
         };
 
-        packager::package(config, &self.package_id, &self.destination, package_version.revisions.len()).unwrap_or_exit(1);
+        packager::package(&config, &self.package_id, &self.destination, package_version.revisions.len()).unwrap_or_exit(1);
     }
 }

--- a/src/cli/commands/repositories.rs
+++ b/src/cli/commands/repositories.rs
@@ -2,6 +2,7 @@ use crate::{
     cli::{commands::HandleCommand, display::logging::warning},
     config::Config,
     repositories::manager::RepositoryManager,
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 use clap::Args;
 use colored::Colorize;
@@ -11,7 +12,9 @@ pub struct RepositoryArgs {}
 
 impl HandleCommand for RepositoryArgs {
     /// Handles the repositories command, listing all configured repositories.
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
         for (index, (repository_id, repository)) in config.repositories.iter().enumerate() {
             if index != 0 {
                 println!();

--- a/src/cli/commands/repositories.rs
+++ b/src/cli/commands/repositories.rs
@@ -8,7 +8,7 @@ use clap::Args;
 use colored::Colorize;
 
 #[derive(Args, Debug)]
-pub struct RepositoryArgs {}
+pub struct RepositoryArgs;
 
 impl HandleCommand for RepositoryArgs {
     /// Handles the repositories command, listing all configured repositories.

--- a/src/cli/commands/repositories.rs
+++ b/src/cli/commands/repositories.rs
@@ -14,7 +14,7 @@ impl HandleCommand for RepositoryArgs {
     /// Handles the repositories command, listing all configured repositories.
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         for (index, (repository_id, repository)) in config.repositories.iter().enumerate() {
             if index != 0 {
                 println!();

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -18,7 +18,9 @@ pub struct SearchArgs {
 
 impl HandleCommand for SearchArgs {
     /// Handles the search command, searching a certain package.
-    fn handle(&self, _: &Config, manager: &RepositoryManager) {
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
         let (repository_id, package) = match manager.read_package(&self.optional_id.name) {
             Ok(package) => package,
             Err(RepositoryError::PackageNotFoundError { .. }) => {

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -20,7 +20,7 @@ impl HandleCommand for SearchArgs {
     /// Handles the search command, searching a certain package.
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         let (repository_id, package) = match manager.read_package(&self.optional_id.name) {
             Ok(package) => package,
             Err(RepositoryError::PackageNotFoundError { .. }) => {

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -7,7 +7,6 @@ use crate::{
         Symlinker,
         types::{PackageName, Version},
     },
-    repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -26,8 +25,9 @@ pub struct SwitchArgs {
 }
 
 impl HandleCommand for SwitchArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_path = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_path = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package
@@ -58,7 +58,7 @@ impl HandleCommand for SwitchArgs {
         let should_symlink = !self.skip_symlinking && package.symlinked;
 
         // Set package version to active
-        Symlinker::new(config)
+        Symlinker::new(&config)
             .set_active(&mut register, &package_id, should_symlink)
             .unwrap_or_exit_msg("Cannot switch active package", 1);
 

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -19,7 +19,7 @@ pub struct UninstallArgs {
 impl HandleCommand for UninstallArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -17,11 +17,13 @@ pub struct UninstallArgs {
 }
 
 impl HandleCommand for UninstallArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        let mut installer = Installer::new(config, &mut register, manager, InstallerOptions::default());
+        let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());
 
         // Uninstall all specified packages
         for optional_id in &self.packages {

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -4,7 +4,6 @@ use crate::{
     cli::commands::HandleCommand,
     config::Config,
     installer::{Symlinker, types::PackageName},
-    repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -16,8 +15,9 @@ pub struct UnlinkArgs {
 }
 
 impl HandleCommand for UnlinkArgs {
-    fn handle(&self, config: &Config, _: &RepositoryManager) {
-        let register_path = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_path = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package
@@ -32,7 +32,7 @@ impl HandleCommand for UnlinkArgs {
         }
 
         // Unlink package
-        Symlinker::new(config)
+        Symlinker::new(&config)
             .unlink_package(&mut register, &self.package_name)
             .unwrap_or_exit_msg("Unable to unlink package", 1);
 

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -27,7 +27,7 @@ pub struct UpdateArgs {
 impl HandleCommand for UpdateArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -25,8 +25,10 @@ pub struct UpdateArgs {
 }
 
 impl HandleCommand for UpdateArgs {
-    fn handle(&self, config: &Config, manager: &RepositoryManager) {
-        let register_dir = PackageRegister::get_default_path(config);
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager: RepositoryManager<'_> = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         let (_, package_meta) = manager.read_package(&self.optional_id.name).unwrap_or_exit(1);
@@ -43,7 +45,7 @@ impl HandleCommand for UpdateArgs {
         }
 
         let options = InstallerOptions::default().skip_active(true).skip_symlinking(true);
-        let mut installer = Installer::new(config, &mut register, manager, options);
+        let mut installer = Installer::new(&config, &mut register, &manager, options);
 
         installer.update(&self.optional_id, new_version).unwrap_or_exit(1);
 

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -24,17 +24,14 @@ pub enum BuilderError {
     #[error("Build files download unsuccessful")]
     RequestUnsuccessful(reqwest::StatusCode),
 
-    #[error("Cannot request files for building")]
-    RequestError(#[from] reqwest::Error),
-
-    #[error("Error while interacting with filesystem")]
-    IOError(#[from] std::io::Error),
-
     #[error("Dependency '{package_name}' of type '{dependency_type}' is not installed.")]
     MissingDependencyError {
         dependency_type: String,
         package_name: String,
     },
+
+    #[error("Checksum does not match")]
+    ChecksumError,
 
     #[error("Cannot unpack response")]
     UnpackError(#[from] UnpackError),
@@ -45,8 +42,11 @@ pub enum BuilderError {
     #[error("Cannot find a repository for building")]
     RepositoryError(#[from] RepositoryError),
 
-    #[error("Checksum does not match")]
-    ChecksumError,
+    #[error("Cannot request files for building")]
+    RequestError(#[from] reqwest::Error),
+
+    #[error("Error while interacting with filesystem")]
+    IOError(#[from] std::io::Error),
 }
 
 pub type Result<T> = core::result::Result<T, BuilderError>;

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -84,7 +84,7 @@ impl<'a> Builder<'a> {
         // Check if the normal dependencies are installed and get installed package for each dependency.
         let dependencies = package_version.dependencies.iter().chain(target.dependencies.iter());
         for dependency in dependencies {
-            if let Some(package) = self.register.get_satisfying_package(dependency) {
+            if let Some(package) = self.register.get_latest_satisfying_package(dependency) {
                 installed_dependencies.push(package);
 
                 continue;
@@ -100,7 +100,7 @@ impl<'a> Builder<'a> {
         // Check if the build dependencies are installed and get installed package for each dependency.
         let build_dependencies = package_version.build_dependencies.iter().chain(target.build_dependencies.iter());
         for build_dependency in build_dependencies {
-            if let Some(package) = self.register.get_satisfying_package(build_dependency) {
+            if let Some(package) = self.register.get_latest_satisfying_package(build_dependency) {
                 installed_build_dependencies.push(package);
 
                 continue;

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -63,6 +63,11 @@ pub enum InstallerError {
         reason: String,
     },
 
+    #[error("An unreachable state has been reached: {msg}.")]
+    UnreachableError {
+        msg: String,
+    },
+
     // Wrapped custom errors
     #[error("Cannot find a repository for installation")]
     RepositoryError(#[from] RepositoryError),

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -61,6 +61,11 @@ pub enum InstallerError {
         package_name: String,
     },
 
+    #[error("Canceled package installation: {reason}.")]
+    InstallationCanceled {
+        reason: String,
+    },
+
     // Wrapped custom errors
     #[error("Cannot find a repository for installation")]
     RepositoryError(#[from] RepositoryError),

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -23,9 +23,6 @@ pub enum InstallerError {
     #[error("Prebuild checksum does not match")]
     ChecksumError,
 
-    #[error("Error while interacting with filesystem")]
-    IOError(#[from] std::io::Error),
-
     #[error("Could not uninstall package '{package_name}'. {e}")]
     UninstallError {
         package_name: String,
@@ -93,6 +90,9 @@ pub enum InstallerError {
 
     #[error("Cannot do tree operation")]
     TreeError(#[from] TreeError),
+
+    #[error("Error while interacting with filesystem")]
+    IOError(#[from] std::io::Error),
 }
 
 pub(super) type Result<T> = std::result::Result<T, InstallerError>;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -181,13 +181,14 @@ impl<'a> Installer<'a> {
         }
 
         // Return early if the user doesn't want to build from source as alternative install method
-        // TODO: Look at this, now it's possible that one of the package dependencies just isn't installed
         let question = format!(
             "Prebuild package for {} cannot be found, would you like to build from source instead?",
             node.get_id()
         );
-        if ask_user(&question, QuestionResponse::Yes)?.is_no() {
-            return Ok(());
+        if ask_user(&question, QuestionResponse::Yes)?.is_no_or_invalid() {
+            return Err(InstallerError::InstallationCanceled {
+                reason: format!("package '{}' cannot be installed without building from source", node.get_id()),
+            });
         }
 
         node.expand_node_with_build(self.repository_manager, self.register)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -497,18 +497,18 @@ impl<'a> Installer<'a> {
         // Path to the determined directory
         let directory = self.config.prefix_directory.join("packages").join(&package_name);
 
-        // Check if package was symlinked
-        if let Some(package) = self.register.get_package(package_name) {
-            if package.symlinked {
-                Symlinker::new(self.config).remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
-            }
-        }
-
         // Remove active path symlink
         let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
         match active_path.exists() {
             true => symlink::remove_symlink(&active_path)?,
             false => warning!("Active symlink did not exist, was the package even installed succesfully?"),
+        }
+
+        // Check if package was symlinked
+        if let Some(package) = self.register.get_package(package_name) {
+            if package.symlinked {
+                Symlinker::new(self.config).remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+            }
         }
 
         // Run uninstall scripts for all versions

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -28,7 +28,6 @@ use std::{
     collections::HashSet,
     fs,
     path::{Path, PathBuf},
-    process::exit,
 };
 
 /// The installer of Packit, managing the installation of packages on the system.
@@ -433,8 +432,9 @@ impl<'a> Installer<'a> {
         let installed_package = match self.register.get_package(&package_id.name) {
             Some(package) => package,
             None => {
-                warning!("Package cannot be found eventhough it was found before, should be unreachable.");
-                return Ok(());
+                return Err(InstallerError::UnreachableError {
+                    msg: "Package cannot be found eventhough it was found before".to_string(),
+                });
             },
         };
 
@@ -442,8 +442,9 @@ impl<'a> Installer<'a> {
         let repository = match installed_package.get_package_version(&package_id.version) {
             Some(package_version) => Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider),
             None => {
-                warning!("Package version cannot be found eventhough it was found before, should be unreachable.");
-                return Ok(());
+                return Err(InstallerError::UnreachableError {
+                    msg: "Package version cannot be found eventhough it was found before".to_string(),
+                });
             },
         };
 
@@ -640,8 +641,9 @@ impl<'a> Installer<'a> {
             Some(package_version) => package_version,
             None => {
                 // Theoretically unreachable
-                error!(msg: "New package version '{new_version}' was not installed correctly.");
-                exit(1);
+                return Err(InstallerError::UnreachableError {
+                    msg: format!("New package version '{new_version}' cannot be retrieved from the register"),
+                });
             },
         };
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -275,6 +275,7 @@ impl<'a> Installer<'a> {
             &install_directory,
             false,
             false,
+            use_prebuild,
         )?;
         self.register.save_to(&PackageRegister::get_default_path(self.config))?;
 

--- a/src/installer/types/optional_id.rs
+++ b/src/installer/types/optional_id.rs
@@ -95,20 +95,20 @@ mod tests {
 
     #[test]
     fn from_str_empty_optional() {
-        assert_eq!(
+        assert!(matches!(
             OptionalPackageId::from_str(""),
             Err(PackageIdError::PackageNameError(PackageNameError::InvalidPackageName))
-        );
+        ))
     }
 
     #[test]
     fn from_str_invalid_chars() {
         let invalid_chars = "!#$%^&*()~:;{}[]<>,.?/|\\\"\'`+=";
         for char in invalid_chars.chars() {
-            assert_eq!(
+            assert!(matches!(
                 OptionalPackageId::from_str(format!("{char}@3.4.1").as_str()),
                 Err(PackageIdError::PackageNameError(PackageNameError::InvalidPackageName))
-            );
+            ))
         }
     }
 }

--- a/src/installer/types/package_id.rs
+++ b/src/installer/types/package_id.rs
@@ -6,7 +6,7 @@ use thiserror::Error;
 use crate::installer::types::{PackageName, Version, VersionError, package_name::PackageNameError};
 
 /// Errors that occur when creating or using the package id.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum PackageIdError {
     #[error("Invalid package id version")]
     VersionError(#[from] VersionError),
@@ -92,28 +92,28 @@ mod tests {
 
     #[test]
     fn from_str_no_version() {
-        assert_eq!(
+        assert!(matches!(
             PackageId::from_str("test"),
             Err(PackageIdError::VersionError(VersionError::NoneError))
-        );
+        ));
     }
 
     #[test]
     fn from_str_no_name() {
-        assert_eq!(
+        assert!(matches!(
             PackageId::from_str("@3.4.1"),
             Err(PackageIdError::PackageNameError(PackageNameError::InvalidPackageName))
-        );
+        ));
     }
 
     #[test]
     fn from_str_invalid_chars() {
         let invalid_chars = "!#$%^&*()~:;{}[]<>,.?/|\\\"\'`+=";
         for char in invalid_chars.chars() {
-            assert_eq!(
+            assert!(matches!(
                 PackageId::from_str(format!("{char}@3.4.1").as_str()),
                 Err(PackageIdError::PackageNameError(PackageNameError::InvalidPackageName))
-            );
+            ));
         }
     }
 

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 const VALID_PACKAGE_NAME: &str = r"^[a-zA-Z0-9\-_]+$";
 
 /// Errors that occur when creating or using the package id.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum PackageNameError {
     #[error("Package name cannot be empty and can only contain characters: 'a-z', 'A-Z', '0-9', '-' and '_'")]
     InvalidPackageName,

--- a/src/installer/types/version.rs
+++ b/src/installer/types/version.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
 /// Errors that occur when requesting metadata from a repository.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum VersionError {
     #[error("Version number is none while version is requested.")]
     NoneError,
@@ -153,20 +153,20 @@ mod tests {
 
     #[test]
     fn from_str_dot_errors() {
-        assert_eq!(Version::from_str("3.4..1"), Err(VersionError::DotsError));
-        assert_eq!(Version::from_str("3.4.1."), Err(VersionError::DotsError));
-        assert_eq!(Version::from_str(".3.4.1"), Err(VersionError::DotsError));
+        assert!(matches!(Version::from_str("3.4..1"), Err(VersionError::DotsError)));
+        assert!(matches!(Version::from_str("3.4.1."), Err(VersionError::DotsError)));
+        assert!(matches!(Version::from_str(".3.4.1"), Err(VersionError::DotsError)));
     }
 
     #[test]
     fn from_str_no_input() {
-        assert_eq!(Version::from_str(""), Err(VersionError::NoneError));
+        assert!(matches!(Version::from_str(""), Err(VersionError::NoneError)));
     }
 
     #[test]
     fn from_str_illegal_char() {
-        assert_eq!(Version::from_str("3.a.1"), Err(VersionError::IllegalCharacterError));
-        assert_eq!(Version::from_str("3.-1.1"), Err(VersionError::IllegalCharacterError));
+        assert!(matches!(Version::from_str("3.a.1"), Err(VersionError::IllegalCharacterError)));
+        assert!(matches!(Version::from_str("3.-1.1"), Err(VersionError::IllegalCharacterError)));
     }
 
     #[test]

--- a/src/installer/unpack.rs
+++ b/src/installer/unpack.rs
@@ -10,14 +10,14 @@ use crate::cli::display::ReaderWithProgress;
 /// The errors that occur during unpacking.
 #[derive(Error, Debug)]
 pub enum UnpackError {
+    #[error("The file extension is not supported")]
+    ExtensionNotSupported,
+
     #[error("Error while interacting with filesystem")]
     IOError(#[from] std::io::Error),
 
     #[error("Error while unpacking")]
     ZipError(#[from] zip::result::ZipError),
-
-    #[error("The file extension is not supported")]
-    ExtensionNotSupported,
 }
 
 type Result<T> = core::result::Result<T, UnpackError>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::{cli::commands::Cli, config::Config, repositories::manager::RepositoryManager};
+use crate::cli::commands::Cli;
 
 mod cli;
 mod config;
@@ -11,7 +11,5 @@ mod utils;
 mod verifier;
 
 fn main() {
-    let config = Config::from(&Config::get_default_path()).expect("Cannot load config");
-    let manager = RepositoryManager::new(&config);
-    Cli::get_instance().handle_command(&manager, &config);
+    Cli::get_instance().handle_command();
 }

--- a/src/packager.rs
+++ b/src/packager.rs
@@ -20,14 +20,14 @@ use crate::{
 /// The errors that occur during installation.
 #[derive(Error, Debug)]
 pub enum PackagerError {
+    #[error("Cannot parse filename, because it contains invalid unicode")]
+    InvalidUnicodeError,
+
     #[error("Cannot get revisions from repository manager")]
     RepositoryError(#[from] RepositoryError),
 
     #[error("Error while packaging")]
     IOError(#[from] std::io::Error),
-
-    #[error("Cannot parse filename, because it contains invalid unicode")]
-    InvalidUnicodeError,
 }
 
 pub fn package(config: &Config, package_id: &PackageId, destination: &PathBuf, revisions: usize) -> Result<(), PackagerError> {

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -5,11 +5,11 @@ use thiserror::Error;
 /// The errors that occur during symlink operations.
 #[derive(Error, Debug)]
 pub enum SymlinkError {
-    #[error("Symlink IO failed")]
-    IOError(#[from] std::io::Error),
-
     #[error("Path is not a symlink")]
     NonSymlink,
+
+    #[error("Symlink IO failed")]
+    IOError(#[from] std::io::Error),
 }
 
 #[cfg(any(target_os = "macos", target_os = "linux"))]

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -5,18 +5,6 @@ use crate::installer::types::PackageId;
 /// The errors that occur when requesting metadata from a repository.
 #[derive(Error, Debug)]
 pub enum RepositoryError {
-    #[error("Cannot read repository file from disk")]
-    ReadError(#[from] std::io::Error),
-
-    #[error("Cannot request repository file from external repository")]
-    RequestError(#[from] reqwest::Error),
-
-    #[error("Cannot parse repository file")]
-    ParseError(#[from] toml::de::Error),
-
-    #[error("Cannot parse checksum from hex")]
-    ChecksumParseError(#[from] hex::FromHexError),
-
     #[error("Cannot find repository '{repository_id}'")]
     RepositoryNotFoundError {
         repository_id: String,
@@ -48,6 +36,18 @@ pub enum RepositoryError {
 
     #[error("No supported version for the current target could be found for package '{0}'.")]
     SupportError(String),
+
+    #[error("Cannot read repository file from disk")]
+    ReadError(#[from] std::io::Error),
+
+    #[error("Cannot request repository file from external repository")]
+    RequestError(#[from] reqwest::Error),
+
+    #[error("Cannot parse repository file")]
+    ParseError(#[from] toml::de::Error),
+
+    #[error("Cannot parse checksum from hex")]
+    ChecksumParseError(#[from] hex::FromHexError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, RepositoryError>;

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -13,7 +13,7 @@ use crate::{
     repositories::{
         error::{RepositoryError, Result},
         provider::{self, MetadataProvider, PrebuildProvider},
-        types::{Checksum, PackageMeta, PackageVersionMeta, RepositoryMeta, TargetBounds},
+        types::{Checksum, PackageMeta, PackageVersionMeta, RepositoryMeta},
     },
 };
 
@@ -131,7 +131,7 @@ impl<'a> RepositoryManager<'a> {
 
     /// Reads package version metadata of the given package, containing dependencies and targets.
     /// Returns the id of the repository and the package version metadata.
-    pub fn read_package_version(&self, package_id: &PackageId, target_bounds: &TargetBounds) -> Result<(String, PackageVersionMeta)> {
+    pub fn read_package_version(&self, package_id: &PackageId, target: &Target) -> Result<(String, PackageVersionMeta)> {
         for repository_id in &self.config.repositories_rank {
             let provider = match self.metadata_providers.get(repository_id) {
                 Some(provider) => provider,
@@ -150,7 +150,7 @@ impl<'a> RepositoryManager<'a> {
             };
 
             // Check if package contains the target
-            if !package.has_target(target_bounds)? {
+            if matches!(package.get_best_target(target), Err(RepositoryError::TargetError)) {
                 continue;
             }
 

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -51,14 +51,21 @@ pub fn create_metadata_provider(repository: &Repository) -> Option<Box<dyn Metad
     }
 }
 
-/// Creates a prebuild repository provider for the given repository.
-pub fn create_prebuild_provider(repository: &Repository, repo_metadata: RepositoryMeta) -> Option<Box<dyn PrebuildProvider>> {
-    let (url, provider) = get_prebuild_repository_info(repository, repo_metadata)?;
+/// Creates a prebuild repository provider for the given repository from its url and provider.
+pub fn create_prebuild_provider_from_url(url: &str, provider: Option<String>) -> Option<Box<dyn PrebuildProvider>> {
+    let provider = provider.unwrap_or(DEFAULT_PREBUILD_PROVIDER_ID.into());
 
     match provider.as_str() {
         FILESYSTEM_PREBUILD_PROVIDER_ID => boxed_prebuild(FileSystemPrebuildProvider::from_url(&url)),
         _ => None,
     }
+}
+
+/// Creates a prebuild repository provider for the given repository.
+pub fn create_prebuild_provider(repository: &Repository, repo_metadata: RepositoryMeta) -> Option<Box<dyn PrebuildProvider>> {
+    let (url, provider) = get_prebuild_repository_info(repository, repo_metadata)?;
+
+    create_prebuild_provider_from_url(&url, Some(provider))
 }
 
 fn get_prebuild_repository_info(repository: &Repository, repo_metadata: RepositoryMeta) -> Option<(String, String)> {

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -10,7 +10,7 @@ use crate::{
 };
 
 /// Errors that occur when creating or using the target bounds.
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum TargetBoundsError {
     #[error("Target additions are not allowed for this target name")]
     AdditionNotAllowed,

--- a/src/storage/error.rs
+++ b/src/storage/error.rs
@@ -18,4 +18,4 @@ pub enum RegisterError {
     PackageIdError(#[from] PackageIdError),
 }
 
-// TODO: Use Result<T> here as well
+pub(super) type Result<T> = std::result::Result<T, RegisterError>;

--- a/src/storage/installed_package_version.rs
+++ b/src/storage/installed_package_version.rs
@@ -17,6 +17,12 @@ pub struct InstalledPackageVersion {
     pub source_repository_provider: String,
     pub source_repository_url: String,
 
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_prebuild_repository_url: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_prebuild_repository_provider: Option<String>,
+
     #[serde(default)]
     #[serde(skip_serializing_if = "HashSet::is_empty")]
     pub dependencies: HashSet<PackageId>,

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -90,12 +90,23 @@ impl PackageRegister {
         install_path: &PathBuf,
         symlinked: bool,
         active: bool,
+        used_prebuild: bool,
     ) -> Result<()> {
+        let (source_prebuild_repository_url, source_prebuild_repository_provider) = match used_prebuild {
+            true => (
+                source_repository.prebuilds_url.clone(),
+                source_repository.prebuilds_provider.clone(),
+            ),
+            false => (None, None),
+        };
+
         let installed_package_version = InstalledPackageVersion {
             package_id: PackageId::new(package.name.clone(), package_version.version.clone()),
             license: package_version.license.clone(),
             source_repository_url: source_repository.path.clone(),
             source_repository_provider: source_repository.provider.clone(),
+            source_prebuild_repository_url,
+            source_prebuild_repository_provider,
             dependencies: dependency_ids,
             dependents: HashSet::new(),
             install_path: install_path.into(),
@@ -282,6 +293,8 @@ pub mod tests {
             license: None,
             source_repository_provider: "-".to_string(),
             source_repository_url: "-".to_string(),
+            source_prebuild_repository_url: None,
+            source_prebuild_repository_provider: None,
             dependencies,
             dependents,
             install_path: "-".into(),
@@ -413,6 +426,7 @@ pub mod tests {
                 dependency_ids,
                 &Repository::new("-", "-"),
                 &PathBuf::from("-"),
+                false,
                 false,
                 false,
             )

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -235,21 +235,24 @@ impl PackageRegister {
         false
     }
 
-    /// Checks if the dependency is satisfied.
-    pub fn dependency_satisfied(&self, dependency: &Dependency) -> bool {
-        self.get_satisfying_package(dependency).is_some()
-    }
+    /// Gets the latest installed package which statisfies the given dependency.
+    pub fn get_latest_satisfying_package(&self, dependency: &Dependency) -> Option<&InstalledPackageVersion> {
+        let mut latest: Option<&InstalledPackageVersion> = None;
 
-    /// Gets an installed package which statisfies the dependency.
-    pub fn get_satisfying_package(&self, dependency: &Dependency) -> Option<&InstalledPackageVersion> {
         // Loop over all packages with the dependency name and check if they satisfy the dependency
         for package in self.packages.get(dependency.get_name())?.get_versions() {
-            if dependency.satisfied(&package.package_id.name, &package.package_id.version) {
-                return Some(package);
+            if !dependency.satisfied(&package.package_id.name, &package.package_id.version) {
+                continue;
             }
+
+            latest = match latest {
+                Some(latest) if latest.package_id.version < package.package_id.version => Some(package),
+                None => Some(package),
+                _ => continue,
+            };
         }
 
-        None
+        latest
     }
 
     /// Returns an iterator, which iterates over all nested installed package version values.
@@ -496,23 +499,23 @@ pub mod tests {
     }
 
     #[test]
-    fn get_satisfying_package() {
+    fn get_latest_satisfying_package() {
         let register = create_register();
-        let package_a_id = PackageId::from_str("A@3.4.1").expect("Expected valid package id");
-        let dependency = create_dependency("A", "3.4.1");
-        let package_a = register.get_package_version(&package_a_id).expect("Expected package A.");
+        let package_a_id = PackageId::from_str("F@6").expect("Expected valid package id");
+        let dependency = create_dependency("F", ">5");
+        let package_a = register.get_package_version(&package_a_id).expect("Expected package F.");
 
-        match register.get_satisfying_package(&dependency) {
+        match register.get_latest_satisfying_package(&dependency) {
             Some(package) => assert_eq!(package.package_id, package_a.package_id),
             None => panic!("Expected Some(InstalledPackageVersion (..)), got None"),
         }
     }
 
     #[test]
-    fn satisfying_package_not_found() {
+    fn latest_satisfying_package_not_found() {
         let register = create_register();
         let dependency = create_dependency("A", ">3.4.1");
 
-        assert!(register.get_satisfying_package(&dependency).is_none());
+        assert!(register.get_latest_satisfying_package(&dependency).is_none());
     }
 }

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -11,7 +11,7 @@ use crate::{
     config::{Config, Repository},
     installer::types::{Dependency, OptionalPackageId, PackageId, PackageName},
     repositories::types::{PackageMeta, PackageVersionMeta},
-    storage::{error::RegisterError, installed_package::InstalledPackage, installed_package_version::InstalledPackageVersion},
+    storage::{error::Result, installed_package::InstalledPackage, installed_package_version::InstalledPackageVersion},
     utils::constants::REGISTER_FILENAME,
 };
 
@@ -31,7 +31,7 @@ impl PackageRegister {
     /// # Errors
     ///
     /// This function will return an error if the file cannot be opened or if the content is invalid.
-    pub fn from(path: &Path) -> Result<Self, RegisterError> {
+    pub fn from(path: &Path) -> Result<Self> {
         // If the file does not exist, we return an empty storage
         if !fs::exists(path)? {
             return Ok(PackageRegister { packages: HashMap::new() });
@@ -54,7 +54,7 @@ impl PackageRegister {
     /// # Errors
     ///
     /// This function will return an error if the data cannot be serialized or if the file cannot be written.
-    pub fn save_to(&self, path: &Path) -> Result<(), RegisterError> {
+    pub fn save_to(&self, path: &Path) -> Result<()> {
         let data = toml::to_string(self)?;
 
         // Add header text to data
@@ -90,7 +90,7 @@ impl PackageRegister {
         install_path: &PathBuf,
         symlinked: bool,
         active: bool,
-    ) -> Result<(), RegisterError> {
+    ) -> Result<()> {
         let installed_package_version = InstalledPackageVersion {
             package_id: PackageId::new(package.name.clone(), package_version.version.clone()),
             license: package_version.license.clone(),

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -227,7 +227,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         include_build: bool,
     ) -> Result<Node<Option<InstallMeta>, DependencyTypes>> {
         // If the package is already satisfied don't expand the dependency tree further
-        if let Some(package) = register.get_satisfying_package(dependency) {
+        if let Some(package) = register.get_latest_satisfying_package(dependency) {
             return Ok(Node {
                 id: package.package_id.clone(),
                 value: None,

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -1,6 +1,5 @@
 use std::{collections::HashSet, fmt::Display};
 
-use clap::error::Result;
 use thiserror::Error;
 
 use crate::{
@@ -28,12 +27,14 @@ pub enum TreeError {
     #[error("Package id '{0}' cannot be found")]
     NotFound(PackageId),
 
-    #[error("Cannot create tree, because of an error reading the repository")]
-    RepositoryError(#[from] RepositoryError),
-
     #[error("Cannot expand a node which does not have a value to expand with.")]
     ExpansionError,
+
+    #[error("Cannot create tree, because of an error reading the repository")]
+    RepositoryError(#[from] RepositoryError),
 }
+
+type Result<T> = std::result::Result<T, TreeError>;
 
 // Static string prefixes for the tree display
 const BRANCH: &str = "\u{251C}\u{2500}\u{2500}\u{2500} ";
@@ -45,13 +46,13 @@ const EMPTY_SPACE: &str = "     ";
 impl<V, L: Eq> Node<V, L> {
     /// Creates a tree based on the installed packages, the given package id will be the root.
     /// It also takes a closure which will get the necessary value and label for each node.
-    fn new_impl<F>(package_id: &PackageId, register: &PackageRegister, value_closure: &F) -> Result<Self, TreeError>
+    fn new_impl<F>(package_id: &PackageId, register: &PackageRegister, value_closure: &F) -> Result<Self>
     where
         F: Fn(&PackageId) -> (V, L),
     {
         let package = register.get_package_version(package_id).ok_or(TreeError::NotFound(package_id.clone()))?;
         let children: Vec<Node<V, L>> =
-            package.dependencies.iter().map(|d| Node::new_impl(&d, register, value_closure)).collect::<Result<Vec<_>, _>>()?;
+            package.dependencies.iter().map(|d| Node::new_impl(&d, register, value_closure)).collect::<Result<Vec<_>>>()?;
 
         let (value, label) = value_closure(package_id);
 
@@ -64,7 +65,7 @@ impl<V, L: Eq> Node<V, L> {
     }
 
     /// A wrapper method to create a tree with nodes that hold values.
-    pub fn new_with_value<F>(package_id: &PackageId, register: &PackageRegister, value_closure: F) -> Result<Self, TreeError>
+    pub fn new_with_value<F>(package_id: &PackageId, register: &PackageRegister, value_closure: F) -> Result<Self>
     where
         F: Fn(&PackageId) -> (V, L),
     {
@@ -130,7 +131,7 @@ impl<V, L: Eq> Node<V, L> {
 
 /// An empty node implementation (node without values or labels).
 impl Node<(), ()> {
-    pub fn new(package_id: &PackageId, register: &PackageRegister) -> Result<Self, TreeError> {
+    pub fn new(package_id: &PackageId, register: &PackageRegister) -> Result<Self> {
         Node::new_impl(package_id, register, &|_| ((), ()))
     }
 }
@@ -146,7 +147,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         register: &PackageRegister,
         label: DependencyTypes,
         include_build: bool,
-    ) -> Result<Self, TreeError> {
+    ) -> Result<Self> {
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
         let dependencies = install_meta.version_metadata.dependencies.iter().chain(target.dependencies.iter());
 
@@ -159,11 +160,11 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
                 .chain(target.build_dependencies.iter())
                 .map(|d| Self::new_from_dependency(manager, register, d, DependencyTypes::Build, include_build))
                 .chain(dependencies.map(|d| Self::new_from_dependency(manager, register, d, label.clone(), include_build)))
-                .collect::<Result<_, _>>()?,
+                .collect::<Result<_>>()?,
             false => dependencies
                 .into_iter()
                 .map(|d| Self::new_from_dependency(manager, register, d, DependencyTypes::Normal, include_build))
-                .collect::<Result<_, _>>()?,
+                .collect::<Result<_>>()?,
         };
 
         Ok(Self {
@@ -180,7 +181,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         install_meta: InstallMeta,
         manager: &RepositoryManager,
         register: &PackageRegister,
-    ) -> Result<Self, TreeError> {
+    ) -> Result<Self> {
         Self::new_from_meta_impl(package_id, install_meta, manager, register, DependencyTypes::Normal, false)
     }
 
@@ -190,14 +191,14 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         install_meta: InstallMeta,
         manager: &RepositoryManager,
         register: &PackageRegister,
-    ) -> Result<Self, TreeError> {
+    ) -> Result<Self> {
         Self::new_from_meta_impl(package_id, install_meta, manager, register, DependencyTypes::Normal, true)
     }
 
     /// Expands a node with its build dependencies after initial creation of the tree.
     /// Note that this only applies for the build dependencies of the current node, the
     /// dependencies of the current node will be satisfied with pre-builds.
-    pub fn expand_node_with_build(&mut self, manager: &RepositoryManager, register: &PackageRegister) -> Result<(), TreeError> {
+    pub fn expand_node_with_build(&mut self, manager: &RepositoryManager, register: &PackageRegister) -> Result<()> {
         let value = match &self.value {
             Some(value) => value,
             None => return Err(TreeError::ExpansionError),
@@ -224,7 +225,7 @@ impl Node<Option<InstallMeta>, DependencyTypes> {
         dependency: &Dependency,
         label: DependencyTypes,
         include_build: bool,
-    ) -> Result<Node<Option<InstallMeta>, DependencyTypes>, TreeError> {
+    ) -> Result<Node<Option<InstallMeta>, DependencyTypes>> {
         // If the package is already satisfied don't expand the dependency tree further
         if let Some(package) = register.get_satisfying_package(dependency) {
             return Ok(Node {

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -29,6 +29,7 @@ impl<'a> Repairer<'a> {
     }
 
     /// Fixes the given issue by executing the fix for that issue.
+    /// Note: The register is not saved after the fix is applied.
     pub fn fix(&mut self, issue: Issue, register: &mut PackageRegister) -> Result<()> {
         match issue {
             Issue::BrokenTree(missing) => self.fix_broken_tree(missing, register)?,

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -132,12 +132,10 @@ impl<'a> Verifier<'a> {
     /// Checks for alterations in a single package using a checksum which is compared to the checksum from the pre-build.
     /// Returns true if the package was altered, false if not.
     fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
-        let package_version = match register.get_package_version(package_id) {
-            Some(package_version) => package_version,
-            None => {
-                error!(msg: "Cannot retrieve package '{package_id}' from register for package alterations check");
-                return Ok(false);
-            },
+        // Get the installed package from the register
+        let Some(package_version) = register.get_package_version(package_id) else {
+            error!(msg: "Cannot retrieve package '{package_id}' from register for package alterations check");
+            return Ok(false);
         };
 
         let mut prebuilds_url = package_version.source_prebuild_repository_url.clone();
@@ -146,12 +144,9 @@ impl<'a> Verifier<'a> {
         if prebuilds_url.is_none() {
             let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
 
-            let provider = match provider::create_metadata_provider(&repository) {
-                Some(provider) => provider,
-                None => {
-                    error!(msg: "Cannot create metadata provider for '{package_id}'.");
-                    return Ok(false);
-                },
+            let Some(provider) = provider::create_metadata_provider(&repository) else {
+                error!(msg: "Cannot create metadata provider for '{package_id}'.");
+                return Ok(false);
             };
 
             let repo_metadata = match provider.read_repository_metadata() {
@@ -166,14 +161,11 @@ impl<'a> Verifier<'a> {
             prebuilds_provider = repo_metadata.prebuilds_provider;
         }
 
-        let prebuilds_url = match prebuilds_url {
-            Some(url) => url,
-            None => {
-                warning!(
-                    "Cannot perform alterations check for package '{package_id}', because no prebuild repository for the package can be found"
-                );
-                return Ok(false);
-            },
+        let Some(prebuilds_url) = &prebuilds_url else {
+            warning!(
+                "Cannot perform alterations check for package '{package_id}', because no prebuild repository for the package can be found"
+            );
+            return Ok(false);
         };
 
         let provider = match provider::create_prebuild_provider_from_url(&prebuilds_url, prebuilds_provider) {

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,11 +1,12 @@
 use std::{fs, str::FromStr};
 
 use crate::{
-    cli::display::logging::warning,
-    config::Config,
+    cli::display::logging::{error, warning},
+    config::{Config, Repository},
     installer::types::{PackageId, PackageName, Version},
     packager,
-    repositories::types::Checksum,
+    platforms::Target,
+    repositories::{provider, types::Checksum},
     storage::package_register::PackageRegister,
     verifier::{
         Issue,
@@ -101,7 +102,7 @@ impl<'a> Verifier<'a> {
 
                     Issue::BrokenTree(missing_dependencies)
                 },
-                Check::Alterations if !self.check_package_alterations(package_id)? => continue,
+                Check::Alterations if !self.check_package_alterations(package_id, register)? => continue,
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
             };
 
@@ -116,7 +117,7 @@ impl<'a> Verifier<'a> {
         // Find issues with a package, maybe even package it and compare it with checksum
         let mut altered = Vec::new();
         for package in register.iterate_all() {
-            if self.check_package_alterations(&package.package_id)? {
+            if self.check_package_alterations(&package.package_id, register)? {
                 altered.push(package.package_id.clone());
             }
         }
@@ -130,17 +131,80 @@ impl<'a> Verifier<'a> {
 
     /// Checks for alterations in a single package using a checksum which is compared to the checksum from the pre-build.
     /// Returns true if the package was altered, false if not.
-    fn check_package_alterations(&self, package_id: &PackageId) -> Result<bool> {
+    fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
+        let package_version = match register.get_package_version(package_id) {
+            Some(package_version) => package_version,
+            None => {
+                error!(msg: "Cannot retrieve package '{package_id}' from register for package alterations check");
+                return Ok(false);
+            },
+        };
+
+        let mut prebuilds_url = package_version.source_prebuild_repository_url.clone();
+        let mut prebuilds_provider = package_version.source_prebuild_repository_provider.clone();
+
+        if prebuilds_url.is_none() {
+            let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
+
+            let provider = match provider::create_metadata_provider(&repository) {
+                Some(provider) => provider,
+                None => {
+                    error!(msg: "Cannot create metadata provider for '{package_id}'.");
+                    return Ok(false);
+                },
+            };
+
+            let repo_metadata = match provider.read_repository_metadata() {
+                Ok(meta) => meta,
+                Err(e) => {
+                    error!(e, "Cannot retrieve repository metadata for '{package_id}'.");
+                    return Ok(false);
+                },
+            };
+
+            prebuilds_url = repo_metadata.prebuilds_url;
+            prebuilds_provider = repo_metadata.prebuilds_provider;
+        }
+
+        let prebuilds_url = match prebuilds_url {
+            Some(url) => url,
+            None => {
+                warning!(
+                    "Cannot perform alterations check for package '{package_id}', because no prebuild repository for the package can be found"
+                );
+                return Ok(false);
+            },
+        };
+
+        let provider = match provider::create_prebuild_provider_from_url(&prebuilds_url, prebuilds_provider) {
+            Some(provider) => provider,
+            None => {
+                error!(msg: "Cannot create prebuild provider for '{package_id}'.");
+                return Ok(false);
+            },
+        };
+
+        let revision = package_version.revisions.len() as u64;
+        let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &Target::current()) {
+            Ok(Some(checksum)) => checksum,
+            Ok(None) => {
+                warning!(
+                    "Cannot perform alterations check for package '{package_id}', because no prebuild version of the package can be found"
+                );
+                return Ok(false);
+            },
+            Err(e) => {
+                error!(
+                    e,
+                    "Cannot perform alterations check for package '{package_id}', because checksum cannot be read"
+                );
+                return Ok(false);
+            },
+        };
+
         let install_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
         let compressed = packager::compress(&install_directory)?;
         let checksum = Checksum::from_bytes(&compressed);
-
-        // TODO: Actually search for the correct checksum
-        let correct_checksum = Checksum {
-            sha256: [
-                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-            ],
-        };
 
         Ok(checksum != correct_checksum)
     }


### PR DESCRIPTION
This PR is a collection of multiple small things that still needed to be fixed:
- Remove PartialEq from errors
- Bugfix for the fix command (register needs to be saved after each fix)
- The config and repository manager are now created inside each specific command to avoid unnecessary creation and for future support for checking them with the verifier.
- Bugfix for unnecessary warning when an uninstall is done, caused by incorrect order of execution.
- Create an unreachable error instead of doing a warning with a return Ok.
- Bugfix in the repository manager for read_package_version which should take the target as parameter instead.
- Bugfix for getting a satisfying package, instead of a random version we now get the latest version.
- Actual implementation of the alteration check in the verifier.