### PR TITLE
Add support for patches to packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `--updatables` flag on the list command, to list packages which can be updated.
 - The list command now has grid printing.
 - The regex search, to search packages based on a given regex pattern.
+- Add support for applying patches to the source code of packages.
 
 ### Removed
 - The repositories command, this command is now integrated in the new config command.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -536,8 +536,9 @@ dependencies = [
 
 [[package]]
 name = "diffy"
-version = "0.4.2"
-source = "git+https://github.com/bmwill/diffy.git#420a9d6f5c0ef831392083a09c09f344f487babf"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
  "hashbrown 0.17.0",
  "zlib-rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "diffy"
+version = "0.4.2"
+source = "git+https://github.com/bmwill/diffy.git#420a9d6f5c0ef831392083a09c09f344f487babf"
+dependencies = [
+ "hashbrown 0.17.0",
+ "zlib-rs",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +673,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -857,7 +872,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -865,6 +880,9 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
@@ -1639,6 +1657,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "diffy",
  "enable-ansi-support",
  "flate2",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ lief = { git = "https://github.com/lief-project/LIEF.git", rev = "1915b921dee222
 url = "2.5.8"
 toml_edit = "0.25.11"
 terminal_size = "0.4.4"
+diffy = { git = "https://github.com/bmwill/diffy.git", features = ["binary"] }
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ lief = { git = "https://github.com/lief-project/LIEF.git", rev = "1915b921dee222
 url = "2.5.8"
 toml_edit = "0.25.11"
 terminal_size = "0.4.4"
-diffy = { git = "https://github.com/bmwill/diffy.git", features = ["binary"] }
+diffy = { version = "0.5.0", features = ["binary"] }
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -161,9 +161,11 @@ impl<'a> Builder<'a> {
             apply_directory = apply_directory.join(PathBuf::from(apply_in));
         }
 
+        let package_id = PackageId::new(package_name.clone(), version.clone());
+
         // Apply patches
         for (id, patch) in source.get_sorted_patches() {
-            let description = format!("patch {id}' of '{package_name}");
+            let description = format!("patch {id}' of '{package_id}");
             let patch_bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
 
             // Construct apply directory for this patch
@@ -175,7 +177,7 @@ impl<'a> Builder<'a> {
             // Apply patch
             patches::apply_patch(&patch_bytes, &apply_directory)?;
 
-            println!("Applied patch '{id}' to '{package_name}'");
+            println!("Applied patch '{id}' to '{package_id}'");
         }
 
         // Create build env
@@ -193,10 +195,8 @@ impl<'a> Builder<'a> {
         let script_path = install_meta.version_metadata.get_build_script_path(&install_meta.target_bounds)?;
         let script_path = scripts::download_script(self.repository_manager, &script_path, package_name, &install_meta.repository_id)?
             .ok_or(ScriptError::ScriptNotFound("build".into()))?;
-        let package_id = PackageId::new(package_name.clone(), version.clone());
         let script_data = ScriptData::new(&script_path, &destination_dir, &package_id, self.config, &script_args, self.verbose);
 
-        let package_id = PackageId::new(package_name.clone(), version.clone());
         println!("Executing build script of {package_id}");
 
         // Show build spinner

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use bytes::Bytes;
 use std::{fs, path::Path};
 use tempfile::TempDir;
 use thiserror::Error;
@@ -128,52 +129,8 @@ impl<'a> Builder<'a> {
         // Get source from the package version
         let source = install_meta.version_metadata.get_source(&install_meta.target_bounds)?;
 
-        // Show download spinner
-        let spinner = Spinner::new();
-        spinner.show(format!("Downloading '{package_name}' from {}", &source.url));
-        let mut finish_message = format!("Downloading '{package_name}' from {} successful", &source.url);
-
         // Download the build files
-        let mut mirrors = source.mirrors.iter();
-        let mut response = requests::get(&source.url).map_err(BuilderError::RequestError);
-        if let Ok(status_response) = &response
-            && !status_response.status().is_success()
-        {
-            response = Err(BuilderError::RequestUnsuccessful(status_response.status()));
-        }
-
-        // Loop through mirrors for alternatives in case of error
-        while response.is_err()
-            && let Some(mirror) = mirrors.next()
-        {
-            // Update spinner for new download url
-            spinner.show(format!("Downloading '{package_name}' from alternative {}", &mirror));
-            finish_message = format!("Downloading '{package_name}' from alternative {} successful", &mirror);
-
-            // Get response from alternative mirror
-            response = requests::get(mirror).map_err(BuilderError::RequestError);
-
-            // Check if the response itself is unsuccessful
-            if let Ok(status_response) = &response
-                && !status_response.status().is_success()
-            {
-                response = Err(BuilderError::RequestUnsuccessful(status_response.status()));
-            }
-        }
-
-        // Get the bytes from the response
-        let bytes = response?.bytes()?;
-
-        // Calculate the checksum
-        let checksum = Checksum::from_bytes(&bytes);
-
-        // Check equality of checksum
-        if source.checksum != checksum {
-            return Err(BuilderError::ChecksumError);
-        }
-
-        // Finish download spinner
-        spinner.finish(finish_message);
+        let bytes = self.download_file(&source.url, &source.mirrors, &source.checksum, package_name)?;
 
         // Create temp directory to build in
         let build_directory = TempDir::new()?;
@@ -187,6 +144,14 @@ impl<'a> Builder<'a> {
             let file_name = url.path_segments().and_then(|mut x| x.next_back()).ok_or(BuilderError::EmptyUrlPath)?;
             let file_path = build_directory.path().join(file_name);
             fs::write(file_path, bytes)?;
+        }
+
+        // Apply patches
+        for (id, patch) in source.get_sorted_patches() {
+            let description = format!("patch {id}' of '{package_name}");
+            let bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
+
+            // TODO: apply patches
         }
 
         // Create build env
@@ -230,5 +195,57 @@ impl<'a> Builder<'a> {
         BinaryPatcher::new(self.config).patch_binaries_in(&destination_dir.as_ref().to_path_buf(), &package_id, installed_dependencies)?;
 
         Ok(())
+    }
+
+    /// Downloads a file from the url, or one of the mirrors. Checks against a checksum and shows a spinner.
+    fn download_file(&self, url: &str, mirrors: &Vec<String>, checksum: &Checksum, download_description: &str) -> Result<Bytes> {
+        // Show download spinner
+        let spinner = Spinner::new();
+        spinner.show(format!("Downloading '{download_description}' from {}", &url));
+        let mut finish_message = format!("Downloading '{download_description}' from {} successful", &url);
+
+        // Try to download from the main url
+        let mut mirrors = mirrors.iter();
+        let mut response = requests::get(url).map_err(BuilderError::RequestError);
+        if let Ok(status_response) = &response
+            && !status_response.status().is_success()
+        {
+            response = Err(BuilderError::RequestUnsuccessful(status_response.status()));
+        }
+
+        // Loop through mirrors for alternatives in case of error
+        while response.is_err()
+            && let Some(mirror) = mirrors.next()
+        {
+            // Update spinner with new download url
+            spinner.show(format!("Downloading '{download_description}' from alternative {}", &mirror));
+            finish_message = format!("Downloading '{download_description}' from alternative {} successful", &mirror);
+
+            // Get response from alternative mirror
+            response = requests::get(mirror).map_err(BuilderError::RequestError);
+
+            // Check if the response itself is unsuccessful
+            if let Ok(status_response) = &response
+                && !status_response.status().is_success()
+            {
+                response = Err(BuilderError::RequestUnsuccessful(status_response.status()));
+            }
+        }
+
+        // Get the bytes from the response
+        let bytes = response?.bytes()?;
+
+        // Calculate the checksum
+        let calculated_checksum = Checksum::from_bytes(&bytes);
+
+        // Check equality of checksum
+        if *checksum != calculated_checksum {
+            return Err(BuilderError::ChecksumError);
+        }
+
+        // Finish download spinner
+        spinner.finish(finish_message);
+
+        Ok(bytes)
     }
 }

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -174,6 +174,8 @@ impl<'a> Builder<'a> {
 
             // Apply patch
             patches::apply_patch(&patch_bytes, &apply_directory)?;
+
+            println!("Applied patch '{id}' to '{package_name}'");
         }
 
         // Create build env

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -21,7 +21,10 @@ use crate::{
     platforms::binaries::{BinaryPatcher, BinaryPatcherError},
     repositories::{error::RepositoryError, manager::RepositoryManager, types::Checksum},
     storage::package_register::PackageRegister,
-    utils::requests,
+    utils::{
+        patches::{self, PatchError},
+        requests,
+    },
 };
 
 /// The errors that occur during building.
@@ -52,7 +55,10 @@ pub enum BuilderError {
     RepositoryError(#[from] RepositoryError),
 
     #[error("Cannot patch binaries")]
-    PatchError(#[from] BinaryPatcherError),
+    PatchBinaryError(#[from] BinaryPatcherError),
+
+    #[error("Cannot apply patch file")]
+    ApplyPatchError(#[from] PatchError),
 
     #[error("Cannot request files for building")]
     RequestError(#[from] reqwest::Error),
@@ -158,15 +164,16 @@ impl<'a> Builder<'a> {
         // Apply patches
         for (id, patch) in source.get_sorted_patches() {
             let description = format!("patch {id}' of '{package_name}");
-            let bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
+            let patch_bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
 
             // Construct apply directory for this patch
-            let mut apply_directory = &apply_directory;
-            if let Some(apply_in) = &patch.apply_in {
-                apply_directory = &apply_directory.join(PathBuf::from(apply_in));
-            }
+            let apply_directory = match &patch.apply_in {
+                Some(apply_in) => apply_directory.join(PathBuf::from(apply_in)),
+                None => apply_directory.clone(),
+            };
 
-            // TODO: apply patches
+            // Apply patch
+            patches::apply_patch(&patch_bytes, &apply_directory)?;
         }
 
         // Create build env

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -1,6 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use bytes::Bytes;
-use std::{fs, path::Path};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
 use tempfile::TempDir;
 use thiserror::Error;
 use url::Url;
@@ -146,10 +149,22 @@ impl<'a> Builder<'a> {
             fs::write(file_path, bytes)?;
         }
 
+        // Construct default apply directory for patches
+        let mut apply_directory = build_directory.path().to_path_buf();
+        if let Some(apply_in) = &source.apply_patches_in {
+            apply_directory = apply_directory.join(PathBuf::from(apply_in));
+        }
+
         // Apply patches
         for (id, patch) in source.get_sorted_patches() {
             let description = format!("patch {id}' of '{package_name}");
             let bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
+
+            // Construct apply directory for this patch
+            let mut apply_directory = &apply_directory;
+            if let Some(apply_in) = &patch.apply_in {
+                apply_directory = &apply_directory.join(PathBuf::from(apply_in));
+            }
 
             // TODO: apply patches
         }

--- a/src/installer/builder.rs
+++ b/src/installer/builder.rs
@@ -19,7 +19,11 @@ use crate::{
         unpack::{ArchiveExtension, UnpackError, unpack},
     },
     platforms::binaries::{BinaryPatcher, BinaryPatcherError},
-    repositories::{error::RepositoryError, manager::RepositoryManager, types::Checksum},
+    repositories::{
+        error::RepositoryError,
+        manager::RepositoryManager,
+        types::{Checksum, Patch},
+    },
     storage::package_register::PackageRegister,
     utils::{
         patches::{self, PatchError},
@@ -44,6 +48,9 @@ pub enum BuilderError {
 
     #[error("The source url has an empty path")]
     EmptyUrlPath,
+
+    #[error("The required patch was not found in the repository")]
+    RepositoryPatchNotFound,
 
     #[error("Cannot unpack response")]
     UnpackError(#[from] UnpackError),
@@ -165,8 +172,7 @@ impl<'a> Builder<'a> {
 
         // Apply patches
         for (id, patch) in source.get_sorted_patches() {
-            let description = format!("patch {id}' of '{package_id}");
-            let patch_bytes = self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &description)?;
+            let patch_bytes = self.download_patch(id, patch, &package_id, &install_meta.repository_id)?;
 
             // Construct apply directory for this patch
             let apply_directory = match &patch.apply_in {
@@ -219,6 +225,34 @@ impl<'a> Builder<'a> {
         BinaryPatcher::new(self.config).patch_binaries_in(&destination_dir.as_ref().to_path_buf(), &package_id, installed_dependencies)?;
 
         Ok(())
+    }
+
+    /// Downloads a patch, either from the given url or from the repository.
+    fn download_patch(&self, id: u32, patch: &Patch, package_id: &PackageId, repository_id: &str) -> Result<Bytes> {
+        // Download patch from the url if it starts with 'http://' or 'https://'
+        if patch.url.starts_with("http://") || patch.url.starts_with("https://") {
+            let download_description = format!("patch {id}' of '{package_id}");
+            return self.download_file(&patch.url, &patch.mirrors, &patch.checksum, &download_description);
+        }
+
+        // Create download spinner
+        let spinner = Spinner::new();
+        spinner.show(format!(
+            "Downloading 'patch {id}' of '{package_id}' from repository '{repository_id}'"
+        ));
+
+        // Download patch file from the repository itself
+        let file = self
+            .repository_manager
+            .read_file_bytes(repository_id, &package_id.name, &patch.url)?
+            .ok_or(BuilderError::RepositoryPatchNotFound)?;
+
+        // Finish download spinner
+        spinner.finish(format!(
+            "Downloading 'patch {id}' of '{package_id}' from repository '{repository_id}' successful"
+        ));
+
+        Ok(file)
     }
 
     /// Downloads a file from the url, or one of the mirrors. Checks against a checksum and shows a spinner.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -205,6 +205,21 @@ impl<'a> RepositoryManager<'a> {
     }
 
     /// Reads a file of the given package from the given repository.
+    /// Returns the file as bytes.
+    pub fn read_file_bytes(&self, repository_id: &str, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {
+        let provider = match self.metadata_providers.get(repository_id) {
+            Some(provider) => provider,
+            None => {
+                return Err(RepositoryError::RepositoryNotFoundError {
+                    repository_id: repository_id.into(),
+                });
+            },
+        };
+
+        provider.read_file_bytes(package, file_path)
+    }
+
+    /// Reads a file of the given package from the given repository.
     /// Returns the file as a string.
     pub fn read_file(&self, repository_id: &str, package: &PackageName, file_path: &str) -> Result<Option<String>> {
         let provider = match self.metadata_providers.get(repository_id) {

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{fs, path::PathBuf};
 
+use bytes::Bytes;
+
 use crate::{
     config::Repository,
     installer::types::{PackageName, Version},
@@ -44,8 +46,17 @@ impl MetadataProvider for FileSystemMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    /// Reads a file and returns its content as a string. If the file doesn't exist Ok(None) is returned.
-    /// Returns an IO error if `fs::read_to_string` fails.
+    fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {
+        let file_path = PathBuf::from(file_path);
+        let path = self.path.join("packages").join(package.to_string()).join(file_path);
+
+        if !fs::exists(&path)? {
+            return Ok(None);
+        }
+
+        Ok(Some(fs::read(&path)?.into()))
+    }
+
     fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>> {
         let file_path = PathBuf::from(file_path);
         let path = self.path.join("packages").join(package.to_string()).join(file_path);

--- a/src/repositories/metadata/web.rs
+++ b/src/repositories/metadata/web.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use bytes::Bytes;
 use reqwest::StatusCode;
 
 use crate::{
@@ -44,8 +45,16 @@ impl MetadataProvider for WebMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    /// Reads a file and returns its content as a string. If the file doesn't exist Ok(None) is returned.
-    /// Returns a response error if `requests::get` or `Response::text` fails.
+    fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {
+        let response = requests::get(format!("{}/packages/{package}/{file_path}", self.url))?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(None);
+        }
+
+        Ok(Some(response.bytes()?))
+    }
+
     fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>> {
         let response = requests::get(format!("{}/packages/{package}/{file_path}", self.url))?;
 

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -33,6 +33,9 @@ pub trait MetadataProvider {
     /// Reads the metadata of a certain version of a package, containing dependencies and targets.
     fn read_package_version(&self, package: &PackageName, version: &Version) -> Result<PackageVersionMeta>;
 
+    /// Reads the requested file from the repository as bytes.
+    fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>>;
+
     /// Reads the requested file from the repository.
     fn read_file(&self, package: &PackageName, file_path: &str) -> Result<Option<String>>;
 }

--- a/src/repositories/types/common.rs
+++ b/src/repositories/types/common.rs
@@ -31,13 +31,12 @@ pub struct Source {
     pub skip_unpack: bool,
     pub apply_patches_in: Option<String>,
 
-    #[serde(deserialize_with = "Source::deserialize_patches")]
+    #[serde(default, deserialize_with = "Source::deserialize_patches")]
     pub patches: HashMap<u32, Patch>,
 }
 
 /// Wrapper to differentiate between Single and Named sources in the metadata files.
-#[derive(Deserialize, Debug)]
-#[serde(untagged)]
+#[derive(Debug)]
 pub enum Sources {
     Single(Source),
     Named(HashMap<String, Source>),
@@ -48,6 +47,8 @@ pub enum Sources {
 pub struct Patch {
     pub url: String,
     pub checksum: Checksum,
+
+    #[serde(default)]
     pub mirrors: Vec<String>,
     pub apply_in: Option<String>,
 }
@@ -71,5 +72,25 @@ impl Source {
                 Err(_) => Err(de::Error::invalid_value(de::Unexpected::Str(&key), &"a non-negative integer")),
             })
             .collect()
+    }
+}
+
+// Custom deserialize implementation of source to differentiate between single and named sources.
+impl<'de> Deserialize<'de> for Sources {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value: toml::Value = Deserialize::deserialize(deserializer)?;
+
+        // If the toml contains an url and a checksum, we assume it is a single source
+        if value.get("url").is_some() && value.get("checksum").is_some() {
+            let single = Source::deserialize(value).map_err(de::Error::custom)?;
+
+            return Ok(Sources::Single(single));
+        }
+
+        let named = HashMap::deserialize(value).map_err(de::Error::custom)?;
+        Ok(Sources::Named(named))
     }
 }

--- a/src/repositories/types/common.rs
+++ b/src/repositories/types/common.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::collections::HashMap;
 
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer, de};
 
 use crate::repositories::types::Checksum;
 
@@ -29,6 +29,9 @@ pub struct Source {
 
     #[serde(default)]
     pub skip_unpack: bool,
+    pub apply_patches_in: Option<String>,
+
+    #[serde(deserialize_with = "Source::deserialize_patches")]
     pub patches: HashMap<u32, Patch>,
 }
 
@@ -46,11 +49,27 @@ pub struct Patch {
     pub url: String,
     pub checksum: Checksum,
     pub mirrors: Vec<String>,
+    pub apply_in: Option<String>,
 }
 
 impl Source {
     /// Gets all patches of the source, sorted by id.
     pub fn get_sorted_patches(&self) -> &HashMap<u32, Patch> {
         &self.patches //TODO
+    }
+
+    /// Custom deserializer to deserialize integer keys correctly
+    fn deserialize_patches<'de, D>(deserializer: D) -> Result<HashMap<u32, Patch>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let map = HashMap::<String, Patch>::deserialize(deserializer)?;
+
+        map.into_iter()
+            .map(|(key, value)| match key.parse() {
+                Ok(key) => Ok((key, value)),
+                Err(_) => Err(de::Error::invalid_value(de::Unexpected::Str(&key), &"a non-negative integer")),
+            })
+            .collect()
     }
 }

--- a/src/repositories/types/common.rs
+++ b/src/repositories/types/common.rs
@@ -55,8 +55,10 @@ pub struct Patch {
 
 impl Source {
     /// Gets all patches of the source, sorted by id.
-    pub fn get_sorted_patches(&self) -> &HashMap<u32, Patch> {
-        &self.patches //TODO
+    pub fn get_sorted_patches(&self) -> Vec<(u32, &Patch)> {
+        let mut vec: Vec<(u32, &Patch)> = self.patches.iter().map(|(key, value)| (*key, value)).collect();
+        vec.sort_by_key(|(key, _)| *key);
+        vec
     }
 
     /// Custom deserializer to deserialize integer keys correctly

--- a/src/repositories/types/common.rs
+++ b/src/repositories/types/common.rs
@@ -18,7 +18,7 @@ pub enum Script {
 }
 
 /// Represents a source, holding a URL and mirror URLs to the source code of a package.
-/// Also has a checksum to check the validity of the recieved source code.
+/// Also has a checksum to check the validity of the received source code.
 #[derive(Deserialize, Debug)]
 pub struct Source {
     pub url: String,
@@ -29,6 +29,7 @@ pub struct Source {
 
     #[serde(default)]
     pub skip_unpack: bool,
+    pub patches: HashMap<u32, Patch>,
 }
 
 /// Wrapper to differentiate between Single and Named sources in the metadata files.
@@ -37,4 +38,19 @@ pub struct Source {
 pub enum Sources {
     Single(Source),
     Named(HashMap<String, Source>),
+}
+
+/// Represents a patch to a source file, holding a URL, mirror URLs and a checksum to check validity.
+#[derive(Deserialize, Debug)]
+pub struct Patch {
+    pub url: String,
+    pub checksum: Checksum,
+    pub mirrors: Vec<String>,
+}
+
+impl Source {
+    /// Gets all patches of the source, sorted by id.
+    pub fn get_sorted_patches(&self) -> &HashMap<u32, Patch> {
+        &self.patches //TODO
+    }
 }

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -19,6 +19,7 @@ pub use self::package_version::PackageVersionMeta;
 pub use self::checksum::Checksum;
 pub use self::common::Script;
 
+pub use self::common::Patch;
 pub use self::common::Source;
 pub use self::common::Sources;
 

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -407,6 +407,7 @@ pub mod tests {
                 checksum: Checksum { sha256: [0; 32] },
                 mirrors: Vec::new(),
                 skip_unpack: false,
+                apply_patches_in: None,
                 patches: HashMap::new(),
             }),
             license: Licenses::Unknown,

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -407,6 +407,7 @@ pub mod tests {
                 checksum: Checksum { sha256: [0; 32] },
                 mirrors: Vec::new(),
                 skip_unpack: false,
+                patches: HashMap::new(),
             }),
             license: Licenses::Unknown,
             skip_symlinking: false,

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::Path};
+use std::{ffi::OsStr, fs, path::Path, str::Utf8Error};
+
+#[cfg(unix)]
+use std::os::unix::ffi::OsStrExt;
 
 use crate::{cli::display::logging::warning, platforms::symlink};
 
@@ -66,4 +69,16 @@ pub fn remove_symlinks(search_dir: &Path, destination_dir: &Path) -> symlink::Re
     }
 
     Ok(())
+}
+
+/// Parses a path from an array of bytes.
+/// Can return a Utf8Error on Windows.
+pub fn parse_path_from_bytes(bytes: &[u8]) -> Result<&Path, Utf8Error> {
+    #[cfg(unix)]
+    let string = OsStr::from_bytes(bytes);
+
+    #[cfg(not(unix))]
+    let string = str::from_utf8(bytes)?;
+
+    Ok(Path::new(string))
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,7 @@ pub mod duplicates;
 pub mod env;
 pub mod fuzzy;
 pub mod io;
+pub mod patches;
 pub mod requests;
 pub mod tree;
 pub mod unwrap_or_exit;

--- a/src/utils/patches.rs
+++ b/src/utils/patches.rs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use std::{fs, path::PathBuf};
+
+use bytes::Bytes;
+use diffy::patch_set::FilePatch;
+use diffy::{
+    binary::BinaryPatch,
+    patch_set::{FileOperation, ParseOptions, PatchKind, PatchSet},
+};
+use thiserror::Error;
+
+use crate::cli::display::logging::warning;
+use crate::utils::io;
+
+/// The errors that occur while applying patches.
+#[derive(Error, Debug)]
+pub enum PatchError {
+    #[error("Error while interacting with filesystem")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Error while parsing path to UTF-8")]
+    PathParseError(#[from] std::str::Utf8Error),
+
+    #[error("Error while parsing patch sets")]
+    PatchSetParseError(#[from] diffy::patch_set::PatchSetParseError),
+
+    #[error("Cannot parse binary patch")]
+    BinaryPatchParseError(#[from] diffy::binary::BinaryPatchParseError),
+
+    #[error("Cannot apply patch")]
+    PatchApplyError(#[from] diffy::ApplyError),
+}
+
+pub type Result<T> = std::result::Result<T, PatchError>;
+
+// Applies the given patch to the given directory directory.
+pub fn apply_patch(patch: &Bytes, directory: &PathBuf) -> Result<()> {
+    let patches = PatchSet::parse_bytes(&patch, ParseOptions::gitdiff());
+
+    for file_patch in patches {
+        let file_patch = file_patch?;
+
+        // Remove a and b prefixes from paths that do not come from the `Rename` or `Copy` operation
+        let operation = file_patch.operation();
+        let operation = match operation {
+            FileOperation::Rename { .. } | FileOperation::Copy { .. } => operation,
+            _ => &operation.strip_prefix(1),
+        };
+
+        handle_file_operation(operation, &file_patch, directory)?;
+    }
+
+    Ok(())
+}
+
+// Handles the file operation to apply the different patch operations.
+fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]>, directory: &PathBuf) -> Result<()> {
+    match operation {
+        FileOperation::Create(path) => {
+            let path = create_path(directory, path)?;
+
+            apply_path(patch.patch(), None, &path)?;
+        },
+        FileOperation::Delete(path) => {
+            let path = create_path(directory, path)?;
+            fs::remove_file(&path)?;
+        },
+        FileOperation::Modify { original, modified } => {
+            let source = create_path(directory, original)?;
+            let destination = create_path(directory, modified)?;
+
+            apply_path(patch.patch(), Some(&source), &destination)?;
+
+            // If the source and destination are not the same, the file is also moved.
+            if source != destination {
+                fs::remove_file(&source)?;
+            }
+        },
+        FileOperation::Rename { from, to } => {
+            let source = create_path(directory, from)?;
+            let destination = create_path(directory, to)?;
+
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            fs::rename(&source, &destination)?;
+        },
+        FileOperation::Copy { from, to } => {
+            let source = create_path(directory, from)?;
+            let destination = create_path(directory, to)?;
+
+            if let Some(parent) = destination.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            fs::copy(&source, &destination)?;
+        },
+    }
+
+    Ok(())
+}
+
+// Creates a path for the patch by parsing the path from bytes and appending it to the given directory.
+fn create_path(directory: &PathBuf, patch_path: &[u8]) -> Result<PathBuf> {
+    Ok(directory.join(io::parse_path_from_bytes(patch_path)?))
+}
+
+// Applies a text or binary patch to a file. The source argument can be none, to use no original file
+fn apply_path(patch: &PatchKind<[u8]>, source: Option<&PathBuf>, destination: &PathBuf) -> Result<()> {
+    if matches!(patch, PatchKind::Binary(BinaryPatch::Marker)) {
+        warning!("Patch has a binary patch marker, but does not contain any data");
+        return Ok(());
+    }
+
+    let original = match source {
+        Some(source) => fs::read(&source)?,
+        None => vec![],
+    };
+
+    let patched = match patch {
+        PatchKind::Text(patch) => diffy::apply_bytes(&original, &patch)?,
+        PatchKind::Binary(patch) => patch.apply(&original)?,
+    };
+
+    if let Some(parent) = destination.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    fs::write(&destination, patched)?;
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds support for applying patches to the source code of packages.

Please note that this cannot be merged yet, because diffy did not yet release the version containing multifile patch support.