### PR TITLE
Automatically set packit path in install.sh

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -20,6 +20,7 @@ mkdir "%PREFIX_DIR%\packages\packit\%VERSION%\bin"
 pushd "%PREFIX_DIR%\packages\packit\%VERSION%\bin"
 
 REM Install Packit to the prefix directory 
+echo Downloading Packit prebuild
 curl --proto "=https" -sSfL %SOURCE_PREBUILD_REPOSITORY_URL% --output packit.exe
 if not ERRORLEVEL 1 (
     echo Downloaded prebuild
@@ -163,6 +164,19 @@ if ERRORLEVEL 1 (
     echo Unsuccessfull install of Packit, the 'packit' command cannot be found
     popd
     exit /b 1
+)
+
+REM Ask the user if they want to automatically add Packit to their PATH
+set "answer="
+set /p "answer=Do you wish to automatically add Packit to your user PATH? (Y/n) "
+set "match="
+if "!answer!"=="y" set "match=1"
+if "!answer!"=="yes" set "match=1"
+if "!answer!"=="" set "match=1"
+if "!match!"=="1" (
+    setx PATH "%PATH%;%PREFIX_DIR%\bin"
+    popd
+    exit /b 0
 )
 
 echo Successfully installed Packit

--- a/install.bat
+++ b/install.bat
@@ -166,6 +166,14 @@ if ERRORLEVEL 1 (
     exit /b 1
 )
 
+echo Successfully installed Packit
+
+REM Exit early if Packit is already in the user PATH
+echo ";%PATH%;" | find /I ";%PREFIX_DIR%\bin;" >nul
+if %ERRORLEVEL%==0 (
+    exit /b 0
+)
+
 REM Ask the user if they want to automatically add Packit to their PATH
 set "answer="
 set /p "answer=Do you wish to automatically add Packit to your user PATH? (Y/n) "
@@ -179,7 +187,6 @@ if "!match!"=="1" (
     exit /b 0
 )
 
-echo Successfully installed Packit
 echo Add %PREFIX_DIR%\bin to your PATH by adding the command below to your shell:
 echo setx PATH "%%PATH%%;%PREFIX_DIR%\bin"
 

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 set -eu
 
+main () {
 VERSION="0.0.1"
 CURRENT_OS="$(uname -s)"
 
@@ -204,8 +205,19 @@ case "$SHELL" in
         ;;
     *fish)
         # Fish is not POSIX, so it needs custom handling
-        set -Ux fish_user_paths "$PREFIX_DIR/bin" $fish_user_paths
-        exit 0
+        echo "Do you wish to automatically add Packit to your PATH? (Y/n)"
+
+        # Use /dev/tty when stdin is not available
+        if [ -t 0 ]; then
+            read answer
+        else
+            read answer < /dev/tty
+        fi
+
+        if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
+            fish -c "fish_add_path $PREFIX_DIR/bin"
+            exit 0
+        fi
         ;;
     *)
         ;;
@@ -230,3 +242,6 @@ fi
 # If the shell is not recognized or user did not want to add Packit automatically tell the user how to add Packit to their shell config
 echo "Add $PREFIX_DIR/bin to your PATH by adding the command below to your shell config:"
 echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\""
+}
+
+main "$@"

--- a/install.sh
+++ b/install.sh
@@ -54,6 +54,7 @@ sudo chown -R $USERNAME "$PREFIX_DIR"
 cd "$PREFIX_DIR/packages/packit/$VERSION/bin"
 
 # Install Packit to the prefix directory
+echo "Downloading Packit prebuild"
 if curl --proto "=https" -sSfL $SOURCE_PREBUILD_REPOSITORY_URL --output packit; then
     echo "Downloaded prebuild"
 else
@@ -171,5 +172,35 @@ if ! command -v $PREFIX_DIR/bin/packit -h >/dev/null 2>&1; then
 fi
 
 echo "Successfully installed Packit"
-echo "Add $PREFIX_DIR/bin to your PATH by adding the command below to your shell (.bashrc or .zshrc):"
+
+SHELL_CONFIG_PATH=""
+
+case "$SHELL" in
+    *zsh)
+        SHELL_CONFIG_PATH="$HOME/.zshrc"
+        ;;
+    *bash)
+        SHELL_CONFIG_PATH="$HOME/.bashrc"
+        ;;
+    *fish)
+        # Fish is not POSIX, so it needs custom handling
+        set -Ux fish_user_paths "$PREFIX_DIR/bin" $fish_user_paths
+        exit 0
+        ;;
+    *)
+        echo Nothing matched
+        ;;
+esac
+
+if [ -e "$SHELL_CONFIG_PATH" ]; then
+    echo "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n)"
+    read answer
+    if [ $answer = "y" ] || [ $answer = "yes" ] || [ $answer = "" ]; then
+        echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
+        exit 0
+    fi
+fi
+
+# If the shell is not recognized or user did not want to add Packit automatically tell the user how to add Packit to their shell config
+echo "Add $PREFIX_DIR/bin to your PATH by adding the command below to your shell config:"
 echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\""

--- a/install.sh
+++ b/install.sh
@@ -59,8 +59,15 @@ if curl --proto "=https" -sSfL $SOURCE_PREBUILD_REPOSITORY_URL --output packit; 
     echo "Downloaded prebuild"
 else
     echo "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n)"
-    read answer
-    if [ $answer = "n" ] || [ $answer = "no" ]; then
+    
+    # Use /dev/tty when stdin is not available
+    if [ -t 0 ]; then
+        read answer
+    else
+        read answer < /dev/tty
+    fi
+
+    if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
         echo "Canceling installation of Packit"
         exit 1
     fi
@@ -70,8 +77,15 @@ else
     # Make sure cargo exists before building Packit
     if ! command -v cargo >/dev/null 2>&1; then
         echo "Cargo is not installed, do you wish to install it to build Packit? (y/N)"
-        read answer
-        if [ $answer = "n" ] || [ $answer = "no" ] || [ $answer = "" ]; then
+        
+        # Use /dev/tty when stdin is not available
+        if [ -t 0 ]; then
+            read answer
+        else
+            read answer < /dev/tty
+        fi
+
+        if [ "$answer" = "n" ] || [ "$answer" = "no" ] || [ "$answer" = "" ]; then
             echo "Canceling installation of Packit"
             exit 1
         fi
@@ -98,9 +112,15 @@ else
 
     if [ $RUSTUP_INSTALLED -eq 1 ]; then
         echo "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n)"
-        read answer
+        
+        # Use /dev/tty when stdin is not available
+        if [ -t 0 ]; then
+            read answer
+        else
+            read answer < /dev/tty
+        fi
 
-        if [ $answer = "y" ] || [ $answer = "yes" ] || [ $answer = "" ]; then
+        if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             echo "Uninstalling rustup"
             rustup self uninstall
         fi
@@ -188,14 +208,20 @@ case "$SHELL" in
         exit 0
         ;;
     *)
-        echo Nothing matched
         ;;
 esac
 
 if [ -e "$SHELL_CONFIG_PATH" ]; then
     echo "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n)"
-    read answer
-    if [ $answer = "y" ] || [ $answer = "yes" ] || [ $answer = "" ]; then
+
+    # Use /dev/tty when stdin is not available
+    if [ -t 0 ]; then
+        read answer
+    else
+        read answer < /dev/tty
+    fi
+
+    if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
         exit 0
     fi

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,17 @@
 #!/bin/sh
 set -eu
 
+# Gets user input and uses /dev/tty when stdin is not available
+get_answer() {
+    if [ -t 0 ]; then
+        read answer
+    else
+        read answer < /dev/tty
+    fi
+
+    echo "$answer"
+}
+
 main () {
 VERSION="0.0.1"
 CURRENT_OS="$(uname -s)"
@@ -60,13 +71,7 @@ if curl --proto "=https" -sSfL $SOURCE_PREBUILD_REPOSITORY_URL --output packit; 
     echo "Downloaded prebuild"
 else
     echo "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n)"
-    
-    # Use /dev/tty when stdin is not available
-    if [ -t 0 ]; then
-        read answer
-    else
-        read answer < /dev/tty
-    fi
+    answer=$(get_answer)
 
     if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
         echo "Canceling installation of Packit"
@@ -78,13 +83,7 @@ else
     # Make sure cargo exists before building Packit
     if ! command -v cargo >/dev/null 2>&1; then
         echo "Cargo is not installed, do you wish to install it to build Packit? (y/N)"
-        
-        # Use /dev/tty when stdin is not available
-        if [ -t 0 ]; then
-            read answer
-        else
-            read answer < /dev/tty
-        fi
+        answer=$(get_answer)
 
         if [ "$answer" = "n" ] || [ "$answer" = "no" ] || [ "$answer" = "" ]; then
             echo "Canceling installation of Packit"
@@ -113,13 +112,7 @@ else
 
     if [ $RUSTUP_INSTALLED -eq 1 ]; then
         echo "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n)"
-        
-        # Use /dev/tty when stdin is not available
-        if [ -t 0 ]; then
-            read answer
-        else
-            read answer < /dev/tty
-        fi
+        answer=$(get_answer)
 
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             echo "Uninstalling rustup"
@@ -194,6 +187,11 @@ fi
 
 echo "Successfully installed Packit"
 
+# Exit early if Packit is already in the PATH
+if echo ":$PATH:" | grep -q ":$PREFIX_DIR/bin:"; then
+    exit 0
+fi
+
 SHELL_CONFIG_PATH=""
 
 case "$SHELL" in
@@ -206,13 +204,7 @@ case "$SHELL" in
     *fish)
         # Fish is not POSIX, so it needs custom handling
         echo "Do you wish to automatically add Packit to your PATH? (Y/n)"
-
-        # Use /dev/tty when stdin is not available
-        if [ -t 0 ]; then
-            read answer
-        else
-            read answer < /dev/tty
-        fi
+        answer=$(get_answer)
 
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             fish -c "fish_add_path $PREFIX_DIR/bin"
@@ -225,13 +217,7 @@ esac
 
 if [ -e "$SHELL_CONFIG_PATH" ]; then
     echo "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n)"
-
-    # Use /dev/tty when stdin is not available
-    if [ -t 0 ]; then
-        read answer
-    else
-        read answer < /dev/tty
-    fi
+    answer=$(get_answer)
 
     if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"


### PR DESCRIPTION
This feature gives users the option to automatically add Packit to their PATH. 
It also fixes a bug which results when piping to the shell (which we do with curl). When piping there is no interactive shell, so now we check if an interactive shell is available, if not, we use /dev/tty with read for user input.

(With special thnx to Berke)