### PR TITLE
Add support for external test files

### DIFF
--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -309,7 +309,27 @@ impl<'a> Installer<'a> {
                 &script_args,
                 self.options.verbose,
             );
-            scripts::run_test_script(&script_data)?;
+
+            let external_files = version_meta.external_test_files.iter().chain(&target.external_test_files);
+            let mut read_files = Vec::new();
+            let mut skip_test = false;
+            for file in external_files {
+                let file_content =
+                    self.repository_manager.read_file(&install_meta.repository_id, &install_meta.package_metadata.name, file)?;
+
+                match file_content {
+                    Some(content) => read_files.push((file, content)),
+                    None => {
+                        warning!("Skipping test, because the required files could not be downloaded.");
+                        skip_test = true;
+                        break;
+                    },
+                }
+            }
+
+            if !skip_test {
+                scripts::run_test_script(&script_data, &read_files)?;
+            }
         }
 
         Ok(())
@@ -646,7 +666,7 @@ impl<'a> Installer<'a> {
         let script_path = package_version.get_uninstall_script_path(&target_bounds)?;
 
         // Download and run script
-        if let Some(script_text) = provider.read_script(&package_id.name, &script_path)? {
+        if let Some(script_text) = provider.read_file(&package_id.name, &script_path)? {
             let script_path = scripts::write_script_to_tempfile(&script_text)?;
 
             // Run script

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -101,9 +101,16 @@ pub fn run_post_script(script_data: &ScriptData) -> Result<()> {
 }
 
 /// Runs the given test script, in a newly created temp directory.
+/// It also writes the specified external test files to the temp directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_test_script(script_data: &ScriptData) -> Result<()> {
+pub fn run_test_script(script_data: &ScriptData, external_files: &Vec<(&String, String)>) -> Result<()> {
     let temp_dir = TempDir::new().map_err(ScriptError::TempCreationError)?;
+
+    // Install external files into the temp directory
+    for (file_name, file_content) in external_files {
+        fs::write(temp_dir.path().join(file_name), file_content).map_err(ScriptError::SaveError)?;
+    }
+
     run_script(script_data, &temp_dir, Environment::new(), true)
 }
 
@@ -182,7 +189,7 @@ pub fn download_script(
     package_name: &PackageName,
     repository_id: &str,
 ) -> Result<Option<NamedTempFile>> {
-    let script_text = match repository_manager.read_script(repository_id, package_name, script_path)? {
+    let script_text = match repository_manager.read_file(repository_id, package_name, script_path)? {
         Some(script_text) => script_text,
         None => return Ok(None), // Script not found, so return None
     };

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::collections::HashMap;
+use std::{collections::HashMap, path::PathBuf};
 
 use bytes::Bytes;
 
@@ -192,7 +192,7 @@ impl<'a> RepositoryManager<'a> {
 
     /// Reads a file of the given package from the given repository.
     /// Returns the file as a string.
-    pub fn read_file(&self, repository_id: &str, package: &PackageName, script_path: &str) -> Result<Option<String>> {
+    pub fn read_file(&self, repository_id: &str, package: &PackageName, file_path: &str) -> Result<Option<String>> {
         let provider = match self.metadata_providers.get(repository_id) {
             Some(provider) => provider,
             None => {
@@ -202,7 +202,7 @@ impl<'a> RepositoryManager<'a> {
             },
         };
 
-        provider.read_file(package, script_path)
+        provider.read_file(package, file_path)
     }
 
     /// Retrieves the prebuild url for the given package version.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -190,9 +190,9 @@ impl<'a> RepositoryManager<'a> {
         Ok(package)
     }
 
-    /// Reads a script of the given package from the given repository.
-    /// Returns the script as a string.
-    pub fn read_script(&self, repository_id: &str, package: &PackageName, script_path: &str) -> Result<Option<String>> {
+    /// Reads a file of the given package from the given repository.
+    /// Returns the file as a string.
+    pub fn read_file(&self, repository_id: &str, package: &PackageName, script_path: &str) -> Result<Option<String>> {
         let provider = match self.metadata_providers.get(repository_id) {
             Some(provider) => provider,
             None => {
@@ -202,7 +202,7 @@ impl<'a> RepositoryManager<'a> {
             },
         };
 
-        provider.read_script(package, script_path)
+        provider.read_file(package, script_path)
     }
 
     /// Retrieves the prebuild url for the given package version.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashMap, path::PathBuf};
+use std::collections::HashMap;
 
 use bytes::Bytes;
 

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -38,10 +38,10 @@ impl MetadataProvider for FileSystemMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    /// Reads a script and returns its content as a string. If the script doesn't exist Ok(None) is returned.
+    /// Reads a file and returns its content as a string. If the file doesn't exist Ok(None) is returned.
     /// Returns an IO error if `fs::read_to_string` fails.
-    fn read_script(&self, package: &PackageName, script_path: &str) -> Result<Option<String>> {
-        let path = self.path.join("packages").join(package.to_string()).join(script_path);
+    fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>> {
+        let path = self.path.join("packages").join(package.to_string()).join(file_path);
 
         if !fs::exists(&path)? {
             return Ok(None);

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -41,6 +41,7 @@ impl MetadataProvider for FileSystemMetadataProvider {
     /// Reads a file and returns its content as a string. If the file doesn't exist Ok(None) is returned.
     /// Returns an IO error if `fs::read_to_string` fails.
     fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>> {
+        let file_path = PathBuf::from(file_path);
         let path = self.path.join("packages").join(package.to_string()).join(file_path);
 
         if !fs::exists(&path)? {

--- a/src/repositories/metadata/web.rs
+++ b/src/repositories/metadata/web.rs
@@ -38,10 +38,10 @@ impl MetadataProvider for WebMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    /// Reads a script and returns its content as a string. If the script doesn't exist Ok(None) is returned.
+    /// Reads a file and returns its content as a string. If the file doesn't exist Ok(None) is returned.
     /// Returns a response error if `requests::get` or `Response::text` fails.
-    fn read_script(&self, package: &PackageName, script_path: &str) -> Result<Option<String>> {
-        let response = requests::get(format!("{}/packages/{package}/{script_path}", self.url))?;
+    fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>> {
+        let response = requests::get(format!("{}/packages/{package}/{file_path}", self.url))?;
 
         if response.status() == StatusCode::NOT_FOUND {
             return Ok(None);

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -27,8 +27,8 @@ pub trait MetadataProvider {
     /// Reads the metadata of a certain version of a package, containing dependencies and targets.
     fn read_package_version(&self, package: &PackageName, version: &Version) -> Result<PackageVersionMeta>;
 
-    /// Reads the requested script from the repository.
-    fn read_script(&self, package: &PackageName, script_path: &str) -> Result<Option<String>>;
+    /// Reads the requested file from the repository.
+    fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>>;
 }
 
 /// Generic prebuild repository provider trait, reading prebuild packages from a repository.

--- a/src/repositories/types/package_target.rs
+++ b/src/repositories/types/package_target.rs
@@ -27,12 +27,6 @@ pub struct PackageTarget {
     pub test_script: Option<Script>,
     pub uninstall_script: Option<Script>,
 
-    #[serde(default = "PackageTarget::default_external_files")]
+    #[serde(default)]
     pub external_test_files: HashSet<String>,
-}
-
-impl PackageTarget {
-    fn default_external_files() -> HashSet<String> {
-        HashSet::new()
-    }
 }

--- a/src/repositories/types/package_target.rs
+++ b/src/repositories/types/package_target.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
 
@@ -26,4 +26,13 @@ pub struct PackageTarget {
     pub postinstall_script: Option<Script>,
     pub test_script: Option<Script>,
     pub uninstall_script: Option<Script>,
+
+    #[serde(default = "PackageTarget::default_external_files")]
+    pub external_test_files: HashSet<String>,
+}
+
+impl PackageTarget {
+    fn default_external_files() -> HashSet<String> {
+        HashSet::new()
+    }
 }

--- a/src/repositories/types/package_version.rs
+++ b/src/repositories/types/package_version.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::Deserialize;
 
@@ -50,6 +50,9 @@ pub struct PackageVersionMeta {
 
     #[serde(default = "PackageVersionMeta::default_use_version_specific")]
     pub use_version_specific_uninstall: bool,
+
+    #[serde(default = "PackageVersionMeta::default_external_files")]
+    pub external_test_files: HashSet<String>,
 
     #[serde(default)]
     pub revisions: Vec<String>,
@@ -196,5 +199,9 @@ impl PackageVersionMeta {
 
     fn default_use_version_specific() -> bool {
         false
+    }
+
+    fn default_external_files() -> HashSet<String> {
+        HashSet::new()
     }
 }

--- a/src/repositories/types/package_version.rs
+++ b/src/repositories/types/package_version.rs
@@ -51,7 +51,7 @@ pub struct PackageVersionMeta {
     #[serde(default = "PackageVersionMeta::default_use_version_specific")]
     pub use_version_specific_uninstall: bool,
 
-    #[serde(default = "PackageVersionMeta::default_external_files")]
+    #[serde(default)]
     pub external_test_files: HashSet<String>,
 
     #[serde(default)]
@@ -199,9 +199,5 @@ impl PackageVersionMeta {
 
     fn default_use_version_specific() -> bool {
         false
-    }
-
-    fn default_external_files() -> HashSet<String> {
-        HashSet::new()
     }
 }

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -396,6 +396,7 @@ pub mod tests {
             dependencies: Vec::new(),
             build_dependencies: Vec::new(),
             targets: HashMap::new(),
+            external_test_files: HashSet::new(),
             sources: Sources::Single(Source {
                 url: "-".to_string(),
                 checksum: Checksum { sha256: [0; 32] },


### PR DESCRIPTION
Feature which allows for external test file in the core repository.
Also fixes a bug in the read_file method in the filesystem implementation of MetadataProvider. We now convert the file_path parameter to a PathBuf to make it work on every platform.