### PR TITLE
Implement binary patching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,15 +95,16 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "aquamarine"
-version = "0.1.12"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
+checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
 dependencies = [
- "itertools 0.9.0",
- "proc-macro-error",
+ "include_dir",
+ "itertools",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -121,8 +122,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 [[package]]
 name = "autocxx"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba64dd33efd8f09724143d45ab91b48aebcee52f4fb11add3464c998fab47dc"
+source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
 dependencies = [
  "aquamarine",
  "autocxx-macro",
@@ -133,8 +133,7 @@ dependencies = [
 [[package]]
 name = "autocxx-macro"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e594e68d030b6eb1ce7e2b40958f4f4ae7150c588c76d76b9f8178d41c47d80"
+source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
 dependencies = [
  "autocxx-parser",
  "proc-macro-error",
@@ -146,11 +145,10 @@ dependencies = [
 [[package]]
 name = "autocxx-parser"
 version = "0.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef00b2fc378804c31c4fbd693a7fea93f8a90467dce331dae1e4ce41e542953"
+source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
 dependencies = [
  "indexmap 1.9.3",
- "itertools 0.10.5",
+ "itertools",
  "log",
  "once_cell",
  "proc-macro2",
@@ -1120,6 +1118,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1202,15 +1219,6 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1301,9 +1309,8 @@ dependencies = [
 
 [[package]]
 name = "lief"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f0e22c006d789d8d712465d685e749cef9634b52ca100bdd144511efc3f20c"
+version = "1.0.0"
+source = "git+https://github.com/lief-project/LIEF.git#88a4d550cd82a5db1446cd19f65d2c0fbc480701"
 dependencies = [
  "bitflags 2.11.0",
  "cxx",
@@ -1316,9 +1323,8 @@ dependencies = [
 
 [[package]]
 name = "lief-build"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790aa6b9c3787b21b17c958ab73071d83306a690ac423938ebcb6663881106f5"
+version = "1.0.0"
+source = "git+https://github.com/lief-project/LIEF.git#88a4d550cd82a5db1446cd19f65d2c0fbc480701"
 dependencies = [
  "git-version",
  "miette",
@@ -1329,9 +1335,8 @@ dependencies = [
 
 [[package]]
 name = "lief-ffi"
-version = "0.17.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ec9b2c9a5755c2b7d39792c81038c3b315d8b9c4dd4214d9f78ff6e556bd102"
+version = "1.0.0"
+source = "git+https://github.com/lief-project/LIEF.git#88a4d550cd82a5db1446cd19f65d2c0fbc480701"
 dependencies = [
  "autocxx",
  "cxx",
@@ -1677,6 +1682,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -2310,7 +2336,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
 dependencies = [
  "proc-macro2",
- "quote",
  "unicode-ident",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler2"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -85,10 +94,72 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "aquamarine"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a941c39708478e8eea39243b5983f1c42d2717b3620ee91f4a52115fd02ac43f"
+dependencies = [
+ "itertools 0.9.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "autocxx"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ba64dd33efd8f09724143d45ab91b48aebcee52f4fb11add3464c998fab47dc"
+dependencies = [
+ "aquamarine",
+ "autocxx-macro",
+ "cxx",
+ "moveit",
+]
+
+[[package]]
+name = "autocxx-macro"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e594e68d030b6eb1ce7e2b40958f4f4ae7150c588c76d76b9f8178d41c47d80"
+dependencies = [
+ "autocxx-parser",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "autocxx-parser"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ef00b2fc378804c31c4fbd693a7fea93f8a90467dce331dae1e4ce41e542953"
+dependencies = [
+ "indexmap 1.9.3",
+ "itertools 0.10.5",
+ "log",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.117",
+ "thiserror 1.0.69",
+]
 
 [[package]]
 name = "aws-lc-rs"
@@ -113,10 +184,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace"
+version = "0.3.76"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-link",
+]
+
+[[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -138,6 +245,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -225,7 +338,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -277,7 +390,7 @@ dependencies = [
  "encode_unicode",
  "libc",
  "once_cell",
- "unicode-width",
+ "unicode-width 0.2.2",
  "windows-sys 0.61.2",
 ]
 
@@ -332,6 +445,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -339,6 +458,35 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c15f3b597018782655a05d417f28bac009f6eb60f4b6703eb818998c1aaa16a"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7eb4c4fd18505f5a935f9c2ee77780350dcdb56da7cd037634e806141c5c43"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d914fcc6452d133236ee067a9538be25ba6a644a450e1a6c617da84bf029854"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -375,7 +523,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -383,6 +531,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "encode_unicode"
@@ -578,6 +732,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+
+[[package]]
+name = "git-version"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad568aa3db0fcbc81f2f116137f263d7304f512a1209b35b85150d3ef88ad19"
+dependencies = [
+ "git-version-macro",
+]
+
+[[package]]
+name = "git-version-macro"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.13.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -588,13 +787,19 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
- "indexmap",
+ "http 1.4.0",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -618,6 +823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +845,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
@@ -644,12 +866,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.0",
 ]
 
 [[package]]
@@ -660,8 +893,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -670,6 +903,36 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
 
 [[package]]
 name = "hyper"
@@ -681,9 +944,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -695,17 +958,31 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http 0.2.12",
+ "hyper 0.14.32",
+ "rustls 0.21.12",
+ "tokio",
+ "tokio-rustls 0.24.1",
+]
+
+[[package]]
+name = "hyper-rustls"
 version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.0",
+ "hyper 1.8.1",
  "hyper-util",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower-service",
 ]
 
@@ -715,19 +992,19 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
- "system-configuration",
+ "socket2 0.6.2",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
@@ -844,6 +1121,17 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -862,7 +1150,7 @@ checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
 dependencies = [
  "console",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.2.2",
  "unit-prefix",
  "web-time",
 ]
@@ -893,10 +1181,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -970,10 +1293,59 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1744e39d1d6a9948f4f388969627434e31128196de472883b39f148769bfe30a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "libc",
  "plain",
  "redox_syscall",
+]
+
+[[package]]
+name = "lief"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f0e22c006d789d8d712465d685e749cef9634b52ca100bdd144511efc3f20c"
+dependencies = [
+ "bitflags 2.11.0",
+ "cxx",
+ "lief-ffi",
+ "num-bigint",
+ "num-derive",
+ "num-traits",
+ "tempfile",
+]
+
+[[package]]
+name = "lief-build"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790aa6b9c3787b21b17c958ab73071d83306a690ac423938ebcb6663881106f5"
+dependencies = [
+ "git-version",
+ "miette",
+ "reqwest 0.11.24",
+ "semver",
+ "zip 0.6.6",
+]
+
+[[package]]
+name = "lief-ffi"
+version = "0.17.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ec9b2c9a5755c2b7d39792c81038c3b315d8b9c4dd4214d9f78ff6e556bd102"
+dependencies = [
+ "autocxx",
+ "cxx",
+ "lief-build",
+ "miette",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -1027,6 +1399,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "miette"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+dependencies = [
+ "backtrace",
+ "backtrace-ext",
+ "is-terminal",
+ "miette-derive",
+ "once_cell",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
+ "thiserror 1.0.69",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "miette-derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1054,10 +1458,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "moveit"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d7335204cb6ef7bd647fa6db0be3e4d7aa25b5823a7aa030027ddf512cefba"
+dependencies = [
+ "cxx",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "object"
+version = "0.37.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "once_cell"
@@ -1078,6 +1539,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "owo-colors"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+
+[[package]]
 name = "packit"
 version = "0.1.0"
 dependencies = [
@@ -1088,8 +1555,9 @@ dependencies = [
  "hex",
  "indicatif",
  "libc",
+ "lief",
  "regex",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "sha2",
  "tar",
@@ -1098,7 +1566,7 @@ dependencies = [
  "toml",
  "windows-version",
  "xz2",
- "zip",
+ "zip 8.1.0",
 ]
 
 [[package]]
@@ -1184,7 +1652,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -1208,8 +1700,8 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls",
- "socket2",
+ "rustls 0.23.37",
+ "socket2 0.6.2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1229,7 +1721,7 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "slab",
  "thiserror 2.0.18",
@@ -1247,7 +1739,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1302,7 +1794,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -1336,22 +1828,63 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.11.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-rustls 0.24.2",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-rustls 0.24.1",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
- "hyper-rustls",
+ "hyper 1.8.1",
+ "hyper-rustls 0.27.7",
  "hyper-util",
  "js-sys",
  "log",
@@ -1359,12 +1892,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls",
+ "tokio-rustls 0.26.4",
  "tower",
  "tower-http",
  "tower-service",
@@ -1389,6 +1922,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-demangle"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1400,11 +1939,23 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.7",
+ "sct",
 ]
 
 [[package]]
@@ -1416,7 +1967,7 @@ dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "subtle",
  "zeroize",
 ]
@@ -1431,6 +1982,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -1454,10 +2014,10 @@ dependencies = [
  "jni",
  "log",
  "once_cell",
- "rustls",
+ "rustls 0.23.37",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki",
+ "rustls-webpki 0.103.9",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -1469,6 +2029,16 @@ name = "rustls-platform-verifier-android"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -1489,6 +2059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1507,12 +2083,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -1531,9 +2117,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
 
 [[package]]
 name = "serde"
@@ -1562,7 +2148,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1585,6 +2171,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -1634,6 +2232,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1662,6 +2276,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "supports-color"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+dependencies = [
+ "is-terminal",
+ "is_ci",
+]
+
+[[package]]
+name = "supports-hyperlinks"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "supports-unicode"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
+dependencies = [
+ "is-terminal",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1671,6 +2324,12 @@ dependencies = [
  "quote",
  "unicode-ident",
 ]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -1689,7 +2348,18 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
 ]
 
 [[package]]
@@ -1698,9 +2368,19 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -1738,6 +2418,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1763,7 +2464,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1774,7 +2475,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1832,8 +2533,18 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls 0.21.12",
+ "tokio",
 ]
 
 [[package]]
@@ -1842,7 +2553,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls",
+ "rustls 0.23.37",
  "tokio",
 ]
 
@@ -1865,7 +2576,7 @@ version = "1.0.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7614eaf19ad818347db24addfa201729cf2a9b6fdfd9eb0ab870fcacc606c0c"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -1907,7 +2618,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -1919,11 +2630,11 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.0",
+ "http-body 1.0.1",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -1985,6 +2696,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2129,7 +2852,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2159,7 +2882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -2170,9 +2893,9 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -2206,6 +2929,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2213,6 +2958,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-link"
@@ -2260,6 +3011,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -2298,6 +3058,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2350,6 +3125,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2368,6 +3149,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2383,6 +3170,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2416,6 +3209,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2431,6 +3230,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2452,6 +3257,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2470,6 +3281,12 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -2485,6 +3302,16 @@ name = "winnow"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2520,9 +3347,9 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2538,7 +3365,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2550,8 +3377,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
- "indexmap",
+ "bitflags 2.11.0",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -2570,7 +3397,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",
@@ -2624,7 +3451,7 @@ checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2645,7 +3472,7 @@ checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2665,7 +3492,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -2686,7 +3513,7 @@ checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2719,7 +3546,20 @@ checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+dependencies = [
+ "byteorder",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "time",
 ]
 
 [[package]]
@@ -2736,7 +3576,7 @@ dependencies = [
  "flate2",
  "getrandom 0.4.1",
  "hmac",
- "indexmap",
+ "indexmap 2.13.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ hex = "0.4.3"
 zip = "8.1.0"
 regex = "1.12.3"
 xz2 = "0.1.7"
+lief = "0.17.5"
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ hex = "0.4.3"
 zip = "8.1.0"
 regex = "1.12.3"
 xz2 = "0.1.7"
-lief = "0.17.5"
+lief = { git = "https://github.com/lief-project/LIEF.git" }
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/src/cli/display/logging.rs
+++ b/src/cli/display/logging.rs
@@ -81,7 +81,7 @@ pub static DEBUG_ENABLED: LazyLock<bool> = LazyLock::new(|| match std::env::var(
 
 /// Macro for displaying debug information. Only shows info when debug is enabled.
 macro_rules! debug {
-    ($error:expr, $($arg:tt)*) => {
+    (err: $error:expr, $($arg:tt)*) => {
         if *$crate::cli::display::logging::DEBUG_ENABLED {
             $crate::cli::display::logging::debug_error_impl(format_args!($($arg)*), $error);
         }

--- a/src/installer/build_env.rs
+++ b/src/installer/build_env.rs
@@ -23,7 +23,7 @@ const STRIPPED_VARS: &'static [&'static str] = &[
 /// Holds all the data necessary to build a normalized build environment.
 pub struct BuildEnv<'a> {
     prefix_directory: &'a PathBuf,
-    dependencies: Vec<&'a InstalledPackageVersion>,
+    dependencies: &'a Vec<&'a InstalledPackageVersion>,
     build_dependencies: Vec<&'a InstalledPackageVersion>,
     register: &'a PackageRegister,
 }
@@ -75,7 +75,7 @@ impl<'a> BuildEnv<'a> {
     /// Creates a new `BuildEnv`.
     pub fn new(
         prefix_directory: &'a PathBuf,
-        dependencies: Vec<&'a InstalledPackageVersion>,
+        dependencies: &'a Vec<&'a InstalledPackageVersion>,
         build_dependencies: Vec<&'a InstalledPackageVersion>,
         register: &'a PackageRegister,
     ) -> Self {
@@ -131,7 +131,7 @@ impl<'a> BuildEnv<'a> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add dependencies to PKG_CONFIG_PATH
-        for dependency in &self.dependencies {
+        for dependency in self.dependencies {
             let lib_path = dependency.install_path.join("lib").join("pkgconfig");
             let share_path = dependency.install_path.join("share").join("pkgconfig");
 
@@ -178,7 +178,7 @@ impl<'a> BuildEnv<'a> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add non symlinked dependencies to CMAKE_PREFIX_PATH
-        for dependency in &self.dependencies {
+        for dependency in self.dependencies {
             if let Some(package) = self.register.get_package(&dependency.package_id.name) {
                 if package.symlinked {
                     continue;
@@ -212,7 +212,7 @@ impl<'a> BuildEnv<'a> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add non symlinked dependencies to ACLOCAL_PATH
-        for dependency in &self.dependencies {
+        for dependency in self.dependencies {
             if let Some(package) = self.register.get_package(&dependency.package_id.name) {
                 if package.symlinked {
                     continue;

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -157,7 +157,7 @@ impl<'a> Builder<'a> {
         // Create build env
         let env = BuildEnv::new(
             &self.config.prefix_directory,
-            installed_dependencies.clone(),
+            &installed_dependencies,
             installed_build_dependencies,
             self.register,
         );

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -157,7 +157,7 @@ impl<'a> Builder<'a> {
         // Create build env
         let env = BuildEnv::new(
             &self.config.prefix_directory,
-            installed_dependencies,
+            installed_dependencies.clone(),
             installed_build_dependencies,
             self.register,
         );
@@ -189,7 +189,7 @@ impl<'a> Builder<'a> {
 
         // Patch binaries
         let package_id = PackageId::new(package_name.clone(), version.clone());
-        BinaryPatcher::new(self.config).patch_binaries_in(&destination_dir.as_ref().to_path_buf(), &package_id)?;
+        BinaryPatcher::new(self.config).patch_binaries_in(&destination_dir.as_ref().to_path_buf(), &package_id, installed_dependencies)?;
 
         Ok(())
     }

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -9,8 +9,10 @@ use crate::{
         build_env::BuildEnv,
         install_tree::InstallMeta,
         scripts::{self, ScriptData, ScriptError},
+        types::PackageId,
         unpack::{ArchiveExtension, UnpackError, unpack},
     },
+    platforms::binaries::{BinaryPatcher, BinaryPatcherError},
     repositories::{error::RepositoryError, manager::RepositoryManager, types::Checksum},
     storage::package_register::PackageRegister,
 };
@@ -38,6 +40,9 @@ pub enum BuilderError {
 
     #[error("Cannot find a repository for building")]
     RepositoryError(#[from] RepositoryError),
+
+    #[error("Cannot patch binaries")]
+    PatchError(#[from] BinaryPatcherError),
 
     #[error("Cannot request files for building")]
     RequestError(#[from] reqwest::Error),
@@ -181,6 +186,10 @@ impl<'a> Builder<'a> {
             // Run build script
             scripts::run_build_script(&script_data, &unpack_directory, env)?;
         }
+
+        // Patch binaries
+        let package_id = PackageId::new(package_name.clone(), version.clone());
+        BinaryPatcher::new(self.config).patch_binaries_in(&destination_dir.as_ref().to_path_buf(), &package_id)?;
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -340,17 +340,23 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
+    /// Creates the symlinks for all package dependencies in the `dependencies` directory.
     fn create_dependency_symlinks(&self, current_package: &PackageId, dependencies: &HashSet<PackageId>) -> Result<()> {
+        // Prevent creating an empty directory
+        if dependencies.is_empty() {
+            return Ok(());
+        }
+
+        // Create package dependencies directory
         let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(current_package.to_string());
         fs::create_dir_all(&dependency_directory_path)?;
 
-        // TODO: Check if it's possible to use the install path instead of manual join
-        // Create symlinks to all children
+        // Create symlinks to all dependencies
         for dependency in dependencies {
             let original =
                 Path::new(&self.config.prefix_directory).join("packages").join(&dependency.name).join(dependency.version.to_string());
             let link = dependency_directory_path.join(&dependency.name);
-            io::create_symlink(&original, &link)?;
+            symlink::create_symlink(&original, &link)?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -491,7 +491,7 @@ impl<'a> Installer<'a> {
 
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
-            io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+            io::remove_symlinks(Path::new(&self.config.prefix_directory), &directory)?;
         }
 
         // Change active package when uninstalled package is currently active
@@ -557,7 +557,7 @@ impl<'a> Installer<'a> {
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
                 debug!("Unlinking '{package_name}'");
-                io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
+                io::remove_symlinks(Path::new(&self.config.prefix_directory), &directory)?;
             }
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -348,13 +348,12 @@ impl<'a> Installer<'a> {
         }
 
         // Create package dependencies directory
-        let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(current_package.to_string());
+        let dependency_directory_path = self.config.prefix_directory.join("dependencies").join(current_package.to_string());
         fs::create_dir_all(&dependency_directory_path)?;
 
         // Create symlinks to all dependencies
         for dependency in dependencies {
-            let original =
-                Path::new(&self.config.prefix_directory).join("packages").join(&dependency.name).join(dependency.version.to_string());
+            let original = self.config.prefix_directory.join("packages").join(&dependency.name).join(dependency.version.to_string());
             let link = dependency_directory_path.join(&dependency.name);
             symlink::create_symlink(&original, &link)?;
         }
@@ -490,14 +489,14 @@ impl<'a> Installer<'a> {
         self.run_uninstall_script(&repository, &package_id, &directory)?;
 
         // Remove the dependency symlinks if they exist
-        let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(package_id.to_string());
+        let dependency_directory_path = self.config.prefix_directory.join("dependencies").join(package_id.to_string());
         if fs::exists(&dependency_directory_path)? {
             fs::remove_dir_all(dependency_directory_path)?;
         }
 
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
-            io::remove_symlinks(Path::new(&self.config.prefix_directory), &directory)?;
+            io::remove_symlinks(&self.config.prefix_directory, &directory)?;
         }
 
         // Change active package when uninstalled package is currently active
@@ -553,7 +552,7 @@ impl<'a> Installer<'a> {
 
         // Remove active path symlink
         debug!("Unlinking the active path");
-        let active_path = Path::new(&self.config.prefix_directory).join("active").join(&package_name);
+        let active_path = self.config.prefix_directory.join("active").join(&package_name);
         match active_path.exists() {
             true => symlink::remove_symlink(&active_path)?,
             false => warning!("Active symlink did not exist, was the package even installed succesfully?"),
@@ -563,7 +562,7 @@ impl<'a> Installer<'a> {
         if let Some(package) = self.register.get_package(package_name) {
             if package.symlinked {
                 debug!("Unlinking '{package_name}'");
-                io::remove_symlinks(Path::new(&self.config.prefix_directory), &directory)?;
+                io::remove_symlinks(&self.config.prefix_directory, &directory)?;
             }
         }
 
@@ -573,8 +572,7 @@ impl<'a> Installer<'a> {
             let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
 
             // Remove the dependency symlinks
-            let dependency_directory_path =
-                Path::new(&self.config.prefix_directory).join("dependencies").join(package_version.package_id.to_string());
+            let dependency_directory_path = self.config.prefix_directory.join("dependencies").join(package_version.package_id.to_string());
             if fs::exists(&dependency_directory_path)? {
                 fs::remove_dir_all(dependency_directory_path)?;
             }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -709,12 +709,19 @@ impl<'a> Installer<'a> {
         // Set the dependents of the old package for the new package
         package_version.dependents = dependents.clone();
 
-        // Change the register dependency entries to the new package version
-        for package_id in &dependents {
-            if let Some(dependent) = self.register.get_package_version_mut(package_id) {
+        let install_path = package_version.install_path.clone();
+
+        // Update dependents to use the new package version
+        for dependent_id in &dependents {
+            if let Some(dependent) = self.register.get_package_version_mut(dependent_id) {
                 dependent.dependencies.remove(&old_package_id);
                 dependent.dependencies.insert(new_package_id.clone());
             }
+
+            // Switch dependents to use new version
+            let link_path = self.config.prefix_directory.join("dependencies").join(dependent_id.to_string()).join(&new_package_id.name);
+            symlink::remove_symlink(&link_path)?;
+            symlink::create_symlink(&install_path, &link_path)?;
         }
 
         // Set the active and symlinked state for the new package (to the old package state)

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -226,7 +226,7 @@ impl<'a> Installer<'a> {
         // Get the target information from the package version info
         let target = version_meta.get_target(&install_meta.target_bounds)?;
 
-        self.create_dependency_directory(&package_id, &dependencies)?;
+        self.create_dependency_symlinks(&package_id, &dependencies)?;
 
         // Get build version of package
         match use_prebuild {
@@ -340,7 +340,7 @@ impl<'a> Installer<'a> {
         Ok(())
     }
 
-    fn create_dependency_directory(&self, current_package: &PackageId, dependencies: &HashSet<PackageId>) -> Result<()> {
+    fn create_dependency_symlinks(&self, current_package: &PackageId, dependencies: &HashSet<PackageId>) -> Result<()> {
         let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(current_package.to_string());
         fs::create_dir_all(&dependency_directory_path)?;
 
@@ -483,6 +483,10 @@ impl<'a> Installer<'a> {
         // Run uninstall script
         self.run_uninstall_script(&repository, &package_id, &directory)?;
 
+        // Remove the dependency symlinks
+        let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(package_id.to_string());
+        fs::remove_dir_all(dependency_directory_path)?;
+
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
             io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&directory))?;
@@ -559,6 +563,11 @@ impl<'a> Installer<'a> {
         for package_version in &installed_versions {
             // Load source repository
             let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
+
+            // Remove the dependency symlinks
+            let dependency_directory_path =
+                Path::new(&self.config.prefix_directory).join("dependencies").join(package_version.package_id.to_string());
+            fs::remove_dir_all(dependency_directory_path)?;
 
             // Run uninstall script
             self.run_uninstall_script(&repository, &package_version.package_id, &directory)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -226,6 +226,8 @@ impl<'a> Installer<'a> {
         // Get the target information from the package version info
         let target = version_meta.get_target(&install_meta.target_bounds)?;
 
+        self.create_dependency_directory(&package_id, &dependencies)?;
+
         // Get build version of package
         match use_prebuild {
             true => {
@@ -333,6 +335,22 @@ impl<'a> Installer<'a> {
         // If package is installed succesfully, set it to active
         if should_set_active {
             Symlinker::new(self.config).set_active(self.register, &package_id, should_symlink)?;
+        }
+
+        Ok(())
+    }
+
+    fn create_dependency_directory(&self, current_package: &PackageId, dependencies: &HashSet<PackageId>) -> Result<()> {
+        let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(current_package.to_string());
+        fs::create_dir_all(&dependency_directory_path)?;
+
+        // TODO: Check if it's possible to use the install path instead of manual join
+        // Create symlinks to all children
+        for dependency in dependencies {
+            let original =
+                Path::new(&self.config.prefix_directory).join("packages").join(&dependency.name).join(dependency.version.to_string());
+            let link = dependency_directory_path.join(&dependency.name);
+            io::create_symlink(&original, &link)?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -483,9 +483,11 @@ impl<'a> Installer<'a> {
         // Run uninstall script
         self.run_uninstall_script(&repository, &package_id, &directory)?;
 
-        // Remove the dependency symlinks
+        // Remove the dependency symlinks if they exist
         let dependency_directory_path = Path::new(&self.config.prefix_directory).join("dependencies").join(package_id.to_string());
-        fs::remove_dir_all(dependency_directory_path)?;
+        if fs::exists(&dependency_directory_path)? {
+            fs::remove_dir_all(dependency_directory_path)?;
+        }
 
         // Check if the package was symlinked
         if installed_package.active_version == package_id.version && installed_package.symlinked {
@@ -567,7 +569,9 @@ impl<'a> Installer<'a> {
             // Remove the dependency symlinks
             let dependency_directory_path =
                 Path::new(&self.config.prefix_directory).join("dependencies").join(package_version.package_id.to_string());
-            fs::remove_dir_all(dependency_directory_path)?;
+            if fs::exists(&dependency_directory_path)? {
+                fs::remove_dir_all(dependency_directory_path)?;
+            }
 
             // Run uninstall script
             self.run_uninstall_script(&repository, &package_version.package_id, &directory)?;

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -57,9 +57,14 @@ impl<'a> Symlinker<'a> {
 
         let package_install_path = package_version.install_path.clone();
 
-        // Remove old symlinks
         let package_directory = self.config.prefix_directory.join("packages").join(&package_id.name);
-        io::remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
+
+        // Symlink directories bin, include, lib and share
+        for dir_name in vec!["bin", "include", "lib", "share", "active"] {
+            let prefix_dir_path = self.config.prefix_directory.join(dir_name);
+
+            io::remove_symlinks(&prefix_dir_path, &package_directory)?;
+        }
 
         // Create active symlink
         fs::create_dir_all(global_active_path)?;

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -1,10 +1,15 @@
-use std::{collections::VecDeque, fs, path::PathBuf, process::Command};
+use std::{
+    collections::VecDeque,
+    fs,
+    path::PathBuf,
+    process::{Command, Stdio},
+};
 
 use lief::{Binary, elf, macho};
 use thiserror::Error;
 
 use crate::{
-    cli::display::logging::{debug, error},
+    cli::display::logging::{self, debug, error},
     config::Config,
     installer::types::PackageId,
     storage::installed_package_version::InstalledPackageVersion,
@@ -156,7 +161,13 @@ impl<'a> BinaryPatcher<'a> {
 
                 // Sign binary
                 let path = path.to_str().ok_or(BinaryPatcherError::OsStringConversionError)?;
-                match Command::new("/usr/bin/codesign").args(["--sign", "-", "--force", path]).status() {
+                let mut command = Command::new("/usr/bin/codesign");
+                let mut command = command.args(["--sign", "-", "--force", path]).stdout(Stdio::null()).stderr(Stdio::null());
+                if *logging::DEBUG_ENABLED {
+                    command = command.stdout(Stdio::inherit()).stderr(Stdio::inherit());
+                }
+
+                match command.status() {
                     Ok(code) if !code.success() => {
                         error!(msg: "Cannot resign binary, exit code {code}");
                         continue;

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -51,9 +51,7 @@ impl<'a> BinaryPatcher<'a> {
         }
 
         let mut queue = VecDeque::from([path.clone()]);
-        while queue.len() != 0 {
-            let item = queue.pop_front().expect("Expected an element in the queue");
-
+        while let Some(item) = queue.pop_front() {
             for entry in fs::read_dir(item)? {
                 let entry = entry?;
 
@@ -192,7 +190,6 @@ impl<'a> BinaryPatcher<'a> {
 
             for dependency in dependencies {
                 let lib_path = dependency.install_path.join("lib").join(library.name());
-
                 if lib_path.exists() {
                     debug!("Found Packit dependency, adding to rpath");
 

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -1,9 +1,13 @@
-use std::{collections::VecDeque, fs, path::PathBuf};
+use std::{collections::VecDeque, fs, path::PathBuf, process::Command};
 
 use lief::{Binary, elf, macho};
 use thiserror::Error;
 
-use crate::{cli::display::logging::debug, config::Config};
+use crate::{
+    cli::display::logging::{debug, error},
+    config::Config,
+    installer::types::PackageId,
+};
 
 /// The errors that occur during binary operations.
 #[derive(Error, Debug)]
@@ -21,6 +25,9 @@ pub enum BinaryError {
 
     #[error("Error while interacting with filesystem")]
     IOError(#[from] std::io::Error),
+
+    #[error("Cannot convert OsString to string")]
+    OsStringConversionError,
 }
 
 type Result<T> = std::result::Result<T, BinaryError>;
@@ -34,18 +41,17 @@ impl<'a> BinaryPatcher<'a> {
         Self { config }
     }
 
-    pub fn patch_binaries_in(&self, path: &PathBuf) -> Result<()> {
+    pub fn patch_binaries_in(&self, path: &PathBuf, package: &PackageId) -> Result<()> {
         let metadata = fs::metadata(path)?;
 
         // If the given path is a file, patch the file directly
         if metadata.is_file() {
-            return self.patch_binary(path);
+            return self.patch_binary(path, package);
         }
 
         let mut queue = VecDeque::from([path.clone()]);
         while queue.len() != 0 {
             let item = queue.pop_front().expect("Expected an element in the queue");
-            debug!("Searching for binaries in '{}'", item.display());
 
             for entry in fs::read_dir(item)? {
                 let entry = entry?;
@@ -59,7 +65,7 @@ impl<'a> BinaryPatcher<'a> {
 
                 // If the entry is a file, try to patch it
                 if metadata.is_file() {
-                    match self.patch_binary(&entry.path()) {
+                    match self.patch_binary(&entry.path(), package) {
                         Ok(_) | Err(BinaryError::CannotParseBinary { .. }) | Err(BinaryError::UnsupportedBinaryType { .. }) => (),
                         Err(e) => return Err(e),
                     }
@@ -70,15 +76,15 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
-    fn patch_binary(&self, path: &PathBuf) -> Result<()> {
+    fn patch_binary(&self, path: &PathBuf, package: &PackageId) -> Result<()> {
         match Binary::parse(path) {
             Some(Binary::ELF(binary)) => {
                 debug!("Patching ELF binary at '{}'", path.display());
-                self.patch_elf(binary, path)?;
+                self.patch_elf(binary, path, package)?;
             },
             Some(Binary::MachO(binary)) => {
                 debug!("Patching MachO binary at '{}'", path.display());
-                self.patch_macho(binary, path)?;
+                self.patch_macho(binary, path, package)?;
             },
             Some(Binary::PE(_binary)) => {
                 debug!("Patching PE binary at '{}'", path.display());
@@ -96,34 +102,77 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
-    fn patch_macho(&self, binary: macho::FatBinary, path: &PathBuf) -> Result<()> {
+    fn patch_macho(&self, binary: macho::FatBinary, path: &PathBuf, package: &PackageId) -> Result<()> {
         for mut binary in binary.iter() {
             let mut changed = false;
 
-            for library in binary.libraries() {
+            for mut library in binary.libraries() {
                 let library_path = PathBuf::from(library.name());
 
                 // Check if library lives in the prefix directory
-                if library_path.starts_with(&self.config.prefix_directory) {
+                let prefix = self.config.prefix_directory.join("packages/");
+                if library_path.starts_with(&prefix) {
                     debug!("Found Packit dependency: {}", library_path.display());
 
-                    // TODO: split out package name and link to correct directory
-                    // TODO: check if the library links to a path outside of the current package
-                    // changed = true;
+                    let library_path = match library_path.strip_prefix(&prefix) {
+                        Ok(path) => path,
+                        Err(_) => {
+                            debug!("Cannot remove prefix from dependency path");
+                            continue;
+                        },
+                    };
+
+                    let parts: Vec<_> = library_path.components().collect();
+                    if parts.len() < 2 {
+                        debug!("Linked dependency path is too short");
+                        continue;
+                    }
+
+                    let dependency_name = parts[0].as_os_str().to_str().ok_or(BinaryError::OsStringConversionError)?;
+                    let dependency_version = parts[1].as_os_str().to_str().ok_or(BinaryError::OsStringConversionError)?;
+
+                    // Check if the dependency links to the package itself
+                    if dependency_name == *package.name && dependency_version == package.version.to_string() {
+                        continue;
+                    }
+
+                    let new_prefix = self.config.prefix_directory.join("dependencies").join(package.to_string()).join(dependency_name);
+                    let new_suffix: PathBuf = parts.iter().skip(2).collect();
+                    let new_path = new_prefix.join(new_suffix);
+
+                    library.set_name(new_path.to_str().ok_or(BinaryError::OsStringConversionError)?);
+
+                    changed = true;
                 }
             }
 
             if changed {
+                debug!("Changed binary {path:?}, writing changes");
+
                 let mut config = macho::builder::Config::default();
                 config.linkedit = true;
                 binary.write_with_config(path, config);
+
+                // Sign binary
+                let path = path.to_str().ok_or(BinaryError::OsStringConversionError)?;
+                match Command::new("/usr/bin/codesign").args(["--sign", "-", "--force", path]).status() {
+                    Ok(code) if !code.success() => {
+                        error!(msg: "Cannot resign binary, exit code {code}");
+                        continue;
+                    },
+                    Ok(_) => (),
+                    Err(e) => {
+                        error!(e, "Cannot resign binary {path:?}");
+                        continue;
+                    },
+                };
             }
         }
 
         Ok(())
     }
 
-    fn patch_elf(&self, binary: elf::Binary, path: &PathBuf) -> Result<()> {
+    fn patch_elf(&self, binary: elf::Binary, path: &PathBuf, package: &PackageId) -> Result<()> {
         todo!();
         Ok(())
     }

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -193,8 +193,13 @@ impl<'a> BinaryPatcher<'a> {
                 if lib_path.exists() {
                     debug!("Found Packit dependency, adding to rpath");
 
-                    let dependency_path =
-                        self.config.prefix_directory.join("dependencies").join(package.to_string()).join(&dependency.package_id.name);
+                    let dependency_path = self
+                        .config
+                        .prefix_directory
+                        .join("dependencies")
+                        .join(package.to_string())
+                        .join(&dependency.package_id.name)
+                        .join("lib");
                     rpaths.push(dependency_path);
                 }
             }

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -11,7 +11,7 @@ use crate::{
 
 /// The errors that occur during binary operations.
 #[derive(Error, Debug)]
-pub enum BinaryError {
+pub enum BinaryPatcherError {
     #[error("Binary '{path}' cannot be parsed.")]
     CannotParseBinary {
         path: PathBuf,
@@ -30,7 +30,7 @@ pub enum BinaryError {
     OsStringConversionError,
 }
 
-type Result<T> = std::result::Result<T, BinaryError>;
+type Result<T> = std::result::Result<T, BinaryPatcherError>;
 
 pub struct BinaryPatcher<'a> {
     config: &'a Config,
@@ -66,7 +66,9 @@ impl<'a> BinaryPatcher<'a> {
                 // If the entry is a file, try to patch it
                 if metadata.is_file() {
                     match self.patch_binary(&entry.path(), package) {
-                        Ok(_) | Err(BinaryError::CannotParseBinary { .. }) | Err(BinaryError::UnsupportedBinaryType { .. }) => (),
+                        Ok(_)
+                        | Err(BinaryPatcherError::CannotParseBinary { .. })
+                        | Err(BinaryPatcherError::UnsupportedBinaryType { .. }) => (),
                         Err(e) => return Err(e),
                     }
                 }
@@ -91,12 +93,12 @@ impl<'a> BinaryPatcher<'a> {
                 todo!();
             },
             Some(Binary::COFF(_)) => {
-                return Err(BinaryError::UnsupportedBinaryType {
+                return Err(BinaryPatcherError::UnsupportedBinaryType {
                     path: path.clone(),
                     bin_type: "COFF".into(),
                 });
             },
-            None => return Err(BinaryError::CannotParseBinary { path: path.clone() }),
+            None => return Err(BinaryPatcherError::CannotParseBinary { path: path.clone() }),
         }
 
         Ok(())
@@ -128,8 +130,8 @@ impl<'a> BinaryPatcher<'a> {
                         continue;
                     }
 
-                    let dependency_name = parts[0].as_os_str().to_str().ok_or(BinaryError::OsStringConversionError)?;
-                    let dependency_version = parts[1].as_os_str().to_str().ok_or(BinaryError::OsStringConversionError)?;
+                    let dependency_name = parts[0].as_os_str().to_str().ok_or(BinaryPatcherError::OsStringConversionError)?;
+                    let dependency_version = parts[1].as_os_str().to_str().ok_or(BinaryPatcherError::OsStringConversionError)?;
 
                     // Check if the dependency links to the package itself
                     if dependency_name == *package.name && dependency_version == package.version.to_string() {
@@ -140,7 +142,7 @@ impl<'a> BinaryPatcher<'a> {
                     let new_suffix: PathBuf = parts.iter().skip(2).collect();
                     let new_path = new_prefix.join(new_suffix);
 
-                    library.set_name(new_path.to_str().ok_or(BinaryError::OsStringConversionError)?);
+                    library.set_name(new_path.to_str().ok_or(BinaryPatcherError::OsStringConversionError)?);
 
                     changed = true;
                 }
@@ -154,7 +156,7 @@ impl<'a> BinaryPatcher<'a> {
                 binary.write_with_config(path, config);
 
                 // Sign binary
-                let path = path.to_str().ok_or(BinaryError::OsStringConversionError)?;
+                let path = path.to_str().ok_or(BinaryPatcherError::OsStringConversionError)?;
                 match Command::new("/usr/bin/codesign").args(["--sign", "-", "--force", path]).status() {
                     Ok(code) if !code.success() => {
                         error!(msg: "Cannot resign binary, exit code {code}");

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -1,0 +1,130 @@
+use std::{collections::VecDeque, fs, path::PathBuf};
+
+use lief::{Binary, elf, macho};
+use thiserror::Error;
+
+use crate::{cli::display::logging::debug, config::Config};
+
+/// The errors that occur during binary operations.
+#[derive(Error, Debug)]
+pub enum BinaryError {
+    #[error("Binary '{path}' cannot be parsed.")]
+    CannotParseBinary {
+        path: PathBuf,
+    },
+
+    #[error("Binary '{path}' of type {bin_type} is not supported.")]
+    UnsupportedBinaryType {
+        path: PathBuf,
+        bin_type: String,
+    },
+
+    #[error("Error while interacting with filesystem")]
+    IOError(#[from] std::io::Error),
+}
+
+type Result<T> = std::result::Result<T, BinaryError>;
+
+pub struct BinaryPatcher<'a> {
+    config: &'a Config,
+}
+
+impl<'a> BinaryPatcher<'a> {
+    pub fn new(config: &'a Config) -> Self {
+        Self { config }
+    }
+
+    pub fn patch_binaries_in(&self, path: &PathBuf) -> Result<()> {
+        let metadata = fs::metadata(path)?;
+
+        // If the given path is a file, patch the file directly
+        if metadata.is_file() {
+            return self.patch_binary(path);
+        }
+
+        let mut queue = VecDeque::from([path.clone()]);
+        while queue.len() != 0 {
+            let item = queue.pop_front().expect("Expected an element in the queue");
+            debug!("Searching for binaries in '{}'", item.display());
+
+            for entry in fs::read_dir(item)? {
+                let entry = entry?;
+
+                let metadata = entry.metadata()?;
+
+                // If the entry is a directory, add it to the queue
+                if metadata.is_dir() {
+                    queue.push_back(entry.path());
+                }
+
+                // If the entry is a file, try to patch it
+                if metadata.is_file() {
+                    match self.patch_binary(&entry.path()) {
+                        Ok(_) | Err(BinaryError::CannotParseBinary { .. }) | Err(BinaryError::UnsupportedBinaryType { .. }) => (),
+                        Err(e) => return Err(e),
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn patch_binary(&self, path: &PathBuf) -> Result<()> {
+        match Binary::parse(path) {
+            Some(Binary::ELF(binary)) => {
+                debug!("Patching ELF binary at '{}'", path.display());
+                self.patch_elf(binary, path)?;
+            },
+            Some(Binary::MachO(binary)) => {
+                debug!("Patching MachO binary at '{}'", path.display());
+                self.patch_macho(binary, path)?;
+            },
+            Some(Binary::PE(_binary)) => {
+                debug!("Patching PE binary at '{}'", path.display());
+                todo!();
+            },
+            Some(Binary::COFF(_)) => {
+                return Err(BinaryError::UnsupportedBinaryType {
+                    path: path.clone(),
+                    bin_type: "COFF".into(),
+                });
+            },
+            None => return Err(BinaryError::CannotParseBinary { path: path.clone() }),
+        }
+
+        Ok(())
+    }
+
+    fn patch_macho(&self, binary: macho::FatBinary, path: &PathBuf) -> Result<()> {
+        for mut binary in binary.iter() {
+            let mut changed = false;
+
+            for library in binary.libraries() {
+                let library_path = PathBuf::from(library.name());
+
+                // Check if library lives in the prefix directory
+                if library_path.starts_with(&self.config.prefix_directory) {
+                    debug!("Found Packit dependency: {}", library_path.display());
+
+                    // TODO: split out package name and link to correct directory
+                    // TODO: check if the library links to a path outside of the current package
+                    // changed = true;
+                }
+            }
+
+            if changed {
+                let mut config = macho::builder::Config::default();
+                config.linkedit = true;
+                binary.write_with_config(path, config);
+            }
+        }
+
+        Ok(())
+    }
+
+    fn patch_elf(&self, binary: elf::Binary, path: &PathBuf) -> Result<()> {
+        todo!();
+        Ok(())
+    }
+}

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -38,6 +38,7 @@ pub enum BinaryPatcherError {
 
 type Result<T> = std::result::Result<T, BinaryPatcherError>;
 
+/// Binary patcher, used for patching linker paths in binaries after building.
 pub struct BinaryPatcher<'a> {
     config: &'a Config,
 }
@@ -47,6 +48,7 @@ impl<'a> BinaryPatcher<'a> {
         Self { config }
     }
 
+    /// Patches all binaries in the given directory.
     pub fn patch_binaries_in(&self, path: &PathBuf, package: &PackageId, dependencies: Vec<&InstalledPackageVersion>) -> Result<()> {
         let metadata = fs::metadata(path)?;
 
@@ -82,6 +84,7 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
+    /// Patches the binary at the given path. Currently supports ELF and MachO binaries.
     fn patch_binary(&self, path: &PathBuf, package: &PackageId, dependencies: &Vec<&InstalledPackageVersion>) -> Result<()> {
         match Binary::parse(path) {
             Some(Binary::ELF(binary)) => {
@@ -108,6 +111,7 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
+    /// Patches the given MachO binary.
     fn patch_macho(&self, binary: macho::FatBinary, path: &PathBuf, package: &PackageId) -> Result<()> {
         for mut binary in binary.iter() {
             let mut changed = false;
@@ -184,6 +188,7 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
+    /// Patches the given ELF binary.
     fn patch_elf(
         &self,
         mut binary: elf::Binary,

--- a/src/platforms/binaries.rs
+++ b/src/platforms/binaries.rs
@@ -7,6 +7,7 @@ use crate::{
     cli::display::logging::{debug, error},
     config::Config,
     installer::types::PackageId,
+    storage::installed_package_version::InstalledPackageVersion,
 };
 
 /// The errors that occur during binary operations.
@@ -23,11 +24,11 @@ pub enum BinaryPatcherError {
         bin_type: String,
     },
 
-    #[error("Error while interacting with filesystem")]
-    IOError(#[from] std::io::Error),
-
     #[error("Cannot convert OsString to string")]
     OsStringConversionError,
+
+    #[error("Error while interacting with filesystem")]
+    IOError(#[from] std::io::Error),
 }
 
 type Result<T> = std::result::Result<T, BinaryPatcherError>;
@@ -41,12 +42,12 @@ impl<'a> BinaryPatcher<'a> {
         Self { config }
     }
 
-    pub fn patch_binaries_in(&self, path: &PathBuf, package: &PackageId) -> Result<()> {
+    pub fn patch_binaries_in(&self, path: &PathBuf, package: &PackageId, dependencies: Vec<&InstalledPackageVersion>) -> Result<()> {
         let metadata = fs::metadata(path)?;
 
         // If the given path is a file, patch the file directly
         if metadata.is_file() {
-            return self.patch_binary(path, package);
+            return self.patch_binary(path, package, &dependencies);
         }
 
         let mut queue = VecDeque::from([path.clone()]);
@@ -65,7 +66,7 @@ impl<'a> BinaryPatcher<'a> {
 
                 // If the entry is a file, try to patch it
                 if metadata.is_file() {
-                    match self.patch_binary(&entry.path(), package) {
+                    match self.patch_binary(&entry.path(), package, &dependencies) {
                         Ok(_)
                         | Err(BinaryPatcherError::CannotParseBinary { .. })
                         | Err(BinaryPatcherError::UnsupportedBinaryType { .. }) => (),
@@ -78,11 +79,11 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
-    fn patch_binary(&self, path: &PathBuf, package: &PackageId) -> Result<()> {
+    fn patch_binary(&self, path: &PathBuf, package: &PackageId, dependencies: &Vec<&InstalledPackageVersion>) -> Result<()> {
         match Binary::parse(path) {
             Some(Binary::ELF(binary)) => {
                 debug!("Patching ELF binary at '{}'", path.display());
-                self.patch_elf(binary, path, package)?;
+                self.patch_elf(binary, path, package, dependencies)?;
             },
             Some(Binary::MachO(binary)) => {
                 debug!("Patching MachO binary at '{}'", path.display());
@@ -174,8 +175,51 @@ impl<'a> BinaryPatcher<'a> {
         Ok(())
     }
 
-    fn patch_elf(&self, binary: elf::Binary, path: &PathBuf, package: &PackageId) -> Result<()> {
-        todo!();
+    fn patch_elf(
+        &self,
+        mut binary: elf::Binary,
+        path: &PathBuf,
+        package: &PackageId,
+        dependencies: &Vec<&InstalledPackageVersion>,
+    ) -> Result<()> {
+        let mut rpaths = Vec::new();
+
+        for entry in binary.dynamic_entries() {
+            let library = match entry {
+                elf::dynamic::Entries::Library(lib) => lib,
+                _ => continue,
+            };
+
+            for dependency in dependencies {
+                let lib_path = dependency.install_path.join("lib").join(library.name());
+
+                if lib_path.exists() {
+                    debug!("Found Packit dependency, adding to rpath");
+
+                    let dependency_path =
+                        self.config.prefix_directory.join("dependencies").join(package.to_string()).join(&dependency.package_id.name);
+                    rpaths.push(dependency_path);
+                }
+            }
+        }
+
+        // Add rpaths to binary
+        if !rpaths.is_empty() {
+            debug!("Changed binary {path:?}, writing changes");
+
+            for rpath in rpaths {
+                let mut string_path = rpath.to_str().ok_or(BinaryPatcherError::OsStringConversionError)?.to_string();
+                if !string_path.ends_with("/") {
+                    string_path.push('/');
+                }
+
+                binary.add_dynamic_entry(&elf::dynamic::Rpath::new(&string_path));
+            }
+
+            let config = elf::builder::Config::default();
+            binary.write_with_config(path, config);
+        }
+
         Ok(())
     }
 }

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -1,3 +1,4 @@
+pub mod binaries;
 mod defaults;
 mod os;
 pub mod permissions;

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -1,4 +1,4 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use thiserror::Error;
 
@@ -7,6 +7,11 @@ use thiserror::Error;
 pub enum SymlinkError {
     #[error("Path is not a symlink")]
     NonSymlink,
+
+    #[error("The given symlink original '{original}' cannot be found.")]
+    OriginalNotFound {
+        original: PathBuf,
+    },
 
     #[error("Symlink IO failed")]
     IOError(#[from] std::io::Error),
@@ -23,7 +28,7 @@ pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> 
 /// Creates a symlink on Windows from link to original.
 #[cfg(target_os = "windows")]
 pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
-    match source.is_dir() {
+    match original.is_dir() {
         true => std::os::windows::fs::symlink_dir(original, link)?,
         false => std::os::windows::fs::symlink_file(original, link)?,
     }
@@ -33,7 +38,7 @@ pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> 
 
 /// Panics for any unsupported OS.
 #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-pub fn create_symlink(source: &Path, destination: &Path) -> Result<(), SymlinkError> {
+pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
     panic!("Cannot create link for target, target is not supported.");
 }
 

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -20,6 +20,7 @@ pub enum SymlinkError {
     IOError(#[from] std::io::Error),
 }
 
+/// Creates a symlink at `link`, pointing to `original`. Checks if the original exists and calls platform specific code.
 pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
     if !fs::exists(original)? {
         return Err(SymlinkError::OriginalNotFound {

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -1,4 +1,7 @@
-use std::path::{Path, PathBuf};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 
@@ -17,29 +20,15 @@ pub enum SymlinkError {
     IOError(#[from] std::io::Error),
 }
 
-/// Creates a symlink on macOS and Linux from link to original.
-#[cfg(any(target_os = "macos", target_os = "linux"))]
 pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
-    std::os::unix::fs::symlink(original, link)?;
-
-    Ok(())
-}
-
-/// Creates a symlink on Windows from link to original.
-#[cfg(target_os = "windows")]
-pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
-    match original.is_dir() {
-        true => std::os::windows::fs::symlink_dir(original, link)?,
-        false => std::os::windows::fs::symlink_file(original, link)?,
+    if !fs::exists(original)? {
+        return Err(SymlinkError::OriginalNotFound {
+            original: original.to_path_buf(),
+        });
     }
 
+    platform::create_symlink(original, link)?;
     Ok(())
-}
-
-/// Panics for any unsupported OS.
-#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
-pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
-    panic!("Cannot create link for target, target is not supported.");
 }
 
 /// Removes the given symlink. This is platform independent.
@@ -51,4 +40,47 @@ pub fn remove_symlink(symlink: &Path) -> Result<(), SymlinkError> {
     std::fs::remove_file(symlink)?;
 
     Ok(())
+}
+
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+pub mod platform {
+    use std::path::Path;
+
+    use super::SymlinkError;
+
+    /// Creates a symlink on macOS and Linux from link to original.
+    pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
+        std::os::unix::fs::symlink(original, link)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(target_os = "windows")]
+pub mod platform {
+    use std::path::Path;
+
+    use super::SymlinkError;
+
+    /// Creates a symlink on Windows from link to original.
+    pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
+        match original.is_dir() {
+            true => std::os::windows::fs::symlink_dir(original, link)?,
+            false => std::os::windows::fs::symlink_file(original, link)?,
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+pub mod platform {
+    use std::path::Path;
+
+    use super::SymlinkError;
+
+    /// Panics for any unsupported OS.
+    pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
+        panic!("Cannot create link for target, target is not supported.");
+    }
 }

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -95,7 +95,7 @@ impl<'a> RepositoryManager<'a> {
             let package = match provider.read_package(package) {
                 Ok(package) => package,
                 Err(e) => {
-                    debug!(e, "Unable to read {package} from repository {repository_id}, continuing...");
+                    debug!(err: e, "Unable to read {package} from repository {repository_id}, continuing...");
                     continue;
                 },
             };

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -69,14 +69,3 @@ pub fn remove_symlinks(search_dir: &Path, destination_dir: &Path) -> Result<(), 
 
     Ok(())
 }
-
-pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
-    if !fs::exists(original)? {
-        return Err(SymlinkError::OriginalNotFound {
-            original: original.to_path_buf(),
-        });
-    }
-
-    symlink::create_symlink(original, link)?;
-    Ok(())
-}

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -65,3 +65,14 @@ pub fn remove_symlinks(search_dir: &Path, destination_dir: &Path) -> Result<(), 
 
     Ok(())
 }
+
+pub fn create_symlink(original: &Path, link: &Path) -> Result<(), SymlinkError> {
+    if !fs::exists(original)? {
+        return Err(SymlinkError::OriginalNotFound {
+            original: original.to_path_buf(),
+        });
+    }
+
+    symlink::create_symlink(original, link)?;
+    Ok(())
+}

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -45,6 +45,10 @@ pub fn create_folder_symlinks(original_dir: &Path, link_dir: &Path) -> Result<()
 
 /// Searches for symlinks with a certain destination (destinations inside of the destination are also a match) and removes them.
 pub fn remove_symlinks(search_dir: &Path, destination_dir: &Path) -> Result<(), SymlinkError> {
+    if !search_dir.exists() {
+        return Ok(());
+    }
+
     for file in fs::read_dir(search_dir)? {
         let file = file?;
         let file_type = file.file_type()?;

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -104,7 +104,7 @@ impl<'a> Repairer<'a> {
             // We have to uninstall and install, because we can't know the repository source otherwise
             // Remove the symlinks first
             if symlinked {
-                remove_symlinks(Path::new(&self.config.prefix_directory), Path::new(&package_directory))?;
+                remove_symlinks(Path::new(&self.config.prefix_directory), &package_directory)?;
             }
 
             // Remove the package


### PR DESCRIPTION
This PR fixes the prebuilds by implementing binary patching for macOS and Linux. It links binaries to a `<prefix>/dependencies` path, to ensure binaries don't need to be changed to switch the linked version.