### PR TITLE
Add build-install xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[alias]
+build-install = "run --package xtask-build-install --"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-Config.toml
 /temp
 .DS_Store
 .vscode/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The regex search, to search packages based on a given regex pattern.
 - Add support for applying patches to the source code of packages.
 
+### Changes
+- The build system now includes a new `build-install` xtask to create a full Packit build in a `bin` directory structure.
+
 ### Removed
 - The repositories command, this command is now integrated in the new config command.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3676,6 +3676,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask-build-install"
+version = "0.0.0"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,11 @@
+[workspace]
+resolver = "3"
+members = ["xtasks/*"]
+
+[workspace.package]
+rust-version = "1.85.0"
+edition = "2024"
+
 [package]
 name = "packit"
 description = "The universal package manager."
@@ -6,8 +14,8 @@ license = "GPL-3.0-only"
 authors = ["The Packit Team"]
 repository = "https://github.com/pack-it/packit"
 categories = ["command-line-utilities", "development-tools"]
-edition = "2024"
-rust-version = "1.85.0"                                      # Earliest stable compiler for rust 2024 edition
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 thiserror = "2.0.18"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,10 @@ curl -fsSL https://raw.githubusercontent.com/pack-it/packit/main/install.bat --o
 You can also build Packit from source locally, by simply using Cargo. Please note that Rust needs link.exe on Windows, which is part of the Visual C++ toolchain.
 
 1. First download the provided source code or clone the Git repository.
-2. Open the terminal inside the source folder and run `cargo build`. Use `cargo build --release` to create a release build.
-3. After building, the `packit` binary (`packit.exe` on Windows) will be located at `target/debug/packit` or at `target/release/packit` for a release build.
+2. Open the terminal inside the source folder and run `cargo build-install`. Use `cargo build-install --destination=<DESTINATION>` to use a different destination than the default.
+3. After building and installing, there will be a `target/build` directory (or the destination you specified in the command) which contains the `bin` directory, containing the `packit` binary (`packit.exe` on Windows).
+
+If you only need the `packit` binary itself, you could build it directly using `cargo build`, or `cargo build --release` for a release build. This will result in the `packit` binary (`packit.exe` on Windows) which will be located at `target/debug/packit` or at `target/release/packit` for a release build.
 
 
 ## License

--- a/xtasks/xtask-build-install/Cargo.toml
+++ b/xtasks/xtask-build-install/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "xtask-build-install"
+description = "Utility to build and install Packit."
+version = "0.0.0"
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+clap = { version = "4.6.0", features = ["derive"] }

--- a/xtasks/xtask-build-install/src/main.rs
+++ b/xtasks/xtask-build-install/src/main.rs
@@ -1,0 +1,115 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::{Command, exit},
+};
+
+use clap::Parser;
+
+#[derive(Parser, Debug)]
+#[command(name = "build-install", version, about)]
+pub struct TaskCommand {
+    /// The destination to install to
+    #[arg(long)]
+    destination: Option<PathBuf>,
+}
+
+fn main() {
+    let command = TaskCommand::parse();
+
+    // Build with cargo
+    run_build();
+
+    // Retrieve destination
+    let destination = command.destination.unwrap_or(get_target_path().join("build"));
+    let destination = match std::path::absolute(destination) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Failed to convert destination directory to absolute path");
+            eprintln!("Error: {e}");
+            exit(1);
+        },
+    };
+
+    // Create destination
+    if let Err(e) = fs::create_dir_all(&destination) {
+        eprintln!("Failed to create destination directory");
+        eprintln!("Error: {e}");
+        exit(1);
+    }
+
+    // Copy files to destination
+    copy_binary_to_destination(&destination);
+
+    println!("Finished building and installing Packit to {}", destination.display())
+}
+
+fn run_build() {
+    // Create build command
+    let mut cmd = Command::new(std::env!("CARGO"));
+    cmd.args(["build", "--release"]);
+
+    // Run build command and handle output
+    match cmd.status() {
+        Ok(status) if !status.success() => {
+            eprintln!("Failed to build Packit, failed command: `{cmd:?}`");
+            exit(status.code().unwrap_or(1));
+        },
+        Ok(_) => {
+            println!("Packit build successful");
+        },
+        Err(e) => {
+            eprintln!("Failed to build Packit, failed command: `{cmd:?}`");
+            eprintln!("Error: {e}");
+            exit(1);
+        },
+    }
+}
+
+fn copy_binary_to_destination(destination: &PathBuf) {
+    // Create destination bin directory
+    let bin_directory = destination.join("bin");
+    if let Err(e) = fs::create_dir_all(&bin_directory) {
+        eprintln!("Failed to create bin directory");
+        eprintln!("Error: {e}");
+        exit(1);
+    }
+
+    let binary_path = get_target_path().join("release").join("packit");
+
+    // Copy packit binary to bin directory
+    if let Err(e) = fs::copy(binary_path, bin_directory.join("packit")) {
+        eprintln!("Failed to copy binary to bin directory");
+        eprintln!("Error: {e}");
+        exit(1);
+    }
+
+    // Create symlink for pit to packit
+    if let Err(e) = create_file_symlink("packit", bin_directory.join("pit")) {
+        eprintln!("Failed to create pit symlink in bin directory");
+        eprintln!("Error: {e}");
+        exit(1);
+    }
+}
+
+fn get_project_root_path() -> PathBuf {
+    Path::new(std::env!("CARGO_MANIFEST_DIR")).ancestors().nth(2).unwrap().to_path_buf()
+}
+
+fn get_target_path() -> PathBuf {
+    get_project_root_path().join("target")
+}
+
+fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
+    #[cfg(unix)]
+    return std::os::unix::fs::symlink(original, link);
+
+    #[cfg(windows)]
+    return std::os::windows::fs::symlink_file(original, link);
+
+    #[cfg(not(any(windows, unix)))]
+    {
+        eprintln!("Failed to create symlink: Platform not supported");
+        exit(1);
+    }
+}

--- a/xtasks/xtask-build-install/src/main.rs
+++ b/xtasks/xtask-build-install/src/main.rs
@@ -6,6 +6,7 @@ use std::{
 
 use clap::Parser;
 
+/// Represents the build-install command, holding the given options.
 #[derive(Parser, Debug)]
 #[command(name = "build-install", version, about)]
 pub struct TaskCommand {
@@ -44,6 +45,7 @@ fn main() {
     println!("Finished building and installing Packit to {}", destination.display())
 }
 
+/// Runs the Packit build using `cargo build --release`.
 fn run_build() {
     // Create build command
     let mut cmd = Command::new(std::env!("CARGO"));
@@ -66,6 +68,7 @@ fn run_build() {
     }
 }
 
+/// Copies the `packit` binary to the destinationa and creates the `pit` symlink.
 fn copy_binary_to_destination(destination: &PathBuf) {
     // Create destination bin directory
     let bin_directory = destination.join("bin");
@@ -92,14 +95,21 @@ fn copy_binary_to_destination(destination: &PathBuf) {
     }
 }
 
+/// Gets the path to the proejct root directory.
 fn get_project_root_path() -> PathBuf {
-    Path::new(std::env!("CARGO_MANIFEST_DIR")).ancestors().nth(2).unwrap().to_path_buf()
+    Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("Expected CARGO_MANIFEST_DIR to return the xtask-build-install directory path.")
+        .to_path_buf()
 }
 
+/// Gets the target directory path in the project root.
 fn get_target_path() -> PathBuf {
     get_project_root_path().join("target")
 }
 
+/// Creates a file symlink. The link at `link` will point to `original`.
 fn create_file_symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> std::io::Result<()> {
     #[cfg(unix)]
     return std::os::unix::fs::symlink(original, link);


### PR DESCRIPTION
This PR adds the build-install xtask to Packit, which can be used to build and install Packit.

The xtask runs the `cargo build --release` command and copies it into `<destination>/bin`. It also creates the `pit` symlink in the bin directory.

Please note that the install scripts need to be adjusted to use this new xtask before releasing v0.0.2.