### PR TITLE
only preserve mtime when building, and discard when unpacking a prebuild

### DIFF
--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -146,13 +146,8 @@ impl<'a> Builder<'a> {
 
         // Unpack the package to the temp directory
         let unpack_directory = TempDir::new()?;
-        unpack(
-            package_name,
-            ArchiveExtension::from_path(&source.url),
-            bytes,
-            &unpack_directory,
-            true,
-        )?;
+        let extention = ArchiveExtension::from_path(&source.url);
+        unpack(package_name, extention, bytes, &unpack_directory, true)?;
 
         // Create build env
         let env = BuildEnv::new(

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -146,7 +146,13 @@ impl<'a> Builder<'a> {
 
         // Unpack the package to the temp directory
         let unpack_directory = TempDir::new()?;
-        unpack(package_name, ArchiveExtension::from_path(&source.url), bytes, &unpack_directory)?;
+        unpack(
+            package_name,
+            ArchiveExtension::from_path(&source.url),
+            bytes,
+            &unpack_directory,
+            true,
+        )?;
 
         // Create build env
         let env = BuildEnv::new(

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -389,7 +389,7 @@ impl<'a> Installer<'a> {
         }
 
         // Unpack the prebuild to the destination
-        unpack(&package.name, extension, bytes, &destination_dir)?;
+        unpack(&package.name, extension, bytes, &destination_dir, false)?;
 
         Ok(())
     }

--- a/src/installer/unpack.rs
+++ b/src/installer/unpack.rs
@@ -49,7 +49,13 @@ impl ArchiveExtension {
 }
 
 // Unpacks files and saves them to the provided destination directory.
-pub fn unpack<P: AsRef<Path>>(package: &PackageName, extension: ArchiveExtension, bytes: Bytes, destination_directory: P) -> Result<()> {
+pub fn unpack<P: AsRef<Path>>(
+    package: &PackageName,
+    extension: ArchiveExtension,
+    bytes: Bytes,
+    destination_directory: P,
+    keep_timestamp: bool,
+) -> Result<()> {
     let size = bytes.len();
     let cursor = Cursor::new(bytes);
 
@@ -58,7 +64,7 @@ pub fn unpack<P: AsRef<Path>>(package: &PackageName, extension: ArchiveExtension
     let reader = ReaderWithProgress::new(cursor, size as u64, bar_prefix);
 
     match extension {
-        ArchiveExtension::GZ => unpack_gz(reader, destination_directory),
+        ArchiveExtension::GZ => unpack_gz(reader, destination_directory, keep_timestamp),
         ArchiveExtension::ZIP | ArchiveExtension::XZ => unpack_zip_xz(reader, destination_directory),
         _ => Err(UnpackError::ExtensionNotSupported),
     }
@@ -66,10 +72,10 @@ pub fn unpack<P: AsRef<Path>>(package: &PackageName, extension: ArchiveExtension
 
 /// Unpacks gz archives into the provided destination directory.
 /// Could return an IO error.
-fn unpack_gz<P: AsRef<Path>>(reader: ReaderWithProgress<Cursor<Bytes>>, destination_directory: P) -> Result<()> {
+fn unpack_gz<P: AsRef<Path>>(reader: ReaderWithProgress<Cursor<Bytes>>, destination_directory: P, keep_timestamp: bool) -> Result<()> {
     let tar = GzDecoder::new(reader);
     let mut archive = Archive::new(tar);
-    archive.set_preserve_mtime(false);
+    archive.set_preserve_mtime(keep_timestamp);
     archive.unpack(destination_directory)?;
 
     Ok(())


### PR DESCRIPTION
Small bugfix: Only preserve mtime when building, and discard when unpacking a prebuild.