### PR TITLE
Prettier (error) logging

### DIFF
--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -49,6 +49,7 @@ impl HandleCommand for InstallArgs {
             let mut duplicate_string = String::new();
             for duplicate in duplicates {
                 duplicate_string.push_str(&duplicate.to_string());
+                duplicate_string.push(' ');
             }
 
             error!(msg: "Duplicate package arguments are not allowed. The following duplicates were found: {duplicate_string}");
@@ -80,8 +81,9 @@ impl HandleCommand for InstallArgs {
 
         // Install all packages
         for package_id in &self.packages {
-            if let Err(error) = installer.install(&package_id) {
-                error!(error, "Cannot install package {package_id}");
+            match installer.install(&package_id) {
+                Ok(installed_package) => println!("Successfully installed {installed_package}"),
+                Err(error) => error!(error, "Cannot install package {package_id}"),
             }
         }
 

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -1,3 +1,5 @@
+use std::process::exit;
+
 use clap::Args;
 
 use crate::{
@@ -6,7 +8,7 @@ use crate::{
     installer::{InstallType, Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::unwrap_or_exit::UnwrapOrExit,
+    utils::{duplicates, unwrap_or_exit::UnwrapOrExit},
 };
 
 /// Installs the specified packages, if a version is given that version will be installed,
@@ -41,6 +43,18 @@ pub struct InstallArgs {
 
 impl HandleCommand for InstallArgs {
     fn handle(&self) {
+        // Check for duplicates, because installing twice will result in a confusing error
+        let duplicates = duplicates::get_duplicates(&self.packages);
+        if !duplicates.is_empty() {
+            let mut duplicate_string = String::new();
+            for duplicate in duplicates {
+                duplicate_string.push_str(&duplicate.to_string());
+            }
+
+            error!(msg: "Duplicate package arguments are not allowed. The following duplicates were found: {duplicate_string}");
+            exit(1);
+        }
+
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);
@@ -63,7 +77,6 @@ impl HandleCommand for InstallArgs {
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)
-        // TODO: check for duplicate packages in Vec
 
         // Install all packages
         for package_id in &self.packages {

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -15,7 +15,7 @@ use crate::{
 #[derive(Args, Debug)]
 pub struct InstallArgs {
     /// The name of the packages to install, with an optional version specified with NAME@VERSION
-    #[arg(num_args(0..))]
+    #[arg(required = true)]
     pub packages: Vec<OptionalPackageId>,
 
     /// True to build from source locally, false to use a prebuild version

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -39,6 +39,10 @@ pub struct InstallArgs {
     /// Flag to keep build dependencies after building from source
     #[arg(long, default_value = "false")]
     pub keep_build: bool,
+
+    /// True if verbose information should be shown
+    #[arg(short, long, default_value = "false")]
+    verbose: bool,
 }
 
 impl HandleCommand for InstallArgs {
@@ -74,7 +78,8 @@ impl HandleCommand for InstallArgs {
             .install_type(install_type)
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
-            .keep_build(self.keep_build);
+            .keep_build(self.keep_build)
+            .verbose(self.verbose);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -99,5 +99,7 @@ impl HandleCommand for LinkArgs {
 
         // Save package register
         register.save_to(&register_path).unwrap_or_exit(1);
+
+        println!("Successfully linked {}", self.package_name);
     }
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -1,7 +1,10 @@
 use clap::Args;
 
 use crate::{
-    cli::commands::HandleCommand, config::Config, storage::package_register::PackageRegister, utils::unwrap_or_exit::UnwrapOrExit,
+    cli::commands::HandleCommand,
+    config::Config,
+    storage::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Lists all the installed packages.
@@ -15,7 +18,9 @@ impl HandleCommand for ListArgs {
         let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        for package in register.iterate_all() {
+        let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();
+        packages.sort_by(|a, b| a.package_id.to_string().cmp(&b.package_id.to_string()));
+        for package in packages {
             println!("{}", package.package_id);
         }
     }

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -65,5 +65,10 @@ impl HandleCommand for SwitchArgs {
 
         // Save package register
         register.save_to(&register_path).unwrap_or_exit(1);
+
+        println!(
+            "Successfully switched '{}' active version to {}",
+            self.package_name, self.package_version
+        )
     }
 }

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -14,8 +14,8 @@ use crate::{
 /// versions installed. Multiple packages can be specified by entering multiple names, split by a space.
 #[derive(Args, Debug)]
 pub struct UninstallArgs {
-    /// The name of the packages to install, with an optional version specified with NAME@VERSION
-    #[arg(num_args(0..))]
+    /// The names of the packages to install, with an optional version specified with NAME@VERSION
+    #[arg(required = true)]
     pub packages: Vec<OptionalPackageId>,
 }
 

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -1,3 +1,5 @@
+use std::process::exit;
+
 use clap::Args;
 
 use crate::{
@@ -6,7 +8,7 @@ use crate::{
     installer::{Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::unwrap_or_exit::UnwrapOrExit,
+    utils::{duplicates, unwrap_or_exit::UnwrapOrExit},
 };
 
 /// Uninstalls the specified packages, if a version is given that version will be uninstalled, if not,
@@ -21,6 +23,18 @@ pub struct UninstallArgs {
 
 impl HandleCommand for UninstallArgs {
     fn handle(&self) {
+        // Check for duplicates, because uninstalling twice will result in a confusing error
+        let duplicates = duplicates::get_duplicates(&self.packages);
+        if !duplicates.is_empty() {
+            let mut duplicate_string = String::new();
+            for duplicate in duplicates {
+                duplicate_string.push_str(&duplicate.to_string());
+            }
+
+            error!(msg: "Duplicate package arguments are not allowed. The following duplicates were found: {duplicate_string}");
+            exit(1);
+        }
+
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
         let register_dir = PackageRegister::get_default_path(&config);

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -16,7 +16,7 @@ use crate::{
 /// versions installed. Multiple packages can be specified by entering multiple names, split by a space.
 #[derive(Args, Debug)]
 pub struct UninstallArgs {
-    /// The names of the packages to install, with an optional version specified with NAME@VERSION
+    /// The names of the packages to install, with an optional version specified with `<name>[@version]`.
     #[arg(required = true)]
     pub packages: Vec<OptionalPackageId>,
 }
@@ -29,6 +29,7 @@ impl HandleCommand for UninstallArgs {
             let mut duplicate_string = String::new();
             for duplicate in duplicates {
                 duplicate_string.push_str(&duplicate.to_string());
+                duplicate_string.push(' ');
             }
 
             error!(msg: "Duplicate package arguments are not allowed. The following duplicates were found: {duplicate_string}");
@@ -44,8 +45,16 @@ impl HandleCommand for UninstallArgs {
 
         // Uninstall all specified packages
         for optional_id in &self.packages {
-            if let Err(error) = installer.uninstall(&optional_id) {
-                error!(error, "Cannot uninstall package {optional_id}");
+            match installer.uninstall(&optional_id) {
+                Ok(uninstalled_packages) => {
+                    let mut uninstalled_string = String::new();
+                    for package in uninstalled_packages {
+                        uninstalled_string.push_str(&package.to_string());
+                        uninstalled_string.push(' ');
+                    }
+                    println!("Successfully uninstalled: {uninstalled_string}");
+                },
+                Err(error) => error!(error, "Cannot uninstall package {optional_id}"),
             }
         }
 

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -37,6 +37,8 @@ impl HandleCommand for UnlinkArgs {
             .unlink_package(&mut register, &self.package_name)
             .unwrap_or_exit_msg("Unable to unlink package", 1);
 
+        println!("Successfully unlinked {}", self.package_name);
+
         // Save package register
         register.save_to(&register_path).unwrap_or_exit(1);
     }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -49,7 +49,9 @@ impl HandleCommand for UpdateArgs {
         let options = InstallerOptions::default().skip_active(true).skip_symlinking(true);
         let mut installer = Installer::new(&config, &mut register, &manager, options);
 
-        installer.update(&self.optional_id, new_version).unwrap_or_exit(1);
+        let new_package_id = installer.update(&self.optional_id, new_version).unwrap_or_exit(1);
+
+        println!("Successfully updated {} to {new_package_id}", self.optional_id);
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);

--- a/src/cli/display/logging.rs
+++ b/src/cli/display/logging.rs
@@ -69,6 +69,11 @@ pub fn debug_impl(message: std::fmt::Arguments) {
     log_impl("DEBUG".blue().to_string(), message);
 }
 
+pub fn debug_error_impl<T: Error>(message: std::fmt::Arguments, error: T) {
+    let message = format_args!("{message}\nCaused by: {}", trace_error(error));
+    log_impl("DEBUG ERROR".purple().to_string(), message);
+}
+
 pub static DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| match std::env::var("PACKIT_DEBUG") {
     Ok(value) => value == "true" || value == "1",
     Err(_) => false,
@@ -76,6 +81,11 @@ pub static DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| match std::env::var(
 
 /// Macro for displaying debug information. Only shows info when debug is enabled.
 macro_rules! debug {
+    ($error:expr, $($arg:tt)*) => {
+        if *$crate::cli::display::logging::DEBUG_ENABLED {
+            $crate::cli::display::logging::debug_error_impl(format_args!($($arg)*), $error);
+        }
+    };
     ($($arg:tt)*) => {
         if *$crate::cli::display::logging::DEBUG_ENABLED {
             $crate::cli::display::logging::debug_impl(format_args!($($arg)*));
@@ -83,12 +93,3 @@ macro_rules! debug {
     };
 }
 pub(crate) use debug;
-
-macro_rules! debug_error {
-    ($($arg:tt)*) => {
-        if *$crate::cli::display::logging::DEBUG_ENABLED {
-            error!($($arg)*);
-        }
-    };
-}
-pub(crate) use debug_error;

--- a/src/cli/display/logging.rs
+++ b/src/cli/display/logging.rs
@@ -83,3 +83,12 @@ macro_rules! debug {
     };
 }
 pub(crate) use debug;
+
+macro_rules! debug_error {
+    ($($arg:tt)*) => {
+        if *$crate::cli::display::logging::DEBUG_ENABLED {
+            error!($($arg)*);
+        }
+    };
+}
+pub(crate) use debug_error;

--- a/src/cli/display/progressbar.rs
+++ b/src/cli/display/progressbar.rs
@@ -8,13 +8,12 @@ pub struct ProgressBar {
 
 impl ProgressBar {
     /// Creates a new progress bar with the given size.
-    pub fn new(size: u64) -> Self {
+    pub fn new(size: u64, prefix: String) -> Self {
         let bar = IndicatifProgressBar::new(size);
 
         // Set the style of the progress bar
-        let style = ProgressStyle::with_template("[{wide_bar:.white}] [{percent}%]")
-            .expect("Expected template to be correct.")
-            .progress_chars("=> ");
+        let template = format!("{prefix} [{{wide_bar:.white}}] [{{percent}}%]");
+        let style = ProgressStyle::with_template(&template).expect("Expected template to be correct.").progress_chars("=> ");
         bar.set_style(style);
 
         Self { bar, size }

--- a/src/cli/display/reader.rs
+++ b/src/cli/display/reader.rs
@@ -11,10 +11,10 @@ pub struct ReaderWithProgress<R: Read + Seek> {
 
 impl<R: Read + Seek> ReaderWithProgress<R> {
     /// Creates a new reader with a progress bar.
-    pub fn new(reader: R, size: u64, prefix: String) -> Self {
+    pub fn new(reader: R, size: u64, bar_prefix: String) -> Self {
         Self {
             reader,
-            bar: ProgressBar::new(size, prefix),
+            bar: ProgressBar::new(size, bar_prefix),
             total: 0,
         }
     }

--- a/src/cli/display/reader.rs
+++ b/src/cli/display/reader.rs
@@ -11,10 +11,10 @@ pub struct ReaderWithProgress<R: Read + Seek> {
 
 impl<R: Read + Seek> ReaderWithProgress<R> {
     /// Creates a new reader with a progress bar.
-    pub fn new(reader: R, size: u64) -> Self {
+    pub fn new(reader: R, size: u64, prefix: String) -> Self {
         Self {
             reader,
-            bar: ProgressBar::new(size),
+            bar: ProgressBar::new(size, prefix),
             total: 0,
         }
     }

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -163,7 +163,7 @@ impl<'a> Builder<'a> {
         let script_path = install_meta.version_metadata.get_build_script_path(&install_meta.target_bounds)?;
         let script_path = scripts::download_script(self.repository_manager, &script_path, &package_name, &install_meta.repository_id)?
             .ok_or(ScriptError::ScriptNotFound("build".into()))?;
-        let script_data = ScriptData::new(&script_path, &destination_dir, &version, self.config, &script_args);
+        let script_data = ScriptData::new(&script_path, &destination_dir, &version, self.config, &script_args, self.verbose);
 
         // Show build spinner
         let spinner = Spinner::new();
@@ -171,7 +171,7 @@ impl<'a> Builder<'a> {
         spinner.show(spinner_message.clone());
 
         // Run build script
-        scripts::run_build_script(&script_data, &unpack_directory, env, self.verbose)?;
+        scripts::run_build_script(&script_data, &unpack_directory, env)?;
 
         // Finish build spinner
         spinner.finish(format!("{spinner_message} successful"));

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -53,15 +53,17 @@ pub struct Builder<'a> {
     config: &'a Config,
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
+    verbose: bool,
 }
 
 impl<'a> Builder<'a> {
     /// Creates new builder
-    pub fn new(config: &'a Config, register: &'a mut PackageRegister, repository_manager: &'a RepositoryManager) -> Self {
+    pub fn new(config: &'a Config, register: &'a mut PackageRegister, repository_manager: &'a RepositoryManager, verbose: bool) -> Self {
         Self {
             config,
             register,
             repository_manager,
+            verbose,
         }
     }
 
@@ -168,7 +170,16 @@ impl<'a> Builder<'a> {
             .ok_or(ScriptError::ScriptNotFound("build".into()))?;
         let script_data = ScriptData::new(&script_path, &destination_dir, &version, self.config, &script_args);
 
-        scripts::run_build_script(&script_data, &unpack_directory, env)?;
+        // Show build spinner
+        let spinner = Spinner::new();
+        let spinner_message = format!("Building {package_name}@{version}");
+        spinner.show(spinner_message.clone());
+
+        // Run build script
+        scripts::run_build_script(&script_data, &unpack_directory, env, self.verbose)?;
+
+        // Finish build spinner
+        spinner.finish(format!("{spinner_message} successful"));
 
         Ok(())
     }

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -114,7 +114,7 @@ impl<'a> Builder<'a> {
 
         // Show download spinner
         let spinner = Spinner::new();
-        spinner.show(format!("Downloading {package_name}"));
+        spinner.show(format!("Downloading {package_name} from {}", &source.url));
 
         // Download the build files
         let mut response = reqwest::blocking::get(&source.url)?;
@@ -140,11 +140,16 @@ impl<'a> Builder<'a> {
         }
 
         // Finish download spinner
-        spinner.finish(format!("Downloading {package_name} successful"));
+        spinner.finish(format!("Downloading {package_name} from {} successful", &source.url));
 
         // Unpack the package to the temp directory
         let unpack_directory = TempDir::new()?;
-        unpack(ArchiveExtension::from_path(&source.url), bytes, &unpack_directory)?;
+        unpack(
+            package_name.to_string(),
+            ArchiveExtension::from_path(&source.url),
+            bytes,
+            &unpack_directory,
+        )?;
 
         // Create build env
         let env = BuildEnv::new(

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -146,12 +146,7 @@ impl<'a> Builder<'a> {
 
         // Unpack the package to the temp directory
         let unpack_directory = TempDir::new()?;
-        unpack(
-            package_name.to_string(),
-            ArchiveExtension::from_path(&source.url),
-            bytes,
-            &unpack_directory,
-        )?;
+        unpack(package_name, ArchiveExtension::from_path(&source.url), bytes, &unpack_directory)?;
 
         // Create build env
         let env = BuildEnv::new(

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -1,6 +1,6 @@
 use crate::{
     cli::display::{
-        QuestionResponse, ask_user,
+        QuestionResponse, Spinner, ask_user,
         logging::{error, warning},
     },
     config::{Config, Repository},
@@ -337,8 +337,16 @@ impl<'a> Installer<'a> {
     /// Downloads a package pre-build and unpacks it into the given destination directory.
     /// Returns an `InstallerError::ChecksumError` if the pre-build checksum doesn't match.
     fn download_prebuild(&self, repository_id: &str, package: &PackageId, revision: u64, destination_dir: impl AsRef<Path>) -> Result<()> {
+        // Show download spinner
+        let spinner = Spinner::new();
+        let spinner_message = format!("Downloading {} prebuild from '{}'", &package.name, repository_id);
+        spinner.show(spinner_message.clone());
+
         let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &Target::current())?;
         let checksum = self.repository_manager.get_prebuild_checksum(repository_id, package, revision, &Target::current())?;
+
+        // Finish download spinner
+        spinner.finish(format!("{spinner_message} successful"));
 
         // Calculate the checksum
         let calculated_checksum = Checksum::from_bytes(&bytes);
@@ -350,7 +358,7 @@ impl<'a> Installer<'a> {
         }
 
         // Unpack the prebuild to the destination
-        unpack(extension, bytes, &destination_dir)?;
+        unpack(package.name.to_string(), extension, bytes, &destination_dir)?;
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -374,7 +374,7 @@ impl<'a> Installer<'a> {
 
     /// Uninstalls a package version if specified, otherwise it will uninstall the entire package directory (after
     /// asking the user if this is the intended behaviour).
-    /// Returns a `PackageId` from the installed package if successful.
+    /// Returns a `Vec<PackageId>` from the uninstalled packages if successful.
     /// Returns an `InstallerError::PermissionsError` error if the current user doesn't have the correct permissions
     /// or an `InstallerError::DependencyError` error if the given package is a dependency.
     pub fn uninstall(&mut self, optional_id: &OptionalPackageId) -> Result<Vec<PackageId>> {
@@ -402,7 +402,7 @@ impl<'a> Installer<'a> {
     }
 
     /// Uninstalls a specific package. If it is the only installed version the entire package directory is removed as well.
-    /// Returns a `PackageId` from the installed package if successful.
+    /// Returns a `Vec<PackageId>` from the uninstalled packages if successful.
     /// Return an `InstallerError::PackageNotFound` error if a package cannot be found. Contains an `InstallerError::UnreachableError`
     /// which as its name suggests should be unreachable.
     fn uninstall_single(&mut self, package_id: PackageId) -> Result<Vec<PackageId>> {
@@ -455,14 +455,19 @@ impl<'a> Installer<'a> {
             other_versions.sort_by_key(|x| &x.package_id.version);
 
             if let Some(newest) = other_versions.last() {
+                println!("Set active package to version `{}`", newest.package_id);
                 Symlinker::new(self.config).set_active(self.register, &newest.package_id.clone(), installed_package.symlinked)?;
             }
         }
 
         // Delete the determined directory
+        if let Some(directory) = directory.to_str() {
+            println!("Remove the package directory: {directory}");
+        }
         fs::remove_dir_all(directory)?;
 
-        // Remove package from installed package toml
+        // Remove package from the register
+        println!("Remove {package_id} from the package register");
         self.register.remove_package_version(&package_id);
 
         Ok(vec![package_id])
@@ -470,7 +475,7 @@ impl<'a> Installer<'a> {
 
     /// Uninstalls an entire package directory. The user is first asked if this is
     /// the intended behaviour (this is skipped if only one version exists).
-    /// Returns a `PackageId` from the installed package if successful.
+    /// Returns a `Vec<PackageId>` from the uninstalled packages if successful.
     /// Returns an `InstallerError::PackageNotFound` error if the package cannot be found.
     fn uninstall_all(&mut self, package_name: &PackageName) -> Result<Vec<PackageId>> {
         let installed_versions = self.register.get_all_package_versions(package_name);
@@ -495,6 +500,7 @@ impl<'a> Installer<'a> {
         let directory = self.config.prefix_directory.join("packages").join(&package_name);
 
         // Remove active path symlink
+        println!("Unlink the active path");
         let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
         match active_path.exists() {
             true => symlink::remove_symlink(&active_path)?,
@@ -504,6 +510,7 @@ impl<'a> Installer<'a> {
         // Check if package was symlinked
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
+                println!("Unlink '{package_name}'");
                 io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
             }
         }
@@ -517,11 +524,15 @@ impl<'a> Installer<'a> {
             self.run_uninstall_script(&repository, &package_version.package_id, &directory)?;
         }
 
+        if let Some(directory) = directory.to_str() {
+            println!("Remove the package directory: {directory}");
+        }
         fs::remove_dir_all(directory)?;
 
         let uninstalled = installed_versions.iter().map(|p| p.package_id.clone()).collect();
 
         // Delete the installed package from toml
+        println!("Remove {package_name} from the package register");
         self.register.remove_package(package_name);
 
         Ok(uninstalled)
@@ -573,9 +584,10 @@ impl<'a> Installer<'a> {
     }
 
     /// Updates a package to a newer version.
+    /// Returns a `PackageId` from the updated package if successful.
     /// Returns an `InstallerError::VersionTooLowError` if the old version is newer then the given new version
     /// or an `InstallerError::AlreadyInstalledError` if the new package version is already installed.
-    pub fn update(&mut self, optional_id: &OptionalPackageId, new_version: &Version) -> Result<()> {
+    pub fn update(&mut self, optional_id: &OptionalPackageId, new_version: &Version) -> Result<PackageId> {
         let old_package = self.get_specific_package_update(optional_id)?;
         let new_package_id = PackageId::new(old_package.package_id.name.clone(), new_version.clone());
 
@@ -661,7 +673,7 @@ impl<'a> Installer<'a> {
         // Uninstall the package
         self.uninstall(&old_package_id.into())?;
 
-        Ok(())
+        Ok(new_package_id)
     }
 
     /// Gets a specific installed package version. If a version is specified that version is used.

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -1,7 +1,7 @@
 use crate::{
     cli::display::{
         QuestionResponse, Spinner, ask_user,
-        logging::{error, warning},
+        logging::{debug, error, warning},
     },
     config::{Config, Repository},
     installer::{
@@ -57,8 +57,11 @@ impl<'a> Installer<'a> {
     }
 
     /// Installs the given package and its dependencies.
+    /// Returns a `PackageId` from the installed package if successful.
     /// Returns an `InstallerError::PermissionsError` if the current user doesn't have the correct permissions.
-    pub fn install(&mut self, optional_id: &OptionalPackageId) -> Result<()> {
+    /// Returns an `InstallerError::AlreadyInstalledError` if the package already exists.
+    /// Returns an `InstallerError::InstallationCanceled` if the installation is canceled.
+    pub fn install(&mut self, optional_id: &OptionalPackageId) -> Result<PackageId> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
@@ -71,15 +74,17 @@ impl<'a> Installer<'a> {
         if optional_id.version.is_none() {
             if let Some(package) = self.register.get_package(&optional_id.name) {
                 if package.get_package_version(latest_version).is_some() {
-                    println!("The latest version '{latest_version}' of '{optional_id}' is already installed.");
-                    return Ok(());
+                    let package_id = optional_id.versioned_or(latest_version.clone());
+                    return Err(InstallerError::AlreadyInstalledError { package_id });
                 }
 
                 let question = format!(
                     "The package '{optional_id}' is already installed, but a newer version '{latest_version}' is available. Do you wish to install the latest version as well?"
                 );
                 if ask_user(&question, QuestionResponse::No)?.is_no_or_invalid() {
-                    return Ok(());
+                    return Err(InstallerError::InstallationCanceled {
+                        reason: "A version of this package was already installed".to_string(),
+                    });
                 }
             }
         }
@@ -89,8 +94,7 @@ impl<'a> Installer<'a> {
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {
-            println!("Package '{}' already installed.", package_id);
-            return Ok(());
+            return Err(InstallerError::AlreadyInstalledError { package_id });
         }
 
         // Get package version info
@@ -108,19 +112,23 @@ impl<'a> Installer<'a> {
         let install_label = InstallLabel::new(self.options.install_type.clone(), false);
 
         // Create the install tree based on the install type
+        println!("Building dependency tree");
         let mut dependency_tree = TreeBuilder::new()
-            .root(package_id, Some(root_meta), install_label)
+            .root(package_id.clone(), Some(root_meta), install_label)
             .expander(InstallNode::expander)
             .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
             .build()?;
 
+        println!("Installing the following packages:");
+        println!("{dependency_tree}");
         self.install_nodes(&mut dependency_tree)?;
 
-        if !self.options.keep_build {
+        if !self.options.keep_build && self.options.install_type != InstallType::Prebuild {
+            println!("Removing build dependencies");
             self.remove_build_dependencies(&dependency_tree, true)?;
         }
 
-        Ok(())
+        Ok(package_id)
     }
 
     /// Installs all packages recursively. For each package the install type is considered.
@@ -324,6 +332,7 @@ impl<'a> Installer<'a> {
 
         // Don't remove the package if it's the root
         if !is_root {
+            println!("Remove build dependency {}", parent.get_id());
             self.uninstall(optional_id)?;
         }
 
@@ -353,7 +362,7 @@ impl<'a> Installer<'a> {
 
         // Check equality of checksum
         match checksum {
-            Some(checksum) if checksum == calculated_checksum => (),
+            Some(checksum) if checksum == calculated_checksum => debug!("{package} prebuild checksum matches"),
             _ => return Err(InstallerError::ChecksumError),
         }
 
@@ -365,9 +374,10 @@ impl<'a> Installer<'a> {
 
     /// Uninstalls a package version if specified, otherwise it will uninstall the entire package directory (after
     /// asking the user if this is the intended behaviour).
+    /// Returns a `PackageId` from the installed package if successful.
     /// Returns an `InstallerError::PermissionsError` error if the current user doesn't have the correct permissions
     /// or an `InstallerError::DependencyError` error if the given package is a dependency.
-    pub fn uninstall(&mut self, optional_id: &OptionalPackageId) -> Result<()> {
+    pub fn uninstall(&mut self, optional_id: &OptionalPackageId) -> Result<Vec<PackageId>> {
         // Check if we can write to the prefix directory
         if !self.can_write_prefix_dir()? {
             return Err(InstallerError::PermissionsError);
@@ -383,20 +393,21 @@ impl<'a> Installer<'a> {
         // This determines the directory to remove. If there are multiple versions and the version is
         // specified only the specified version directory will be deleted. The entire package directory
         // is deleted if the version isn't specified or if the package directory only contains one version.
-        match optional_id.versioned() {
-            Some(package_id) => self.uninstall_single(&package_id)?,
+        let uninstalled = match optional_id.versioned() {
+            Some(package_id) => self.uninstall_single(package_id)?,
             None => self.uninstall_all(&optional_id.name)?,
-        }
+        };
 
-        Ok(())
+        Ok(uninstalled)
     }
 
     /// Uninstalls a specific package. If it is the only installed version the entire package directory is removed as well.
+    /// Returns a `PackageId` from the installed package if successful.
     /// Return an `InstallerError::PackageNotFound` error if a package cannot be found. Contains an `InstallerError::UnreachableError`
     /// which as its name suggests should be unreachable.
-    fn uninstall_single(&mut self, package_id: &PackageId) -> Result<()> {
+    fn uninstall_single(&mut self, package_id: PackageId) -> Result<Vec<PackageId>> {
         // Return an existError if the package to uninstall doesn't exist
-        if self.register.get_package_version(package_id).is_none() {
+        if self.register.get_package_version(&package_id).is_none() {
             return Err(InstallerError::PackageNotFound {
                 package_name: package_id.name.to_string(),
                 version: Some(package_id.version.to_string()),
@@ -430,7 +441,7 @@ impl<'a> Installer<'a> {
         };
 
         // Run uninstall script
-        self.run_uninstall_script(&repository, package_id, &directory)?;
+        self.run_uninstall_script(&repository, &package_id, &directory)?;
 
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
@@ -452,22 +463,24 @@ impl<'a> Installer<'a> {
         fs::remove_dir_all(directory)?;
 
         // Remove package from installed package toml
-        self.register.remove_package_version(package_id);
+        self.register.remove_package_version(&package_id);
 
-        Ok(())
+        Ok(vec![package_id])
     }
 
     /// Uninstalls an entire package directory. The user is first asked if this is
     /// the intended behaviour (this is skipped if only one version exists).
+    /// Returns a `PackageId` from the installed package if successful.
     /// Returns an `InstallerError::PackageNotFound` error if the package cannot be found.
-    fn uninstall_all(&mut self, package_name: &PackageName) -> Result<()> {
+    fn uninstall_all(&mut self, package_name: &PackageName) -> Result<Vec<PackageId>> {
         let installed_versions = self.register.get_all_package_versions(package_name);
 
         // Ask the user if he/she wants to continue when version isn't specified and there are multiple versions installed
         let question = "Version is not specified, do you wish to uninstall all versions of this package?";
         if installed_versions.len() > 1 && ask_user(question, QuestionResponse::No)?.is_no_or_invalid() {
-            println!("Canceled uninstall of package: {package_name}");
-            return Ok(());
+            return Err(InstallerError::InstallationCanceled {
+                reason: format!("Prevent uninstall of all {package_name} versions"),
+            });
         }
 
         // Make sure at least one version exists
@@ -496,7 +509,7 @@ impl<'a> Installer<'a> {
         }
 
         // Run uninstall scripts for all versions
-        for package_version in installed_versions {
+        for package_version in &installed_versions {
             // Load source repository
             let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
 
@@ -506,10 +519,12 @@ impl<'a> Installer<'a> {
 
         fs::remove_dir_all(directory)?;
 
+        let uninstalled = installed_versions.iter().map(|p| p.package_id.clone()).collect();
+
         // Delete the installed package from toml
         self.register.remove_package(package_name);
 
-        Ok(())
+        Ok(uninstalled)
     }
 
     /// Downloads and runs the uninstall script of a given package.

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -210,7 +210,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_pre_script(&script_data, &install_directory, self.options.verbose)?;
+            scripts::run_pre_script(&script_data, &install_directory)?;
         }
 
         // Get source repository for installed storage before actually installing package
@@ -251,7 +251,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_post_script(&script_data, self.options.verbose)?;
+            scripts::run_post_script(&script_data)?;
         }
 
         self.determine_active(install_meta, &package_id, target)?;
@@ -262,7 +262,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_test_script(&script_data, self.options.verbose)?;
+            scripts::run_test_script(&script_data)?;
         }
 
         Ok(())
@@ -368,7 +368,7 @@ impl<'a> Installer<'a> {
         }
 
         // Unpack the prebuild to the destination
-        unpack(package.name.to_string(), extension, bytes, &destination_dir)?;
+        unpack(&package.name, extension, bytes, &destination_dir)?;
 
         Ok(())
     }
@@ -463,12 +463,12 @@ impl<'a> Installer<'a> {
 
         // Delete the determined directory
         if let Some(directory) = directory.to_str() {
-            debug!("Remove the package directory: {directory}");
+            debug!("Removing the package directory: {directory}");
         }
         fs::remove_dir_all(directory)?;
 
         // Remove package from the register
-        debug!("Remove {package_id} from the package register");
+        debug!("Removing {package_id} from the package register");
         self.register.remove_package_version(&package_id);
 
         Ok(vec![package_id])
@@ -501,7 +501,7 @@ impl<'a> Installer<'a> {
         let directory = self.config.prefix_directory.join("packages").join(&package_name);
 
         // Remove active path symlink
-        debug!("Unlink the active path");
+        debug!("Unlinking the active path");
         let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
         match active_path.exists() {
             true => symlink::remove_symlink(&active_path)?,
@@ -511,7 +511,7 @@ impl<'a> Installer<'a> {
         // Check if package was symlinked
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
-                debug!("Unlink '{package_name}'");
+                debug!("Unlinking '{package_name}'");
                 io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
             }
         }
@@ -526,14 +526,14 @@ impl<'a> Installer<'a> {
         }
 
         if let Some(directory) = directory.to_str() {
-            debug!("Remove the package directory: {directory}");
+            debug!("Removing the package directory: {directory}");
         }
         fs::remove_dir_all(directory)?;
 
         let uninstalled = installed_versions.iter().map(|p| p.package_id.clone()).collect();
 
         // Delete the installed package from toml
-        debug!("Remove {package_name} from the package register");
+        debug!("Removing {package_name} from the package register");
         self.register.remove_package(package_name);
 
         Ok(uninstalled)
@@ -572,7 +572,7 @@ impl<'a> Installer<'a> {
             // Run script
             let script_args = package_version.get_script_args(&target_bounds)?;
             let script_data = ScriptData::new(&script_path, &install_directory, &package_id.version, self.config, &script_args);
-            scripts::run_uninstall_script(&script_data, self.options.verbose)?
+            scripts::run_uninstall_script(&script_data)?
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -209,7 +209,14 @@ impl<'a> Installer<'a> {
         let downloaded_script =
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
-            let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
+            let script_data = ScriptData::new(
+                &script_file,
+                &install_directory,
+                &version_meta.version,
+                self.config,
+                &script_args,
+                self.options.verbose,
+            );
             scripts::run_pre_script(&script_data, &install_directory)?;
         }
 
@@ -250,7 +257,14 @@ impl<'a> Installer<'a> {
         let downloaded_script =
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
-            let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
+            let script_data = ScriptData::new(
+                &script_file,
+                &install_directory,
+                &version_meta.version,
+                self.config,
+                &script_args,
+                self.options.verbose,
+            );
             scripts::run_post_script(&script_data)?;
         }
 
@@ -261,7 +275,14 @@ impl<'a> Installer<'a> {
         let downloaded_script =
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
-            let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
+            let script_data = ScriptData::new(
+                &script_file,
+                &install_directory,
+                &version_meta.version,
+                self.config,
+                &script_args,
+                self.options.verbose,
+            );
             scripts::run_test_script(&script_data)?;
         }
 
@@ -571,7 +592,14 @@ impl<'a> Installer<'a> {
 
             // Run script
             let script_args = package_version.get_script_args(&target_bounds)?;
-            let script_data = ScriptData::new(&script_path, &install_directory, &package_id.version, self.config, &script_args);
+            let script_data = ScriptData::new(
+                &script_path,
+                &install_directory,
+                &package_id.version,
+                self.config,
+                &script_args,
+                self.options.verbose,
+            );
             scripts::run_uninstall_script(&script_data)?
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -210,7 +210,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_pre_script(&script_data, &install_directory)?;
+            scripts::run_pre_script(&script_data, &install_directory, self.options.verbose)?;
         }
 
         // Get source repository for installed storage before actually installing package
@@ -225,7 +225,8 @@ impl<'a> Installer<'a> {
                 let revision = install_meta.version_metadata.revisions.len() as u64;
                 self.download_prebuild(&install_meta.repository_id, &package_id, revision, &install_directory)?
             },
-            false => Builder::new(self.config, self.register, self.repository_manager).build(&install_meta, &install_directory)?,
+            false => Builder::new(self.config, self.register, self.repository_manager, self.options.verbose)
+                .build(&install_meta, &install_directory)?,
         }
 
         // Set correct permissions for the installed package
@@ -250,7 +251,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_post_script(&script_data)?;
+            scripts::run_post_script(&script_data, self.options.verbose)?;
         }
 
         self.determine_active(install_meta, &package_id, target)?;
@@ -261,7 +262,7 @@ impl<'a> Installer<'a> {
             scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
         if let Some(script_file) = downloaded_script {
             let script_data = ScriptData::new(&script_file, &install_directory, &version_meta.version, self.config, &script_args);
-            scripts::run_test_script(&script_data)?;
+            scripts::run_test_script(&script_data, self.options.verbose)?;
         }
 
         Ok(())
@@ -462,12 +463,12 @@ impl<'a> Installer<'a> {
 
         // Delete the determined directory
         if let Some(directory) = directory.to_str() {
-            println!("Remove the package directory: {directory}");
+            debug!("Remove the package directory: {directory}");
         }
         fs::remove_dir_all(directory)?;
 
         // Remove package from the register
-        println!("Remove {package_id} from the package register");
+        debug!("Remove {package_id} from the package register");
         self.register.remove_package_version(&package_id);
 
         Ok(vec![package_id])
@@ -500,7 +501,7 @@ impl<'a> Installer<'a> {
         let directory = self.config.prefix_directory.join("packages").join(&package_name);
 
         // Remove active path symlink
-        println!("Unlink the active path");
+        debug!("Unlink the active path");
         let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
         match active_path.exists() {
             true => symlink::remove_symlink(&active_path)?,
@@ -510,7 +511,7 @@ impl<'a> Installer<'a> {
         // Check if package was symlinked
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
-                println!("Unlink '{package_name}'");
+                debug!("Unlink '{package_name}'");
                 io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
             }
         }
@@ -525,14 +526,14 @@ impl<'a> Installer<'a> {
         }
 
         if let Some(directory) = directory.to_str() {
-            println!("Remove the package directory: {directory}");
+            debug!("Remove the package directory: {directory}");
         }
         fs::remove_dir_all(directory)?;
 
         let uninstalled = installed_versions.iter().map(|p| p.package_id.clone()).collect();
 
         // Delete the installed package from toml
-        println!("Remove {package_name} from the package register");
+        debug!("Remove {package_name} from the package register");
         self.register.remove_package(package_name);
 
         Ok(uninstalled)
@@ -571,7 +572,7 @@ impl<'a> Installer<'a> {
             // Run script
             let script_args = package_version.get_script_args(&target_bounds)?;
             let script_data = ScriptData::new(&script_path, &install_directory, &package_id.version, self.config, &script_args);
-            scripts::run_uninstall_script(&script_data)?
+            scripts::run_uninstall_script(&script_data, self.options.verbose)?
         }
 
         Ok(())

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -6,6 +6,7 @@ pub struct InstallerOptions {
     pub skip_symlinking: bool,
     pub skip_active: bool,
     pub keep_build: bool,
+    pub verbose: bool,
 }
 
 impl Default for InstallerOptions {
@@ -16,6 +17,7 @@ impl Default for InstallerOptions {
             skip_symlinking: false,
             skip_active: false,
             keep_build: false,
+            verbose: false,
         }
     }
 }
@@ -42,6 +44,11 @@ impl InstallerOptions {
     /// Sets the keep build field.
     pub fn keep_build(mut self, keep_build: bool) -> Self {
         self.keep_build = keep_build;
+        self
+    }
+
+    pub fn verbose(mut self, verbose: bool) -> Self {
+        self.verbose = verbose;
         self
     }
 }

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -77,37 +77,37 @@ impl<'a> ScriptData<'a> {
 
 /// Runs the given pre install script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Result<()> {
-    run_script(script_data, run_dir, Environment::new())
+pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, verbose: bool) -> Result<()> {
+    run_script(script_data, run_dir, Environment::new(), verbose)
 }
 
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv) -> Result<()> {
-    run_script(script_data, run_dir, build_env.into())
+pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, verbose: bool) -> Result<()> {
+    run_script(script_data, run_dir, build_env.into(), verbose)
 }
 
 /// Runs the given post install script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_post_script(script_data: &ScriptData) -> Result<()> {
-    run_script(script_data, &script_data.package_install_path, Environment::new())
+pub fn run_post_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
+    run_script(script_data, &script_data.package_install_path, Environment::new(), verbose)
 }
 
 /// Runs the given test script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_test_script(script_data: &ScriptData) -> Result<()> {
-    run_script(script_data, script_data.package_install_path, Environment::new())
+pub fn run_test_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
+    run_script(script_data, script_data.package_install_path, Environment::new(), verbose)
 }
 
 /// Runs the given uninstall script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_uninstall_script(script_data: &ScriptData) -> Result<()> {
-    run_script(script_data, script_data.package_install_path, Environment::new())
+pub fn run_uninstall_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
+    run_script(script_data, script_data.package_install_path, Environment::new(), verbose)
 }
 
 /// Runs the script at the given path, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environment) -> Result<()> {
+fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environment, verbose: bool) -> Result<()> {
     let path = to_absolute_path(&script_data.path)?;
 
     let package_install_path = to_absolute_path(script_data.package_install_path)?;
@@ -116,12 +116,15 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
     let mut command = create_command(path);
     command
         .current_dir(run_dir)
-        .stdout(Stdio::inherit())
-        .stderr(Stdio::inherit())
         .env("PACKIT_PREFIX_PATH", &script_data.config.prefix_directory)
         .env("PACKIT_TARGET", TargetArchitecture::current().to_string())
         .env("PACKIT_PACKAGE_PATH", package_install_path)
         .env("PACKIT_PACKAGE_VERSION", script_data.package_version.to_string());
+
+    // Only display build logging if verbose is enabled
+    if verbose {
+        command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+    }
 
     // Remove stripped environment variables
     for key in env.stripped_vars {

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -54,6 +54,7 @@ pub struct ScriptData<'a> {
     package_version: &'a Version,
     config: &'a Config,
     args: &'a HashMap<&'a str, &'a str>,
+    verbose: bool,
 }
 
 impl<'a> ScriptData<'a> {
@@ -64,6 +65,7 @@ impl<'a> ScriptData<'a> {
         package_version: &'a Version,
         config: &'a Config,
         args: &'a HashMap<&str, &str>,
+        verbose: bool,
     ) -> Self {
         Self {
             path,
@@ -71,6 +73,7 @@ impl<'a> ScriptData<'a> {
             package_version,
             config,
             args,
+            verbose,
         }
     }
 }
@@ -83,8 +86,8 @@ pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Re
 
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, verbose: bool) -> Result<()> {
-    run_script(script_data, run_dir, build_env.into(), verbose)
+pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv) -> Result<()> {
+    run_script(script_data, run_dir, build_env.into(), script_data.verbose)
 }
 
 /// Runs the given post install script, in the package install directory.
@@ -119,7 +122,8 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         .env("PACKIT_PREFIX_PATH", &script_data.config.prefix_directory)
         .env("PACKIT_TARGET", TargetArchitecture::current().to_string())
         .env("PACKIT_PACKAGE_PATH", package_install_path)
-        .env("PACKIT_PACKAGE_VERSION", script_data.package_version.to_string());
+        .env("PACKIT_PACKAGE_VERSION", script_data.package_version.to_string())
+        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" });
 
     // Only display build logging if verbose is enabled
     if show_output {

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -77,8 +77,8 @@ impl<'a> ScriptData<'a> {
 
 /// Runs the given pre install script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, verbose: bool) -> Result<()> {
-    run_script(script_data, run_dir, Environment::new(), verbose)
+pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Result<()> {
+    run_script(script_data, run_dir, Environment::new(), true)
 }
 
 /// Runs the given build script, in the given directory.
@@ -89,25 +89,25 @@ pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, bui
 
 /// Runs the given post install script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_post_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
-    run_script(script_data, &script_data.package_install_path, Environment::new(), verbose)
+pub fn run_post_script(script_data: &ScriptData) -> Result<()> {
+    run_script(script_data, &script_data.package_install_path, Environment::new(), true)
 }
 
 /// Runs the given test script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_test_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
-    run_script(script_data, script_data.package_install_path, Environment::new(), verbose)
+pub fn run_test_script(script_data: &ScriptData) -> Result<()> {
+    run_script(script_data, script_data.package_install_path, Environment::new(), true)
 }
 
 /// Runs the given uninstall script, in the package install directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_uninstall_script(script_data: &ScriptData, verbose: bool) -> Result<()> {
-    run_script(script_data, script_data.package_install_path, Environment::new(), verbose)
+pub fn run_uninstall_script(script_data: &ScriptData) -> Result<()> {
+    run_script(script_data, script_data.package_install_path, Environment::new(), true)
 }
 
 /// Runs the script at the given path, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environment, verbose: bool) -> Result<()> {
+fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environment, show_output: bool) -> Result<()> {
     let path = to_absolute_path(&script_data.path)?;
 
     let package_install_path = to_absolute_path(script_data.package_install_path)?;
@@ -122,7 +122,7 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         .env("PACKIT_PACKAGE_VERSION", script_data.package_version.to_string());
 
     // Only display build logging if verbose is enabled
-    if verbose {
+    if show_output {
         command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
     }
 

--- a/src/installer/unpack.rs
+++ b/src/installer/unpack.rs
@@ -48,13 +48,14 @@ impl ArchiveExtension {
     }
 }
 
-/// Unpacks files and saves them to the provided destination directory.
-pub fn unpack<P: AsRef<Path>>(extension: ArchiveExtension, bytes: Bytes, destination_directory: P) -> Result<()> {
+// Unpacks files and saves them to the provided destination directory.
+pub fn unpack<P: AsRef<Path>>(package: String, extension: ArchiveExtension, bytes: Bytes, destination_directory: P) -> Result<()> {
     let size = bytes.len();
     let cursor = Cursor::new(bytes);
 
     // Initialize progress bar
-    let reader = ReaderWithProgress::new(cursor, size as u64);
+    let bar_prefix = format!("Unpacking {package}");
+    let reader = ReaderWithProgress::new(cursor, size as u64, bar_prefix);
 
     match extension {
         ArchiveExtension::GZ => unpack_gz(reader, destination_directory),

--- a/src/installer/unpack.rs
+++ b/src/installer/unpack.rs
@@ -5,7 +5,7 @@ use tar::Archive;
 use thiserror::Error;
 use zip::ZipArchive;
 
-use crate::cli::display::ReaderWithProgress;
+use crate::{cli::display::ReaderWithProgress, installer::types::PackageName};
 
 /// The errors that occur during unpacking.
 #[derive(Error, Debug)]
@@ -49,7 +49,7 @@ impl ArchiveExtension {
 }
 
 // Unpacks files and saves them to the provided destination directory.
-pub fn unpack<P: AsRef<Path>>(package: String, extension: ArchiveExtension, bytes: Bytes, destination_directory: P) -> Result<()> {
+pub fn unpack<P: AsRef<Path>>(package: &PackageName, extension: ArchiveExtension, bytes: Bytes, destination_directory: P) -> Result<()> {
     let size = bytes.len();
     let cursor = Cursor::new(bytes);
 

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 
 use crate::{
-    cli::display::logging::{debug, debug_error, error, warning},
+    cli::display::logging::{debug, error, warning},
     config::Config,
     installer::{
         types::{PackageId, PackageName},
@@ -95,7 +95,7 @@ impl<'a> RepositoryManager<'a> {
             let package = match provider.read_package(package) {
                 Ok(package) => package,
                 Err(e) => {
-                    debug_error!(e, "Unable to read {package} from repository {repository_id}, continuing...",);
+                    debug!(e, "Unable to read {package} from repository {repository_id}, continuing...");
                     continue;
                 },
             };

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use bytes::Bytes;
 
 use crate::{
-    cli::display::logging::{debug, error, warning},
+    cli::display::logging::{debug, debug_error, error, warning},
     config::Config,
     installer::{
         types::{PackageId, PackageName},
@@ -95,7 +95,7 @@ impl<'a> RepositoryManager<'a> {
             let package = match provider.read_package(package) {
                 Ok(package) => package,
                 Err(e) => {
-                    error!(e, "Unable to read {package} from repository {repository_id}, continuing...");
+                    debug_error!(e, "Unable to read {package} from repository {repository_id}, continuing...",);
                     continue;
                 },
             };

--- a/src/utils/duplicates.rs
+++ b/src/utils/duplicates.rs
@@ -16,7 +16,9 @@ pub fn get_duplicates(packages: &Vec<OptionalPackageId>) -> HashSet<String> {
             continue;
         }
 
-        if packages.iter().any(|p| p.name == package.name) {
+        // Check if any of the packages have the same name.
+        // Also make sure not to match on the same package item in the vec by checking the pointer.
+        if packages.iter().any(|p| !std::ptr::eq(p, package) && p.name == package.name) {
             duplicates.insert(package.name.to_string());
         }
     }

--- a/src/utils/duplicates.rs
+++ b/src/utils/duplicates.rs
@@ -1,0 +1,25 @@
+use std::collections::HashSet;
+
+use crate::installer::types::OptionalPackageId;
+
+/// Gets all the duplicate package arguments. Packages are duplicate if they have the same name and version
+/// or if the version isn't specified on one of them, the package is also considered duplicate.
+pub fn get_duplicates(packages: &Vec<OptionalPackageId>) -> HashSet<String> {
+    let mut duplicates = HashSet::new();
+    let mut seen = HashSet::new();
+    for package in packages {
+        if let Some(package_version) = package.versioned() {
+            if !seen.insert(package_version) {
+                duplicates.insert(package.to_string());
+            }
+
+            continue;
+        }
+
+        if packages.iter().any(|p| p.name == package.name) {
+            duplicates.insert(package.name.to_string());
+        }
+    }
+
+    duplicates
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,4 +1,5 @@
 pub mod constants;
+pub mod duplicates;
 pub mod env;
 pub mod io;
 pub mod tree;


### PR DESCRIPTION
Adds several styling features:
- Print packages alphabetically in the list command
- Add debug errors, so there aren't too many (unnecessary) errors.
- Create more detailed logging in the install and uninstall methods.
- Add success message to link, unlink, update, install and uninstall commands.
- A verbose mode for the build, so build logging is only done with it enabled. It now has a spinner.

Small bugfix:
- An (un)install with multiple packages should have at least one package argument, this is now enforced.

Small feature:
- Duplicates are now not allowed anymore in the (un)install package arguments.