### PR TITLE
Complete refactor of the tree struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,11 @@ TODO
 ## Usage
 The general usage of Packit is: `pit <COMMAND>`.
 
-#### `pit install <PACKAGE-NAME>[@<VERSION>] [--build] [--keep-build] [--skip-symlinking] [--skip-active]`
+#### `pit install <PACKAGE-NAME>[@<VERSION>] [--build] [--build-all] [--keep-build] [--skip-symlinking] [--skip-active]`
 Installs the specified packages, if a version is given that version will be installed, if not the latest available version will be installed. Multiple packages can be specified by entering multiple names, split by a space.
 <br>
 If the `--build` option is given, the package is build from source, instead of installing a prebuild version.
+If the `--build-all` option is given, the package and all its dependencies are build from source, instead of installing prebuild versions.
 If the `--keep-build` option is given, the build dependencies will not be deleted after building.
 If the `--skip-symlinking` option is enabled, the package is not symlinked into the /bin, /lib, /share, etc. directories.
 If the `--skip-active` option is enabled, the package is not set to active and the current active version is kept. If there is no current active version, this flag is ignored and the package is set to active.
@@ -58,16 +59,16 @@ Packages the specified package into a prebuild and store it in the destination d
 
 ## Config
 
-| Field               | Explanation                                                       |
-| ------------------- | ----------------------------------------------------------------- |
+| Field               | Explanation                                                                                                                  |
+|---------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `prefix_directory`  | Defines the directory used for installing packages, see [File structure](#file-structure) for the defaults on each platform. |
-| `repositories_rank` | Defines the order of repositories to search for a package.        |
-| `multiuser`         | True to run Packit in multiuser mode, false for single user mode. |
+| `repositories_rank` | Defines the order of repositories to search for a package.                                                                   |
+| `multiuser`         | True to run Packit in multiuser mode, false for single user mode.                                                            |
 
 ### Repositories
 
 | Field                | Explanation                                                              |
-| -------------------- | ------------------------------------------------------------------------ |
+|----------------------|--------------------------------------------------------------------------|
 | `path`               | Defines the path to the repository.                                      |
 | `provider`           | Defines the provider of the repository, defaults to `web`.               |
 | `prebuilds_url`      | Defines the url of the prebuilds repository for this package repository. |

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -42,7 +42,7 @@ impl HandleCommand for InfoArgs {
         // Display tree if tree flag is given
         if self.tree {
             if let Some(package_id) = self.package.versioned() {
-                let tree = EmptyNode::build_simple(package_id, &register).unwrap_or_exit(1);
+                let tree = EmptyNode::build_simple_tree(package_id, &register).unwrap_or_exit(1);
                 println!("{tree}");
                 return;
             } else {

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -7,7 +7,7 @@ use crate::{
     config::Config,
     installer::types::{OptionalPackageId, PackageId},
     storage::{installed_package::InstalledPackage, package_register::PackageRegister},
-    utils::{tree::Node, unwrap_or_exit::UnwrapOrExit},
+    utils::{tree::EmptyNode, unwrap_or_exit::UnwrapOrExit},
 };
 
 #[derive(Args, Debug)]
@@ -42,7 +42,7 @@ impl HandleCommand for InfoArgs {
         // Display tree if tree flag is given
         if self.tree {
             if let Some(package_id) = self.package.versioned() {
-                let tree = Node::new(&package_id, &register).unwrap_or_exit(1);
+                let tree = EmptyNode::build_simple(package_id, &register).unwrap_or_exit(1);
                 println!("{tree}");
                 return;
             } else {

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::{InstallTypes, Installer, InstallerOptions, types::OptionalPackageId},
+    installer::{InstallLabel, InstallTypes, Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -45,15 +45,17 @@ impl HandleCommand for InstallArgs {
 
         // Determine the install type. Note that clap already check if build and build-all are both set (which should not be possible).
         let install_type = if self.build {
-            InstallTypes::Build { is_dependency: false }
+            InstallTypes::Build
         } else if self.build_all {
-            InstallTypes::BuildAll { is_dependency: false }
+            InstallTypes::BuildAll
         } else {
-            InstallTypes::Prebuild { is_dependency: false }
+            InstallTypes::Prebuild
         };
 
+        let install_label = InstallLabel::new(install_type, false);
+
         let installer_options = InstallerOptions::default()
-            .install_type(install_type)
+            .install_label(install_label)
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
             .keep_build(self.keep_build);

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::{Installer, InstallerOptions, types::OptionalPackageId},
+    installer::{InstallTypes, Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -16,8 +16,12 @@ pub struct InstallArgs {
     pub packages: Vec<OptionalPackageId>,
 
     /// True to build from source locally, false to use a prebuild version
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value = "false", conflicts_with = "build_all")]
     pub build: bool,
+
+    /// True to build everything from source locally, false to use a prebuild version
+    #[arg(long, default_value = "false", conflicts_with = "build")]
+    pub build_all: bool,
 
     /// True to skip symlinking the package, false to use defaults specified for the package
     #[arg(long, default_value = "false")]
@@ -39,8 +43,17 @@ impl HandleCommand for InstallArgs {
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
+        // Determine the install type. Note that clap already check if build and build-all are both set (which should not be possible).
+        let install_type = if self.build {
+            InstallTypes::Build { is_dependency: false }
+        } else if self.build_all {
+            InstallTypes::BuildAll { is_dependency: false }
+        } else {
+            InstallTypes::Prebuild { is_dependency: false }
+        };
+
         let installer_options = InstallerOptions::default()
-            .build_source(self.build)
+            .install_type(install_type)
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
             .keep_build(self.keep_build);

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -3,7 +3,7 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::Config,
-    installer::{InstallLabel, InstallTypes, Installer, InstallerOptions, types::OptionalPackageId},
+    installer::{InstallType, Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -45,17 +45,15 @@ impl HandleCommand for InstallArgs {
 
         // Determine the install type. Note that clap already check if build and build-all are both set (which should not be possible).
         let install_type = if self.build {
-            InstallTypes::Build
+            InstallType::Build
         } else if self.build_all {
-            InstallTypes::BuildAll
+            InstallType::BuildAll
         } else {
-            InstallTypes::Prebuild
+            InstallType::Prebuild
         };
 
-        let install_label = InstallLabel::new(install_type, false);
-
         let installer_options = InstallerOptions::default()
-            .install_label(install_label)
+            .install_type(install_type)
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
             .keep_build(self.keep_build);

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -13,24 +13,31 @@ use crate::{
 /// A label enum for the install/dependency tree
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum InstallTypes {
-    Prebuild {
-        is_dependency: bool,
-    },
-    Build {
-        is_dependency: bool,
-    },
-    BuildAll {
-        is_dependency: bool,
-    },
+    Prebuild,
+    Build,
+    BuildAll,
 }
 
-impl InstallTypes {
-    pub fn is_dependency(&self) -> bool {
-        match self {
-            InstallTypes::Prebuild { is_dependency } => *is_dependency,
-            InstallTypes::Build { is_dependency } => *is_dependency,
-            InstallTypes::BuildAll { is_dependency } => *is_dependency,
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub struct InstallLabel {
+    install_type: InstallTypes,
+    is_dependency: bool,
+}
+
+impl InstallLabel {
+    pub fn new(install_type: InstallTypes, is_dependency: bool) -> Self {
+        Self {
+            install_type,
+            is_dependency,
         }
+    }
+
+    pub fn get_type(&self) -> &InstallTypes {
+        &self.install_type
+    }
+
+    pub fn is_dependency(&self) -> bool {
+        self.is_dependency
     }
 }
 
@@ -56,10 +63,10 @@ impl InstallMeta {
     }
 }
 
-pub type InstallNode = Node<Option<InstallMeta>, InstallTypes>;
+pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 
 impl InstallNode {
-    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallTypes)>> {
+    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallLabel)>> {
         // Return early if the node value is None (meaning that the package is already installed)
         let install_meta = match parent.get_value() {
             Some(install_meta) => install_meta,
@@ -67,57 +74,50 @@ impl InstallNode {
         };
 
         // Determine the (build) dependency types of the children based on the parent
-        // TODO: Refactor to not depent on Option
-        let (install_type, build_install_type) = match *parent.get_label() {
-            InstallTypes::Prebuild { .. } => (InstallTypes::Prebuild { is_dependency: true }, None),
-            InstallTypes::Build { .. } => (
-                InstallTypes::Prebuild { is_dependency: true },
-                Some(InstallTypes::Prebuild { is_dependency: false }),
-            ),
-            InstallTypes::BuildAll { .. } => (
-                InstallTypes::BuildAll { is_dependency: true },
-                Some(InstallTypes::BuildAll { is_dependency: false }),
-            ),
+        let install_type = match *parent.get_label().get_type() {
+            InstallTypes::Prebuild => InstallTypes::Prebuild,
+            InstallTypes::Build => InstallTypes::Prebuild,
+            InstallTypes::BuildAll => InstallTypes::BuildAll,
         };
 
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
 
-        if let Some(build_install_type) = build_install_type {
-            let build_dependencies = install_meta
-                .version_metadata
-                .build_dependencies
-                .iter()
-                .chain(target.build_dependencies.iter())
-                .cloned()
-                .map(|d| (d, build_install_type.clone()));
-
-            let dependencies = install_meta
+        if *parent.get_label().get_type() == InstallTypes::Prebuild {
+            return Ok(install_meta
                 .version_metadata
                 .dependencies
                 .iter()
                 .chain(target.dependencies.iter())
                 .cloned()
-                .map(|d| (d, install_type.clone()));
-
-            return Ok(build_dependencies.chain(dependencies).collect());
+                .map(|d| (d, InstallLabel::new(install_type.clone(), true)))
+                .collect());
         }
 
-        Ok(install_meta
+        let build_dependencies = install_meta
+            .version_metadata
+            .build_dependencies
+            .iter()
+            .chain(target.build_dependencies.iter())
+            .cloned()
+            .map(|d| (d, InstallLabel::new(install_type.clone(), false)));
+
+        let dependencies = install_meta
             .version_metadata
             .dependencies
             .iter()
             .chain(target.dependencies.iter())
             .cloned()
-            .map(|d| (d, install_type.clone()))
-            .collect())
+            .map(|d| (d, InstallLabel::new(install_type.clone(), true)));
+
+        Ok(build_dependencies.chain(dependencies).collect())
     }
 
     pub fn populator(
         register: &PackageRegister,
         manager: &RepositoryManager,
         dependency: &Dependency,
-        label: InstallTypes,
-    ) -> tree::Result<(PackageId, Option<InstallMeta>, InstallTypes)> {
+        label: InstallLabel,
+    ) -> tree::Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
         // If the package is already satisfied don't expand the dependency tree further
         if let Some(package) = register.get_latest_satisfying_package(dependency) {
             return Ok((package.package_id.clone(), None, label));
@@ -133,7 +133,8 @@ impl InstallNode {
     }
 
     pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
-        self.set_label(InstallTypes::Build {
+        self.set_label(InstallLabel {
+            install_type: InstallTypes::Build,
             is_dependency: self.get_label().is_dependency(),
         });
 

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -12,7 +12,7 @@ use crate::{
 
 /// Represents the different types of installing a package.
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum InstallTypes {
+pub enum InstallType {
     Prebuild,
     Build,
     BuildAll,
@@ -21,19 +21,19 @@ pub enum InstallTypes {
 /// Label for the install tree.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct InstallLabel {
-    install_type: InstallTypes,
+    install_type: InstallType,
     is_dependency: bool,
 }
 
 impl InstallLabel {
-    pub fn new(install_type: InstallTypes, is_dependency: bool) -> Self {
+    pub fn new(install_type: InstallType, is_dependency: bool) -> Self {
         Self {
             install_type,
             is_dependency,
         }
     }
 
-    pub fn get_type(&self) -> &InstallTypes {
+    pub fn get_type(&self) -> &InstallType {
         &self.install_type
     }
 
@@ -79,9 +79,9 @@ impl InstallNode {
 
         // Determine the (build) dependency types of the children based on the parent
         let install_type = match *parent.get_label().get_type() {
-            InstallTypes::Prebuild => InstallTypes::Prebuild,
-            InstallTypes::Build => InstallTypes::Prebuild,
-            InstallTypes::BuildAll => InstallTypes::BuildAll,
+            InstallType::Prebuild => InstallType::Prebuild,
+            InstallType::Build => InstallType::Prebuild,
+            InstallType::BuildAll => InstallType::BuildAll,
         };
 
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
@@ -94,7 +94,7 @@ impl InstallNode {
             .map(|d| (d, InstallLabel::new(install_type.clone(), true)));
 
         // Only return normal dependencies when the parent is a prebuild
-        if *parent.get_label().get_type() == InstallTypes::Prebuild {
+        if *parent.get_label().get_type() == InstallType::Prebuild {
             return Ok(dependencies.collect());
         }
 
@@ -136,7 +136,7 @@ impl InstallNode {
     /// and its children will be updated accordingly.
     pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
         self.set_label(InstallLabel {
-            install_type: InstallTypes::Build,
+            install_type: InstallType::Build,
             is_dependency: self.get_label().is_dependency(),
         });
 

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -10,7 +10,7 @@ use crate::{
     utils::tree::{self, Node},
 };
 
-/// A label enum for the install/dependency tree
+/// Represents the different types of installing a package.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum InstallTypes {
     Prebuild,
@@ -18,6 +18,7 @@ pub enum InstallTypes {
     BuildAll,
 }
 
+/// Label for the install tree.
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub struct InstallLabel {
     install_type: InstallTypes,
@@ -66,6 +67,9 @@ impl InstallMeta {
 pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 
 impl InstallNode {
+    /// Expands a tree based on metadata and also takes into account already installed packages.
+    /// The children install types are based on the parent install type and determine how the tree
+    /// is further expanded (with or without build dependencies).
     pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallLabel)>> {
         // Return early if the node value is None (meaning that the package is already installed)
         let install_meta = match parent.get_value() {
@@ -81,26 +85,6 @@ impl InstallNode {
         };
 
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
-
-        if *parent.get_label().get_type() == InstallTypes::Prebuild {
-            return Ok(install_meta
-                .version_metadata
-                .dependencies
-                .iter()
-                .chain(target.dependencies.iter())
-                .cloned()
-                .map(|d| (d, InstallLabel::new(install_type.clone(), true)))
-                .collect());
-        }
-
-        let build_dependencies = install_meta
-            .version_metadata
-            .build_dependencies
-            .iter()
-            .chain(target.build_dependencies.iter())
-            .cloned()
-            .map(|d| (d, InstallLabel::new(install_type.clone(), false)));
-
         let dependencies = install_meta
             .version_metadata
             .dependencies
@@ -109,9 +93,25 @@ impl InstallNode {
             .cloned()
             .map(|d| (d, InstallLabel::new(install_type.clone(), true)));
 
+        // Only return normal dependencies when the parent is a prebuild
+        if *parent.get_label().get_type() == InstallTypes::Prebuild {
+            return Ok(dependencies.collect());
+        }
+
+        // Get the build dependencies
+        let build_dependencies = install_meta
+            .version_metadata
+            .build_dependencies
+            .iter()
+            .chain(target.build_dependencies.iter())
+            .cloned()
+            .map(|d| (d, InstallLabel::new(install_type.clone(), false)));
+
         Ok(build_dependencies.chain(dependencies).collect())
     }
 
+    /// Populates the tree with metadata info. If a package is already installed it is added
+    /// to the tree without a value and children.
     pub fn populator(
         register: &PackageRegister,
         manager: &RepositoryManager,
@@ -132,6 +132,8 @@ impl InstallNode {
         Ok((dependency_id, Some(install_meta), label))
     }
 
+    /// Expands an install tree after it has been build. The current node will be changed to a build node
+    /// and its children will be updated accordingly.
     pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
         self.set_label(InstallLabel {
             install_type: InstallTypes::Build,

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -12,9 +12,26 @@ use crate::{
 
 /// A label enum for the install/dependency tree
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub enum DependencyTypes {
-    Normal,
-    Build,
+pub enum InstallTypes {
+    Prebuild {
+        is_dependency: bool,
+    },
+    Build {
+        is_dependency: bool,
+    },
+    BuildAll {
+        is_dependency: bool,
+    },
+}
+
+impl InstallTypes {
+    pub fn is_dependency(&self) -> bool {
+        match self {
+            InstallTypes::Prebuild { is_dependency } => *is_dependency,
+            InstallTypes::Build { is_dependency } => *is_dependency,
+            InstallTypes::BuildAll { is_dependency } => *is_dependency,
+        }
+    }
 }
 
 /// A helper struct for the installer to move around nodes from the dependency trees
@@ -27,11 +44,7 @@ pub struct InstallMeta {
 }
 
 impl InstallMeta {
-    fn new(
-        package_metadata: PackageMeta,
-        version_metadata: PackageVersionMeta,
-        repository_id: String,
-    ) -> std::result::Result<Self, RepositoryError> {
+    fn new(package_metadata: PackageMeta, version_metadata: PackageVersionMeta, repository_id: String) -> Result<Self, RepositoryError> {
         let target_bounds = version_metadata.get_best_target(&Target::current())?;
 
         Ok(Self {
@@ -43,59 +56,67 @@ impl InstallMeta {
     }
 }
 
-pub type InstallNode = Node<Option<InstallMeta>, DependencyTypes>;
+pub type InstallNode = Node<Option<InstallMeta>, InstallTypes>;
 
 impl InstallNode {
-    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, DependencyTypes)>> {
+    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallTypes)>> {
         let install_meta = match parent.get_value() {
             Some(install_meta) => install_meta,
             None => return Ok(Vec::new()),
         };
 
+        // Determine the (build) dependency types of the children based on the parent
+        // TODO: Refactor to not depent on Option
+        let (install_type, build_install_type) = match *parent.get_label() {
+            InstallTypes::Prebuild { .. } => (InstallTypes::Prebuild { is_dependency: true }, None),
+            InstallTypes::Build { .. } => (
+                InstallTypes::Prebuild { is_dependency: true },
+                Some(InstallTypes::Prebuild { is_dependency: false }),
+            ),
+            InstallTypes::BuildAll { .. } => (
+                InstallTypes::BuildAll { is_dependency: true },
+                Some(InstallTypes::BuildAll { is_dependency: false }),
+            ),
+        };
+
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
+
+        if let Some(build_install_type) = build_install_type {
+            let build_dependencies = install_meta
+                .version_metadata
+                .build_dependencies
+                .iter()
+                .chain(target.build_dependencies.iter())
+                .cloned()
+                .map(|d| (d, build_install_type.clone()));
+
+            let dependencies = install_meta
+                .version_metadata
+                .dependencies
+                .iter()
+                .chain(target.dependencies.iter())
+                .cloned()
+                .map(|d| (d, install_type.clone()));
+
+            return Ok(build_dependencies.chain(dependencies).collect());
+        }
+
         Ok(install_meta
             .version_metadata
             .dependencies
             .iter()
             .chain(target.dependencies.iter())
             .cloned()
-            .map(|d| (d, DependencyTypes::Normal))
+            .map(|d| (d, install_type.clone()))
             .collect())
-    }
-
-    pub fn expander_with_build(parent: &InstallNode) -> tree::Result<Vec<(Dependency, DependencyTypes)>> {
-        // Return early if the value was not set, it means that this node is already installed
-        let install_meta = match parent.get_value() {
-            Some(install_meta) => install_meta,
-            None => return Ok(Vec::new()),
-        };
-
-        let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
-        let build_dependencies = install_meta
-            .version_metadata
-            .build_dependencies
-            .iter()
-            .chain(target.build_dependencies.iter())
-            .cloned()
-            .map(|d| (d, DependencyTypes::Build));
-
-        let dependencies = install_meta
-            .version_metadata
-            .dependencies
-            .iter()
-            .chain(target.dependencies.iter())
-            .cloned()
-            .map(|d| (d, parent.get_label().clone()));
-
-        Ok(build_dependencies.chain(dependencies).collect())
     }
 
     pub fn populator(
         register: &PackageRegister,
         manager: &RepositoryManager,
         dependency: &Dependency,
-        label: DependencyTypes,
-    ) -> tree::Result<(PackageId, Option<InstallMeta>, DependencyTypes)> {
+        label: InstallTypes,
+    ) -> tree::Result<(PackageId, Option<InstallMeta>, InstallTypes)> {
         // If the package is already satisfied don't expand the dependency tree further
         if let Some(package) = register.get_latest_satisfying_package(dependency) {
             return Ok((package.package_id.clone(), None, label));
@@ -111,6 +132,11 @@ impl InstallNode {
     }
 
     pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
-        self.expand(&Self::expander_with_build, &|(d, l)| Self::populator(register, manager, &d, l))
+        self.set_label(InstallTypes::Build {
+            is_dependency: self.get_label().is_dependency(),
+        });
+
+        // TODO: Check if this doesn't give double children (because some children already exist)
+        self.expand(&Self::expander, &|(d, l)| Self::populator(register, manager, &d, l))
     }
 }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -1,0 +1,116 @@
+use crate::{
+    installer::types::{Dependency, PackageId},
+    platforms::Target,
+    repositories::{
+        error::RepositoryError,
+        manager::RepositoryManager,
+        types::{PackageMeta, PackageVersionMeta, TargetBounds},
+    },
+    storage::package_register::PackageRegister,
+    utils::tree::{self, Node},
+};
+
+/// A label enum for the install/dependency tree
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum DependencyTypes {
+    Normal,
+    Build,
+}
+
+/// A helper struct for the installer to move around nodes from the dependency trees
+#[derive(Debug)]
+pub struct InstallMeta {
+    pub package_metadata: PackageMeta,
+    pub version_metadata: PackageVersionMeta,
+    pub repository_id: String,
+    pub target_bounds: TargetBounds,
+}
+
+impl InstallMeta {
+    fn new(
+        package_metadata: PackageMeta,
+        version_metadata: PackageVersionMeta,
+        repository_id: String,
+    ) -> std::result::Result<Self, RepositoryError> {
+        let target_bounds = version_metadata.get_best_target(&Target::current())?;
+
+        Ok(Self {
+            package_metadata,
+            version_metadata,
+            repository_id,
+            target_bounds,
+        })
+    }
+}
+
+pub type InstallNode = Node<Option<InstallMeta>, DependencyTypes>;
+
+impl InstallNode {
+    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, DependencyTypes)>> {
+        let install_meta = match parent.get_value() {
+            Some(install_meta) => install_meta,
+            None => return Ok(Vec::new()),
+        };
+
+        let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
+        Ok(install_meta
+            .version_metadata
+            .dependencies
+            .iter()
+            .chain(target.dependencies.iter())
+            .cloned()
+            .map(|d| (d, DependencyTypes::Normal))
+            .collect())
+    }
+
+    pub fn expander_with_build(parent: &InstallNode) -> tree::Result<Vec<(Dependency, DependencyTypes)>> {
+        // Return early if the value was not set, it means that this node is already installed
+        let install_meta = match parent.get_value() {
+            Some(install_meta) => install_meta,
+            None => return Ok(Vec::new()),
+        };
+
+        let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
+        let build_dependencies = install_meta
+            .version_metadata
+            .build_dependencies
+            .iter()
+            .chain(target.build_dependencies.iter())
+            .cloned()
+            .map(|d| (d, DependencyTypes::Build));
+
+        let dependencies = install_meta
+            .version_metadata
+            .dependencies
+            .iter()
+            .chain(target.dependencies.iter())
+            .cloned()
+            .map(|d| (d, parent.get_label().clone()));
+
+        Ok(build_dependencies.chain(dependencies).collect())
+    }
+
+    pub fn populator(
+        register: &PackageRegister,
+        manager: &RepositoryManager,
+        dependency: &Dependency,
+        label: DependencyTypes,
+    ) -> tree::Result<(PackageId, Option<InstallMeta>, DependencyTypes)> {
+        // If the package is already satisfied don't expand the dependency tree further
+        if let Some(package) = register.get_latest_satisfying_package(dependency) {
+            return Ok((package.package_id.clone(), None, label));
+        }
+
+        // Use the latest version if the dependency is not yet satisfied
+        let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
+        let version = package_metadata.get_latest_dependency_version(&dependency, &Target::current())?;
+        let dependency_id = PackageId::new(dependency.get_name().clone(), version.clone());
+        let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
+        let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;
+        Ok((dependency_id, Some(install_meta), label))
+    }
+
+    pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
+        self.expand(&Self::expander_with_build, &|(d, l)| Self::populator(register, manager, &d, l))
+    }
+}

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -138,7 +138,10 @@ impl InstallNode {
             is_dependency: self.get_label().is_dependency(),
         });
 
-        // TODO: Check if this doesn't give double children (because some children already exist)
+        // Clear all the children to avoid duplicates
+        self.get_children_mut().clear();
+
+        // Expand the node again, but now for build
         self.expand(&Self::expander, &|(d, l)| Self::populator(register, manager, &d, l))
     }
 }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -60,6 +60,7 @@ pub type InstallNode = Node<Option<InstallMeta>, InstallTypes>;
 
 impl InstallNode {
     pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallTypes)>> {
+        // Return early if the node value is None (meaning that the package is already installed)
         let install_meta = match parent.get_value() {
             Some(install_meta) => install_meta,
             None => return Ok(Vec::new()),

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -140,10 +140,7 @@ impl InstallNode {
             is_dependency: self.get_label().is_dependency(),
         });
 
-        // Clear all the children to avoid duplicates
-        self.get_children_mut().clear();
-
-        // Expand the node again, but now for build
+        // Expand the node again, but now for build. Duplicate nodes will be handled by the tree implementation
         self.expand(&Self::expander, &|(d, l)| Self::populator(register, manager, &d, l))
     }
 }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -5,6 +5,7 @@ use crate::{
     },
     config::{Config, Repository},
     installer::{
+        InstallLabel,
         builder::Builder,
         error::{InstallerError, Result},
         install_tree::{InstallMeta, InstallNode, InstallTypes},
@@ -105,7 +106,7 @@ impl<'a> Installer<'a> {
 
         // Create the install tree based on the install type
         let mut dependency_tree = TreeBuilder::new()
-            .root(package_id, Some(root_meta), self.options.install_type.clone())
+            .root(package_id, Some(root_meta), self.options.install_label.clone())
             .expander(InstallNode::expander)
             .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
             .build()?;
@@ -132,10 +133,10 @@ impl<'a> Installer<'a> {
             None => return Ok(()),
         };
 
-        let children = node.get_children_ids(Some(InstallTypes::is_dependency));
+        let children = node.get_children_ids(Some(InstallLabel::is_dependency));
 
         // Check if the current package should be build from source
-        if matches!(*node.get_label(), InstallTypes::Build { .. }) || matches!(*node.get_label(), InstallTypes::BuildAll { .. }) {
+        if matches!(node.get_label().get_type(), InstallTypes::Build) || matches!(node.get_label().get_type(), InstallTypes::BuildAll) {
             // Install the current node without prebuild
             return self.install_package(node_value, children, false);
         }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -7,7 +7,7 @@ use crate::{
     installer::{
         builder::Builder,
         error::{InstallerError, Result},
-        install_tree::{DependencyTypes, InstallMeta, InstallNode},
+        install_tree::{InstallMeta, InstallNode, InstallTypes},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -103,38 +103,27 @@ impl<'a> Installer<'a> {
             target_bounds,
         };
 
-        let mut installed_build_deps = Vec::new();
-        match self.options.build_source {
-            true => {
-                let dependency_tree = TreeBuilder::new()
-                    .root(package_id, Some(root_meta), DependencyTypes::Normal)
-                    .expander(InstallNode::expander_with_build)
-                    .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
-                    .build()?;
-                self.install_nodes_build(&dependency_tree, &mut installed_build_deps)?;
-            },
-            false => {
-                let mut dependency_tree = TreeBuilder::new()
-                    .root(package_id, Some(root_meta), DependencyTypes::Normal)
-                    .expander(InstallNode::expander)
-                    .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
-                    .build()?;
-                self.install_nodes(&mut dependency_tree, &mut installed_build_deps)?;
-            },
-        }
+        // Create the install tree based on the install type
+        let mut dependency_tree = TreeBuilder::new()
+            .root(package_id, Some(root_meta), self.options.install_type.clone())
+            .expander(InstallNode::expander)
+            .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
+            .build()?;
+
+        self.install_nodes(&mut dependency_tree)?;
 
         if !self.options.keep_build {
-            self.remove_build_dependencies(&installed_build_deps)?;
+            self.remove_build_dependencies(&dependency_tree, &dependency_tree)?;
         }
 
         Ok(())
     }
 
-    fn install_nodes(&mut self, node: &mut InstallNode, installed_build_deps: &mut Vec<PackageId>) -> Result<()> {
+    fn install_nodes(&mut self, node: &mut InstallNode) -> Result<()> {
         // Install childs first
         // TODO: Implement parallelization here
         for child in node.get_children_mut() {
-            self.install_nodes(child, installed_build_deps)?;
+            self.install_nodes(child)?;
         }
 
         // Get the value or return early if there is no value (package is already satisfied)
@@ -143,11 +132,19 @@ impl<'a> Installer<'a> {
             None => return Ok(()),
         };
 
+        let children = node.get_children_ids(Some(InstallTypes::is_dependency));
+
+        // Check if the current package should be build from source
+        if matches!(*node.get_label(), InstallTypes::Build { .. }) || matches!(*node.get_label(), InstallTypes::BuildAll { .. }) {
+            // Install the current node without prebuild
+            return self.install_package(node_value, children, false);
+        }
+
         // Install the package with a prebuild if possible
         let revision = node_value.version_metadata.revisions.len() as u64;
         match self.repository_manager.get_prebuild_url(&node_value.repository_id, node.get_id(), revision, &Target::current()) {
             Ok(Some(_)) => {
-                self.install_package(node_value, node.get_children_ids(Some(DependencyTypes::Normal)), true)?;
+                self.install_package(node_value, children, true)?;
                 return Ok(());
             },
             Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
@@ -166,30 +163,7 @@ impl<'a> Installer<'a> {
         }
 
         node.expand_with_build(self.register, self.repository_manager)?;
-        self.install_nodes_build(node, installed_build_deps)?;
-
-        Ok(())
-    }
-
-    fn install_nodes_build(&mut self, node: &InstallNode, installed_build_deps: &mut Vec<PackageId>) -> Result<()> {
-        // Install childs first
-        // TODO: Implement parallelization here
-        for child in node.get_children() {
-            self.install_nodes_build(child, installed_build_deps)?;
-        }
-
-        // Get the value or return early if there is no value (package is already satisfied)
-        let node_value = match node.get_value() {
-            Some(value) => value,
-            None => return Ok(()),
-        };
-
-        if *node.get_label() == DependencyTypes::Build {
-            installed_build_deps.push(node.get_id().clone());
-        }
-
-        // Install the current node
-        self.install_package(node_value, node.get_children_ids(Some(DependencyTypes::Normal)), false)?;
+        self.install_nodes(node)?;
 
         Ok(())
     }
@@ -332,18 +306,19 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    fn remove_build_dependencies(&mut self, installed: &Vec<PackageId>) -> Result<()> {
-        // Loop through the installed build dependencies in reverse, because then the dependents
-        // are uninstalled before the dependencies due to the install order.
-        for package_id in installed.iter().rev() {
-            let optional_id = &OptionalPackageId::from(package_id.clone());
+    fn remove_build_dependencies(&mut self, parent: &InstallNode, root: &InstallNode) -> Result<()> {
+        let optional_id = &OptionalPackageId::from(parent.get_id().clone());
+        if self.register.get_package_version(parent.get_id()).is_none() || self.register.is_dependency(optional_id) {
+            return Ok(());
+        }
 
-            // Continue if the package is None (already removed in a previous iteration) or if it's also a dependency
-            if self.register.get_package_version(package_id).is_some() && self.register.is_dependency(optional_id) {
-                continue;
-            }
-
+        // Don't remove the package if it's the root
+        if parent.get_id() != root.get_id() {
             self.uninstall(optional_id)?;
+        }
+
+        for child in parent.get_children() {
+            self.remove_build_dependencies(child, root)?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -307,6 +307,12 @@ impl<'a> Installer<'a> {
     }
 
     fn remove_build_dependencies(&mut self, parent: &InstallNode, root: &InstallNode) -> Result<()> {
+        // Return early if the node value is None (meaning that the package was already installed)
+        if parent.get_value().is_none() {
+            return Ok(());
+        }
+
+        // Return early if the package doesn't exist (removed in earlier iteration) or if it's a dependency
         let optional_id = &OptionalPackageId::from(parent.get_id().clone());
         if self.register.get_package_version(parent.get_id()).is_none() || self.register.is_dependency(optional_id) {
             return Ok(());

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -7,6 +7,7 @@ use crate::{
     installer::{
         builder::Builder,
         error::{InstallerError, Result},
+        install_tree::{DependencyTypes, InstallMeta, InstallNode},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -18,10 +19,10 @@ use crate::{
         error::RepositoryError,
         manager::RepositoryManager,
         provider,
-        types::{Checksum, PackageMeta, PackageTarget, PackageVersionMeta, TargetBounds},
+        types::{Checksum, PackageTarget},
     },
     storage::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
-    utils::tree::Node,
+    utils::tree::TreeBuilder,
 };
 
 use std::{
@@ -36,39 +37,6 @@ pub struct Installer<'a> {
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     options: InstallerOptions,
-}
-
-/// A label enum for the install/dependency tree
-#[derive(Debug, PartialEq, Eq, Clone)]
-pub enum DependencyTypes {
-    Normal,
-    Build,
-}
-
-/// A helper struct for the installer to move around nodes from the dependency trees
-#[derive(Debug)]
-pub struct InstallMeta {
-    pub package_metadata: PackageMeta,
-    pub version_metadata: PackageVersionMeta,
-    pub repository_id: String,
-    pub target_bounds: TargetBounds,
-}
-
-impl InstallMeta {
-    pub fn new(
-        package_metadata: PackageMeta,
-        version_metadata: PackageVersionMeta,
-        repository_id: String,
-    ) -> std::result::Result<Self, RepositoryError> {
-        let target_bounds = version_metadata.get_best_target(&Target::current())?;
-
-        Ok(Self {
-            package_metadata,
-            version_metadata,
-            repository_id,
-            target_bounds,
-        })
-    }
 }
 
 impl<'a> Installer<'a> {
@@ -138,11 +106,19 @@ impl<'a> Installer<'a> {
         let mut installed_build_deps = Vec::new();
         match self.options.build_source {
             true => {
-                let dependency_tree = Node::new_from_meta_build(&package_id, root_meta, self.repository_manager, self.register)?;
+                let dependency_tree = TreeBuilder::new()
+                    .root(package_id, Some(root_meta), DependencyTypes::Normal)
+                    .expander(InstallNode::expander_with_build)
+                    .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
+                    .build()?;
                 self.install_nodes_build(&dependency_tree, &mut installed_build_deps)?;
             },
             false => {
-                let mut dependency_tree = Node::new_from_meta(&package_id, root_meta, self.repository_manager, self.register)?;
+                let mut dependency_tree = TreeBuilder::new()
+                    .root(package_id, Some(root_meta), DependencyTypes::Normal)
+                    .expander(InstallNode::expander)
+                    .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
+                    .build()?;
                 self.install_nodes(&mut dependency_tree, &mut installed_build_deps)?;
             },
         }
@@ -154,11 +130,7 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    fn install_nodes(
-        &mut self,
-        node: &mut Node<Option<InstallMeta>, DependencyTypes>,
-        installed_build_deps: &mut Vec<PackageId>,
-    ) -> Result<()> {
+    fn install_nodes(&mut self, node: &mut InstallNode, installed_build_deps: &mut Vec<PackageId>) -> Result<()> {
         // Install childs first
         // TODO: Implement parallelization here
         for child in node.get_children_mut() {
@@ -193,17 +165,13 @@ impl<'a> Installer<'a> {
             });
         }
 
-        node.expand_node_with_build(self.repository_manager, self.register)?;
+        node.expand_with_build(self.register, self.repository_manager)?;
         self.install_nodes_build(node, installed_build_deps)?;
 
         Ok(())
     }
 
-    fn install_nodes_build(
-        &mut self,
-        node: &Node<Option<InstallMeta>, DependencyTypes>,
-        installed_build_deps: &mut Vec<PackageId>,
-    ) -> Result<()> {
+    fn install_nodes_build(&mut self, node: &InstallNode, installed_build_deps: &mut Vec<PackageId>) -> Result<()> {
         // Install childs first
         // TODO: Implement parallelization here
         for child in node.get_children() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -8,7 +8,7 @@ use crate::{
         InstallLabel,
         builder::Builder,
         error::{InstallerError, Result},
-        install_tree::{InstallMeta, InstallNode, InstallTypes},
+        install_tree::{InstallMeta, InstallNode, InstallType},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -104,9 +104,11 @@ impl<'a> Installer<'a> {
             target_bounds,
         };
 
+        let install_label = InstallLabel::new(self.options.install_type.clone(), false);
+
         // Create the install tree based on the install type
         let mut dependency_tree = TreeBuilder::new()
-            .root(package_id, Some(root_meta), self.options.install_label.clone())
+            .root(package_id, Some(root_meta), install_label)
             .expander(InstallNode::expander)
             .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
             .build()?;
@@ -114,7 +116,7 @@ impl<'a> Installer<'a> {
         self.install_nodes(&mut dependency_tree)?;
 
         if !self.options.keep_build {
-            self.remove_build_dependencies(&dependency_tree, &dependency_tree)?;
+            self.remove_build_dependencies(&dependency_tree, true)?;
         }
 
         Ok(())
@@ -137,7 +139,7 @@ impl<'a> Installer<'a> {
         let dependencies = node.get_children_ids(Some(InstallLabel::is_dependency));
 
         // Check if the current package should be build from source
-        if matches!(node.get_label().get_type(), InstallTypes::Build) || matches!(node.get_label().get_type(), InstallTypes::BuildAll) {
+        if matches!(node.get_label().get_type(), InstallType::Build | InstallType::BuildAll) {
             // Install the current node without prebuild
             return self.install_package(node_value, dependencies, false);
         }
@@ -311,7 +313,7 @@ impl<'a> Installer<'a> {
 
     /// Removes the build dependencies recursively. There are early returns to make sure that the
     /// package is not removed if it was already installed, is not installed anymore or is a dependency.
-    fn remove_build_dependencies(&mut self, parent: &InstallNode, root: &InstallNode) -> Result<()> {
+    fn remove_build_dependencies(&mut self, parent: &InstallNode, is_root: bool) -> Result<()> {
         // Return early if the node value is None (meaning that the package was already installed)
         if parent.get_value().is_none() {
             return Ok(());
@@ -324,12 +326,12 @@ impl<'a> Installer<'a> {
         }
 
         // Don't remove the package if it's the root
-        if parent.get_id() != root.get_id() {
+        if !is_root {
             self.uninstall(optional_id)?;
         }
 
         for child in parent.get_children() {
-            self.remove_build_dependencies(child, root)?;
+            self.remove_build_dependencies(child, false)?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -120,6 +120,7 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
+    /// Installs all packages recursively. For each package the install type is considered.
     fn install_nodes(&mut self, node: &mut InstallNode) -> Result<()> {
         // Install childs first
         // TODO: Implement parallelization here
@@ -133,19 +134,19 @@ impl<'a> Installer<'a> {
             None => return Ok(()),
         };
 
-        let children = node.get_children_ids(Some(InstallLabel::is_dependency));
+        let dependencies = node.get_children_ids(Some(InstallLabel::is_dependency));
 
         // Check if the current package should be build from source
         if matches!(node.get_label().get_type(), InstallTypes::Build) || matches!(node.get_label().get_type(), InstallTypes::BuildAll) {
             // Install the current node without prebuild
-            return self.install_package(node_value, children, false);
+            return self.install_package(node_value, dependencies, false);
         }
 
         // Install the package with a prebuild if possible
         let revision = node_value.version_metadata.revisions.len() as u64;
         match self.repository_manager.get_prebuild_url(&node_value.repository_id, node.get_id(), revision, &Target::current()) {
             Ok(Some(_)) => {
-                self.install_package(node_value, children, true)?;
+                self.install_package(node_value, dependencies, true)?;
                 return Ok(());
             },
             Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
@@ -169,7 +170,8 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    fn install_package(&mut self, install_meta: &InstallMeta, children: HashSet<PackageId>, use_prebuild: bool) -> Result<()> {
+    /// Downloads and installs a package. This is done with a build from the source repository or with prebuilds.
+    fn install_package(&mut self, install_meta: &InstallMeta, dependencies: HashSet<PackageId>, use_prebuild: bool) -> Result<()> {
         // Create the package id and install directory
         let package_id = PackageId::new(
             install_meta.package_metadata.name.clone(),
@@ -227,7 +229,7 @@ impl<'a> Installer<'a> {
         self.register.add_package(
             &install_meta.package_metadata,
             &install_meta.version_metadata,
-            children,
+            dependencies,
             source_repository,
             &install_directory,
             false,
@@ -307,6 +309,8 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
+    /// Removes the build dependencies recursively. There are early returns to make sure that the
+    /// package is not removed if it was already installed, is not installed anymore or is a dependency.
     fn remove_build_dependencies(&mut self, parent: &InstallNode, root: &InstallNode) -> Result<()> {
         // Return early if the node value is None (meaning that the package was already installed)
         if parent.get_value().is_none() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -136,7 +136,7 @@ impl<'a> Installer<'a> {
             None => return Ok(()),
         };
 
-        let dependencies = node.get_children_ids(Some(InstallLabel::is_dependency));
+        let dependencies = node.get_children_ids_filtered(InstallLabel::is_dependency);
 
         // Check if the current package should be build from source
         if matches!(node.get_label().get_type(), InstallType::Build | InstallType::BuildAll) {

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -10,7 +10,7 @@ pub mod types;
 pub mod unpack;
 
 pub use self::install_tree::InstallLabel;
-pub use self::install_tree::InstallTypes;
+pub use self::install_tree::InstallType;
 
 pub use self::installer::Installer;
 

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -1,6 +1,7 @@
 mod build_env;
 mod builder;
 pub mod error;
+mod install_tree;
 mod installer;
 mod options;
 pub mod scripts;
@@ -8,8 +9,6 @@ mod symlinker;
 pub mod types;
 pub mod unpack;
 
-pub use self::installer::DependencyTypes;
-pub use self::installer::InstallMeta;
 pub use self::installer::Installer;
 
 pub use self::options::InstallerOptions;

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -9,6 +9,8 @@ mod symlinker;
 pub mod types;
 pub mod unpack;
 
+pub use self::install_tree::InstallTypes;
+
 pub use self::installer::Installer;
 
 pub use self::options::InstallerOptions;

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -9,6 +9,7 @@ mod symlinker;
 pub mod types;
 pub mod unpack;
 
+pub use self::install_tree::InstallLabel;
 pub use self::install_tree::InstallTypes;
 
 pub use self::installer::Installer;

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -1,7 +1,7 @@
-use crate::installer::{InstallLabel, install_tree::InstallTypes};
+use crate::installer::install_tree::InstallType;
 
 pub struct InstallerOptions {
-    pub install_label: InstallLabel,
+    pub install_type: InstallType,
     pub skip_symlinking: bool,
     pub skip_active: bool,
     pub keep_build: bool,
@@ -10,7 +10,7 @@ pub struct InstallerOptions {
 impl Default for InstallerOptions {
     fn default() -> Self {
         Self {
-            install_label: InstallLabel::new(InstallTypes::Prebuild, false),
+            install_type: InstallType::Prebuild,
             skip_symlinking: false,
             skip_active: false,
             keep_build: false,
@@ -19,8 +19,8 @@ impl Default for InstallerOptions {
 }
 
 impl InstallerOptions {
-    pub fn install_label(mut self, install_label: InstallLabel) -> Self {
-        self.install_label = install_label;
+    pub fn install_type(mut self, install_type: InstallType) -> Self {
+        self.install_type = install_type;
         self
     }
 

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -1,7 +1,7 @@
-use crate::installer::install_tree::InstallTypes;
+use crate::installer::{InstallLabel, install_tree::InstallTypes};
 
 pub struct InstallerOptions {
-    pub install_type: InstallTypes,
+    pub install_label: InstallLabel,
     pub skip_symlinking: bool,
     pub skip_active: bool,
     pub keep_build: bool,
@@ -10,7 +10,7 @@ pub struct InstallerOptions {
 impl Default for InstallerOptions {
     fn default() -> Self {
         Self {
-            install_type: InstallTypes::Prebuild { is_dependency: false },
+            install_label: InstallLabel::new(InstallTypes::Prebuild, false),
             skip_symlinking: false,
             skip_active: false,
             keep_build: false,
@@ -19,8 +19,8 @@ impl Default for InstallerOptions {
 }
 
 impl InstallerOptions {
-    pub fn install_type(mut self, install_type: InstallTypes) -> Self {
-        self.install_type = install_type;
+    pub fn install_label(mut self, install_label: InstallLabel) -> Self {
+        self.install_label = install_label;
         self
     }
 

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -1,5 +1,7 @@
+use crate::installer::install_tree::InstallTypes;
+
 pub struct InstallerOptions {
-    pub build_source: bool,
+    pub install_type: InstallTypes,
     pub skip_symlinking: bool,
     pub skip_active: bool,
     pub keep_build: bool,
@@ -8,7 +10,7 @@ pub struct InstallerOptions {
 impl Default for InstallerOptions {
     fn default() -> Self {
         Self {
-            build_source: false,
+            install_type: InstallTypes::Prebuild { is_dependency: false },
             skip_symlinking: false,
             skip_active: false,
             keep_build: false,
@@ -17,8 +19,8 @@ impl Default for InstallerOptions {
 }
 
 impl InstallerOptions {
-    pub fn build_source(mut self, build_source: bool) -> Self {
-        self.build_source = build_source;
+    pub fn install_type(mut self, install_type: InstallTypes) -> Self {
+        self.install_type = install_type;
         self
     }
 

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -110,8 +110,16 @@ impl<V, L: Eq> Node<V, L> {
         E: Fn(&Node<V, L>) -> Result<Vec<T>>,
         P: Fn(T) -> Result<(PackageId, V, L)>,
     {
+        let existing_childs = self.get_children_ids();
+
         for child in expander(&self)? {
             let (id, value, label) = populator(child)?;
+
+            // Node already exists, skip adding
+            if existing_childs.contains(&id) {
+                continue;
+            }
+
             let mut child_node = Node {
                 id,
                 value,
@@ -158,15 +166,16 @@ impl<V, L: Eq> Node<V, L> {
         &self.value
     }
 
-    /// Gets the children ids of a node in a hashset. If a label has been given it will only return the children with that label.
-    pub fn get_children_ids<F>(&self, filter: Option<F>) -> HashSet<PackageId>
+    /// Gets the children ids of the node in a hashset. Checks for a filter on the label and will only return the children that satisfy the filter.
+    pub fn get_children_ids_filtered<F>(&self, filter: F) -> HashSet<PackageId>
     where
         F: Fn(&L) -> bool,
     {
-        if let Some(filter) = filter {
-            return self.children.iter().filter(|c| filter(&c.label)).map(|c| c.id.clone()).collect();
-        }
+        self.children.iter().filter(|c| filter(&c.label)).map(|c| c.id.clone()).collect()
+    }
 
+    /// Gets the children ids of the node in a hashset.
+    pub fn get_children_ids(&self) -> HashSet<PackageId> {
         self.children.iter().map(|c| c.id.clone()).collect()
     }
 

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -159,9 +159,12 @@ impl<V, L: Eq> Node<V, L> {
     }
 
     /// Gets the children ids of a node in a hashset. If a label has been given it will only return the children with that label.
-    pub fn get_children_ids(&self, label: Option<L>) -> HashSet<PackageId> {
-        if let Some(label) = label {
-            return self.children.iter().filter(|c| c.label == label).map(|c| c.id.clone()).collect();
+    pub fn get_children_ids<F>(&self, filter: Option<F>) -> HashSet<PackageId>
+    where
+        F: Fn(&L) -> bool,
+    {
+        if let Some(filter) = filter {
+            return self.children.iter().filter(|c| filter(&c.label)).map(|c| c.id.clone()).collect();
         }
 
         self.children.iter().map(|c| c.id.clone()).collect()
@@ -180,6 +183,11 @@ impl<V, L: Eq> Node<V, L> {
     /// Gets the label.
     pub fn get_label(&self) -> &L {
         &self.label
+    }
+
+    /// Sets a new label.
+    pub fn set_label(&mut self, new_label: L) {
+        self.label = new_label;
     }
 }
 

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -195,7 +195,7 @@ pub type EmptyNode = Node<(), ()>;
 
 /// An empty node implementation (node without values or labels).
 impl EmptyNode {
-    pub fn build_simple(package_id: PackageId, register: &PackageRegister) -> Result<EmptyNode> {
+    pub fn build_simple_tree(package_id: PackageId, register: &PackageRegister) -> Result<EmptyNode> {
         TreeBuilder::new()
             .root(package_id, (), ())
             .expander(|p| EmptyNode::expander(p, register))

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -1,16 +1,26 @@
-use std::{collections::HashSet, fmt::Display};
+use std::{
+    collections::HashSet,
+    fmt::{Debug, Display},
+};
 
 use thiserror::Error;
 
-use crate::{
-    installer::{
-        DependencyTypes, InstallMeta,
-        types::{Dependency, PackageId},
-    },
-    platforms::Target,
-    repositories::{error::RepositoryError, manager::RepositoryManager},
-    storage::package_register::PackageRegister,
-};
+use crate::{installer::types::PackageId, repositories::error::RepositoryError, storage::package_register::PackageRegister};
+
+/// Errors which could occur while doing tree operations
+#[derive(Error, Debug)]
+pub enum TreeError {
+    #[error("Package id '{0}' cannot be found")]
+    NotFound(PackageId),
+
+    #[error("Cannot create tree, because of an error reading the repository.")]
+    RepositoryError(#[from] RepositoryError),
+
+    #[error("Cannot create tree, because necessary build attribute '{0}' was missing from the tree builder.")]
+    MissingBuildAttributes(String),
+}
+
+pub type Result<T> = std::result::Result<T, TreeError>;
 
 /// A node to create a dependency tree with generic values and labels.
 #[derive(Debug)]
@@ -21,20 +31,16 @@ pub struct Node<V, L: Eq> {
     label: L,
 }
 
-/// Errors which could occur while doing tree operations
-#[derive(Error, Debug)]
-pub enum TreeError {
-    #[error("Package id '{0}' cannot be found")]
-    NotFound(PackageId),
-
-    #[error("Cannot expand a node which does not have a value to expand with.")]
-    ExpansionError,
-
-    #[error("Cannot create tree, because of an error reading the repository")]
-    RepositoryError(#[from] RepositoryError),
+#[derive(Debug)]
+pub struct TreeBuilder<E, P, T, V, L: Eq>
+where
+    E: Fn(&Node<V, L>) -> Result<Vec<T>>,
+    P: Fn(T) -> Result<(PackageId, V, L)>,
+{
+    root: Option<Node<V, L>>,
+    expander: Option<E>,  // Specifies how to get children of a certain package id
+    populator: Option<P>, // Specifies how to populate the tree with the expander return values
 }
-
-type Result<T> = std::result::Result<T, TreeError>;
 
 // Static string prefixes for the tree display
 const BRANCH: &str = "\u{251C}\u{2500}\u{2500}\u{2500} ";
@@ -42,34 +48,82 @@ const LAST_BRANCH: &str = "\u{2514}\u{2500}\u{2500}\u{2500} ";
 const VERTICAL_LINE: &str = "\u{2502}    ";
 const EMPTY_SPACE: &str = "     ";
 
-/// Generic node implementation.
-impl<V, L: Eq> Node<V, L> {
-    /// Creates a tree based on the installed packages, the given package id will be the root.
-    /// It also takes a closure which will get the necessary value and label for each node.
-    fn new_impl<F>(package_id: &PackageId, register: &PackageRegister, value_closure: &F) -> Result<Self>
-    where
-        F: Fn(&PackageId) -> (V, L),
-    {
-        let package = register.get_package_version(package_id).ok_or(TreeError::NotFound(package_id.clone()))?;
-        let children: Vec<Node<V, L>> =
-            package.dependencies.iter().map(|d| Node::new_impl(&d, register, value_closure)).collect::<Result<Vec<_>>>()?;
-
-        let (value, label) = value_closure(package_id);
-
-        Ok(Self {
-            id: package_id.clone(),
-            value,
-            children,
-            label,
-        })
+impl<E, P, T, V, L: Eq> TreeBuilder<E, P, T, V, L>
+where
+    E: Fn(&Node<V, L>) -> Result<Vec<T>>,
+    P: Fn(T) -> Result<(PackageId, V, L)>,
+{
+    pub fn new() -> Self {
+        Self {
+            root: None,
+            expander: None,
+            populator: None,
+        }
     }
 
-    /// A wrapper method to create a tree with nodes that hold values.
-    pub fn new_with_value<F>(package_id: &PackageId, register: &PackageRegister, value_closure: F) -> Result<Self>
+    pub fn expander(mut self, expander: E) -> Self {
+        self.expander = Some(expander);
+        self
+    }
+
+    pub fn populator(mut self, populator: P) -> Self {
+        self.populator = Some(populator);
+        self
+    }
+
+    pub fn root(mut self, package_id: PackageId, value: V, label: L) -> Self {
+        self.root = Some(Node {
+            id: package_id,
+            value,
+            children: Vec::new(),
+            label,
+        });
+
+        self
+    }
+
+    pub fn build(self) -> Result<Node<V, L>> {
+        let mut root = match self.root {
+            Some(root) => root,
+            None => return Err(TreeError::MissingBuildAttributes("root".to_string())),
+        };
+
+        let expander = match &self.expander {
+            Some(expander) => expander,
+            None => return Err(TreeError::MissingBuildAttributes("expander".to_string())),
+        };
+
+        let populator = match &self.populator {
+            Some(populator) => populator,
+            None => return Err(TreeError::MissingBuildAttributes("populator".to_string())),
+        };
+
+        root.expand(&expander, &populator)?;
+        Ok(root)
+    }
+}
+
+/// Generic node implementation.
+impl<V, L: Eq> Node<V, L> {
+    pub fn expand<E, P, T>(&mut self, expander: &E, populator: &P) -> Result<()>
     where
-        F: Fn(&PackageId) -> (V, L),
+        E: Fn(&Node<V, L>) -> Result<Vec<T>>,
+        P: Fn(T) -> Result<(PackageId, V, L)>,
     {
-        Self::new_impl(package_id, register, &value_closure)
+        for child in expander(&self)? {
+            let (id, value, label) = populator(child)?;
+            let mut child_node = Node {
+                id,
+                value,
+                children: Vec::new(),
+                label,
+            };
+
+            child_node.expand(expander, populator)?;
+            self.children.push(child_node);
+        }
+
+        Ok(())
     }
 
     /// The implementation of the tree display.
@@ -129,120 +183,25 @@ impl<V, L: Eq> Node<V, L> {
     }
 }
 
+pub type EmptyNode = Node<(), ()>;
+
 /// An empty node implementation (node without values or labels).
-impl Node<(), ()> {
-    pub fn new(package_id: &PackageId, register: &PackageRegister) -> Result<Self> {
-        Node::new_impl(package_id, register, &|_| ((), ()))
-    }
-}
-
-/// A node implementation based on metadata instead of installed packages. Meant specifically for that installer.
-impl Node<Option<InstallMeta>, DependencyTypes> {
-    /// Creates a tree based on metadata with the given package id as root.
-    /// If include_build is true the build dependencies are included in the tree (with the appropriate labels).
-    fn new_from_meta_impl(
-        package_id: &PackageId,
-        install_meta: InstallMeta,
-        manager: &RepositoryManager,
-        register: &PackageRegister,
-        label: DependencyTypes,
-        include_build: bool,
-    ) -> Result<Self> {
-        let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
-        let dependencies = install_meta.version_metadata.dependencies.iter().chain(target.dependencies.iter());
-
-        // Also add build dependencies if include build is true
-        let children = match include_build {
-            true => install_meta
-                .version_metadata
-                .build_dependencies
-                .iter()
-                .chain(target.build_dependencies.iter())
-                .map(|d| Self::new_from_dependency(manager, register, d, DependencyTypes::Build, include_build))
-                .chain(dependencies.map(|d| Self::new_from_dependency(manager, register, d, label.clone(), include_build)))
-                .collect::<Result<_>>()?,
-            false => dependencies
-                .into_iter()
-                .map(|d| Self::new_from_dependency(manager, register, d, DependencyTypes::Normal, include_build))
-                .collect::<Result<_>>()?,
-        };
-
-        Ok(Self {
-            id: package_id.clone(),
-            value: Some(install_meta),
-            children,
-            label,
-        })
+impl EmptyNode {
+    pub fn build_simple(package_id: PackageId, register: &PackageRegister) -> Result<EmptyNode> {
+        TreeBuilder::new()
+            .root(package_id, (), ())
+            .expander(|p| EmptyNode::expander(p, register))
+            .populator(EmptyNode::populator)
+            .build()
     }
 
-    /// A wrapper method which creates the metadata dependency tree without build dependencies.
-    pub fn new_from_meta(
-        package_id: &PackageId,
-        install_meta: InstallMeta,
-        manager: &RepositoryManager,
-        register: &PackageRegister,
-    ) -> Result<Self> {
-        Self::new_from_meta_impl(package_id, install_meta, manager, register, DependencyTypes::Normal, false)
+    fn expander(parent: &EmptyNode, register: &PackageRegister) -> Result<Vec<PackageId>> {
+        let package = register.get_package_version(parent.get_id()).ok_or(TreeError::NotFound(parent.get_id().clone()))?;
+        Ok(package.dependencies.iter().cloned().collect())
     }
 
-    /// A wrapper method which creates the metadata dependency tree with build dependencies.
-    pub fn new_from_meta_build(
-        package_id: &PackageId,
-        install_meta: InstallMeta,
-        manager: &RepositoryManager,
-        register: &PackageRegister,
-    ) -> Result<Self> {
-        Self::new_from_meta_impl(package_id, install_meta, manager, register, DependencyTypes::Normal, true)
-    }
-
-    /// Expands a node with its build dependencies after initial creation of the tree.
-    /// Note that this only applies for the build dependencies of the current node, the
-    /// dependencies of the current node will be satisfied with pre-builds.
-    pub fn expand_node_with_build(&mut self, manager: &RepositoryManager, register: &PackageRegister) -> Result<()> {
-        let value = match &self.value {
-            Some(value) => value,
-            None => return Err(TreeError::ExpansionError),
-        };
-
-        let target = value.version_metadata.get_target(&value.target_bounds)?;
-        for dependency in value.version_metadata.build_dependencies.iter().chain(target.build_dependencies.iter()) {
-            self.children.push(Self::new_from_dependency(
-                manager,
-                register,
-                dependency,
-                DependencyTypes::Build,
-                false,
-            )?);
-        }
-
-        Ok(())
-    }
-
-    /// A helper method which does an often used recursion step. It creates the install meta from the dependency and then calls the new_from_meta_impl.
-    fn new_from_dependency(
-        manager: &RepositoryManager,
-        register: &PackageRegister,
-        dependency: &Dependency,
-        label: DependencyTypes,
-        include_build: bool,
-    ) -> Result<Node<Option<InstallMeta>, DependencyTypes>> {
-        // If the package is already satisfied don't expand the dependency tree further
-        if let Some(package) = register.get_latest_satisfying_package(dependency) {
-            return Ok(Node {
-                id: package.package_id.clone(),
-                value: None,
-                children: Vec::new(),
-                label,
-            });
-        }
-
-        // Use the latest version if the dependency is not yet satisfied
-        let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
-        let version = package_metadata.get_latest_dependency_version(&dependency, &Target::current())?;
-        let dependency_id = PackageId::new(dependency.get_name().clone(), version.clone());
-        let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
-        let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;
-        Self::new_from_meta_impl(&dependency_id, install_meta, manager, register, label, include_build)
+    fn populator(package_id: PackageId) -> Result<(PackageId, (), ())> {
+        Ok((package_id, (), ()))
     }
 }
 


### PR DESCRIPTION
- There is now a tree builder which builds the tree with help of a generic expander and populator.
- The logic for the install tree is now separated from the generic tree struct in the util.
- There are now two build flags, --build and --build-all (to also build dependencies from source).