### PR TITLE
Add Licenses options for metadata

### DIFF
--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -97,8 +97,8 @@ impl InfoArgs {
             println!("Homepage: {homepage}");
         }
 
-        if let Some(license) = &package_version.license {
-            println!("License: {}", license);
+        if !package_version.license.is_none() {
+            println!("License: {}", package_version.license);
         }
 
         println!(

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -97,7 +97,7 @@ impl InfoArgs {
             println!("Homepage: {homepage}");
         }
 
-        if !package_version.license.is_none() {
+        if !package_version.license.is_unknown() {
             println!("License: {}", package_version.license);
         }
 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -85,7 +85,7 @@ impl HandleCommand for SearchArgs {
         println!("{}", package.description.green());
         println!("Latest version: {}", latest_version.to_string().red());
         println!("Dependencies: {}", dependencies.join(", ").red());
-        println!("License: {}", package_version.license.unwrap_or("None".to_string()).red());
+        println!("License: {}", package_version.license.to_string().red());
 
         // Also print revisions if there are any
         if package_version.revisions.len() > 0 {

--- a/src/repositories/types/license.rs
+++ b/src/repositories/types/license.rs
@@ -1,0 +1,41 @@
+use std::fmt::Display;
+
+use serde::{Deserialize, Serialize};
+
+/// Wrapper to differentiate between different License types in metadata files.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum Licenses {
+    None,
+    Single(String),
+    Any {
+        any: Vec<String>,
+    },
+    All {
+        all: Vec<String>,
+    },
+}
+
+impl Licenses {
+    /// Returns true if the License is `None`.
+    pub fn is_none(&self) -> bool {
+        matches!(self, Self::None)
+    }
+}
+
+impl Display for Licenses {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Licenses::None => write!(f, "None"),
+            Licenses::Single(license) => write!(f, "{license}"),
+            Licenses::Any { any } => write!(f, "any of: {}", any.join(", ")),
+            Licenses::All { all } => write!(f, "all of: {}", all.join(", ")),
+        }
+    }
+}
+
+impl Default for Licenses {
+    fn default() -> Self {
+        Self::None
+    }
+}

--- a/src/repositories/types/license.rs
+++ b/src/repositories/types/license.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(untagged)]
 pub enum Licenses {
-    None,
+    Unknown,
     Single(String),
     Any {
         any: Vec<String>,
@@ -17,16 +17,16 @@ pub enum Licenses {
 }
 
 impl Licenses {
-    /// Returns true if the License is `None`.
-    pub fn is_none(&self) -> bool {
-        matches!(self, Self::None)
+    /// Returns true if the License is `Unknown`.
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Self::Unknown)
     }
 }
 
 impl Display for Licenses {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Licenses::None => write!(f, "None"),
+            Licenses::Unknown => write!(f, "Unknown"),
             Licenses::Single(license) => write!(f, "{license}"),
             Licenses::Any { any } => write!(f, "any of: {}", any.join(", ")),
             Licenses::All { all } => write!(f, "all of: {}", all.join(", ")),
@@ -36,6 +36,6 @@ impl Display for Licenses {
 
 impl Default for Licenses {
     fn default() -> Self {
-        Self::None
+        Self::Unknown
     }
 }

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -1,5 +1,6 @@
 mod checksum;
 mod common;
+mod license;
 mod package;
 mod package_target;
 mod package_version;
@@ -16,9 +17,9 @@ pub use self::package_version::PackageVersionMeta;
 pub use self::checksum::Checksum;
 pub use self::common::Script;
 
-#[cfg(test)]
 pub use self::common::Source;
-#[cfg(test)]
 pub use self::common::Sources;
+
+pub use self::license::Licenses;
 
 pub use self::target_bounds::TargetBounds;

--- a/src/repositories/types/package.rs
+++ b/src/repositories/types/package.rs
@@ -7,7 +7,7 @@ use crate::{
     platforms::Target,
     repositories::{
         error::{RepositoryError, Result},
-        types::target_bounds::TargetBounds,
+        types::TargetBounds,
     },
 };
 

--- a/src/repositories/types/package_version.rs
+++ b/src/repositories/types/package_version.rs
@@ -10,11 +10,7 @@ use crate::{
     platforms::Target,
     repositories::{
         error::{RepositoryError, Result},
-        types::{
-            PackageTarget, Script,
-            common::{Source, Sources},
-            target_bounds::TargetBounds,
-        },
+        types::{Licenses, PackageTarget, Script, Source, Sources, TargetBounds},
     },
 };
 
@@ -30,8 +26,8 @@ pub struct PackageVersionMeta {
     #[serde(rename = "source")]
     pub sources: Sources,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub license: Option<String>,
+    #[serde(skip_serializing_if = "Licenses::is_none", default)]
+    pub license: Licenses,
 
     #[serde(default = "PackageVersionMeta::default_skip_symlinking")]
     pub skip_symlinking: bool,

--- a/src/repositories/types/package_version.rs
+++ b/src/repositories/types/package_version.rs
@@ -26,7 +26,7 @@ pub struct PackageVersionMeta {
     #[serde(rename = "source")]
     pub sources: Sources,
 
-    #[serde(skip_serializing_if = "Licenses::is_none", default)]
+    #[serde(skip_serializing_if = "Licenses::is_unknown", default)]
     pub license: Licenses,
 
     #[serde(default = "PackageVersionMeta::default_skip_symlinking")]

--- a/src/storage/installed_package_version.rs
+++ b/src/storage/installed_package_version.rs
@@ -2,15 +2,15 @@ use std::{collections::HashSet, path::PathBuf};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{config::Repository, installer::types::PackageId};
+use crate::{config::Repository, installer::types::PackageId, repositories::types::Licenses};
 
 /// Represents a specific package version which is installed on the system.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct InstalledPackageVersion {
     pub package_id: PackageId,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub license: Option<String>,
+    #[serde(skip_serializing_if = "Licenses::is_none", default)]
+    pub license: Licenses,
 
     #[serde(default = "Repository::default_repository_provider")]
     #[serde(skip_serializing_if = "is_repository_provider_default")]

--- a/src/storage/installed_package_version.rs
+++ b/src/storage/installed_package_version.rs
@@ -9,7 +9,7 @@ use crate::{config::Repository, installer::types::PackageId, repositories::types
 pub struct InstalledPackageVersion {
     pub package_id: PackageId,
 
-    #[serde(skip_serializing_if = "Licenses::is_none", default)]
+    #[serde(skip_serializing_if = "Licenses::is_unknown", default)]
     pub license: Licenses,
 
     #[serde(default = "Repository::default_repository_provider")]

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -281,7 +281,7 @@ pub mod tests {
     use crate::installer::types::VersionIntervals;
     use crate::installer::types::dependency_tests::create_dependency;
     use crate::platforms::TargetArchitecture;
-    use crate::repositories::types::{Checksum, Source, Sources, TargetBounds};
+    use crate::repositories::types::{Checksum, Licenses, Source, Sources, TargetBounds};
 
     use super::*;
 
@@ -292,7 +292,7 @@ pub mod tests {
     ) -> InstalledPackageVersion {
         InstalledPackageVersion {
             package_id,
-            license: None,
+            license: Licenses::None,
             source_repository_provider: "-".to_string(),
             source_repository_url: "-".to_string(),
             source_prebuild_repository_url: None,
@@ -400,7 +400,7 @@ pub mod tests {
                 checksum: Checksum { sha256: [0; 32] },
                 mirrors: Vec::new(),
             }),
-            license: None,
+            license: Licenses::None,
             skip_symlinking: false,
             script_args: HashMap::new(),
             use_version_specific_build: false,

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -292,7 +292,7 @@ pub mod tests {
     ) -> InstalledPackageVersion {
         InstalledPackageVersion {
             package_id,
-            license: Licenses::None,
+            license: Licenses::Unknown,
             source_repository_provider: "-".to_string(),
             source_repository_url: "-".to_string(),
             source_prebuild_repository_url: None,
@@ -400,7 +400,7 @@ pub mod tests {
                 checksum: Checksum { sha256: [0; 32] },
                 mirrors: Vec::new(),
             }),
-            license: Licenses::None,
+            license: Licenses::Unknown,
             skip_symlinking: false,
             script_args: HashMap::new(),
             use_version_specific_build: false,


### PR DESCRIPTION
This PR implements several options for specifying licenses in the metadata.

The supported options are:
- Single: just a single license as string
- Any: Any of the licenses in the list
- All: All of the licenses in the list