### PR TITLE
Verifier structural changes and new checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The list command now has grid printing.
 - The regex search, to search packages based on a given regex pattern.
 - Add support for applying patches to the source code of packages.
+- Verifier and Repairer features
+    - The check and fix command now except multiple package parameters.
+    - Add support for 'check dependencies' (checks which have to be executed before the current check).
+    - The inconsistent register fix doesn't require a re-install anymore.
+    - Add check after fix (re-run check to make sure the fix worked).
+    - Add checks and fixes for: stray directories, empty directories, package existence, correct permissions, missing Config.toml and missing Installed.toml.
 
 ### Changes
 - The build system now includes a new `build-install` xtask to create a full Packit build in a `bin` directory structure.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The regex search, to search packages based on a given regex pattern.
 - Add support for applying patches to the source code of packages.
 - Verifier and Repairer features
-    - The check and fix command now except multiple package parameters.
-    - Add support for 'check dependencies' (checks which have to be executed before the current check).
+    - The check and fix command now accept multiple package parameters.
     - The inconsistent register fix doesn't require a re-install anymore.
     - Add check after fix (re-run check to make sure the fix worked).
     - Add checks and fixes for: stray directories, empty directories, package existence, correct permissions, missing Config.toml and missing Installed.toml.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Shows info about the specified installed package. If the `-v` option is given, e
 #### `pit check [<PACKAGE-NAME>@<VERSION> ...]`
 Checks the Packit installation for issues. When package name(s) and version(s) are given, only those package(s) are checked for issues. 
 
-#### `pit fix`
+#### `pit fix [<PACKAGE-NAME>@<VERSION> ...]`
 Fix all issues found by the check command. You will be asked if you want to fix an issue for each issue type. When package name(s) and version(s) are given, only those package(s) are checked and fixed. 
 
 #### `pit switch <PACKAGE-NAME> <VERSION> [--skip-symlinking]`

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ Updates the specified package to the new version, or the latest version if no ne
 #### `pit info <PACKAGE-NAME>[@<VERSION>] [-v] [--tree]`
 Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown.
 
-#### `pit check [<PACKAGE-NAME>@<VERSION>]`
-Checks the Packit installation for issues. When a package name and version is given, only that package is checked for issues.
+#### `pit check [<PACKAGE-NAME>@<VERSION> ...]`
+Checks the Packit installation for issues. When package name(s) and version(s) are given, only those package(s) are checked for issues. 
 
 #### `pit fix`
-Fix all issues found by the check command. You will be asked if you want to fix an issue for each issue type.
+Fix all issues found by the check command. You will be asked if you want to fix an issue for each issue type. When package name(s) and version(s) are given, only those package(s) are checked and fixed. 
 
 #### `pit switch <PACKAGE-NAME> <VERSION> [--skip-symlinking]`
 Switches the active version of the specified package to the specified version. If the `--skip-symlinking` option is given, the new active version is not symlinked into the /bin, /lib, /share, etc. directories.

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -15,8 +15,8 @@ use crate::{
 /// Checks for any inconsistencies or mistakes in the installed packages or in the Packit files itself.
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// Optional package id, to limit the check to the specified package
-    package: Option<PackageId>,
+    /// A vec of packages to fix. Could be empty, then all packages are checked.
+    pub packages: Vec<PackageId>,
 }
 
 impl HandleCommand for CheckArgs {
@@ -26,20 +26,37 @@ impl HandleCommand for CheckArgs {
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
         let mut verifier = Verifier::new(&config);
 
-        // Check if the package exists before checking it with the verifier
-        if let Some(package_id) = &self.package {
+        let error_message = "An error occured during the check, this error could be caused by one of the issues above and might still be fixed by `pit fix`. It's possible that not all issues were found (especially when checking a single package).";
+        if self.packages.is_empty() {
+            while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit_msg(error_message, 1) {
+                println!("{issue}")
+            }
+
+            // Return correct message based on found issues
+            if verifier.issues_found() {
+                println!("Consider running `pit fix` to resolve the issues above.");
+            } else {
+                println!("No issues were found");
+            }
+
+            return;
+        }
+
+        for package_id in &self.packages {
             // Check if the package exists in the register or in storage before doing any checks
+            // TODO: The verifier should handle this (at the places where it currently says "note doesn't check for existance in xyz")
             let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
             if register.get_package_version(package_id).is_none() && !fs::exists(installed_directory).unwrap_or_exit(1) {
                 error!(msg: "Cannot perform checks, package '{package_id}' doesn't exist in register or storage.");
 
                 // Show possible versions if a package with the given name exists
                 if let Some(package_name) = register.get_package(&package_id.name) {
-                    let versions = package_name.versions.keys();
                     print!("Did you mean version(s): ");
+                    let versions = package_name.versions.keys();
                     for version in versions {
                         print!("'{version}' ");
                     }
+
                     println!();
                     return;
                 }
@@ -51,28 +68,17 @@ impl HandleCommand for CheckArgs {
 
                 exit(1);
             }
-        }
 
-        // Show all issues
-        let error_message = "An error occured during the check, this error could be caused by one of the issues above and might still be fixed by `pit fix`. It's possible that not all issues were found.";
-        match &self.package {
-            Some(id) => {
-                while let Some(issue) = verifier.next_package_issue(id, &register).unwrap_or_exit_msg(error_message, 1) {
-                    println!("{issue}")
-                }
-            },
-            None => {
-                while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit_msg(error_message, 1) {
-                    println!("{issue}")
-                }
-            },
-        }
+            while let Some(issue) = verifier.next_package_issue(package_id, &register).unwrap_or_exit_msg(error_message, 1) {
+                println!("{issue}")
+            }
 
-        // Return correct message based on found issues
-        if verifier.issues_found() {
-            println!("Consider running `pit fix` to resolve the issues above.");
-        } else {
-            println!("No issues were found");
+            // Return correct message based on found issues
+            if verifier.issues_found() {
+                println!("Consider running `pit fix` to resolve the issues above.");
+            } else {
+                println!("No issues were found");
+            }
         }
     }
 }

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -37,8 +37,6 @@ impl CheckArgs {
         if verifier.issues_found() {
             println!("{ISSUE_FOUND_MESSAGE}");
             return;
-        } else {
-            println!("{NO_ISSUE_FOUND_MESSAGE}");
         }
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -15,22 +15,26 @@ pub struct CheckArgs {
 
 impl HandleCommand for CheckArgs {
     fn handle(&self) {
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
-        let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
-        let mut verifier = Verifier::new(&config);
-
         match self.packages.is_empty() {
-            true => self.check_all(&mut verifier, &register),
-            false => self.check_packages(&mut verifier, &register),
+            true => self.check_all(),
+            false => self.check_packages(),
         }
     }
 }
 
 impl CheckArgs {
     /// Checks all packages.
-    fn check_all(&self, verifier: &mut Verifier, register: &PackageRegister) {
-        while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit(1) {
+    fn check_all(&self) {
+        let mut verifier = Verifier::new();
+        while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
+            println!("{issue}")
+        }
+
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
+        let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
+
+        while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
             println!("{issue}")
         }
 
@@ -43,9 +47,14 @@ impl CheckArgs {
     }
 
     /// Checks the packages specified by the user.
-    fn check_packages(&self, verifier: &mut Verifier, register: &PackageRegister) {
+    fn check_packages(&self) {
+        let mut verifier = Verifier::new();
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_dir = PackageRegister::get_default_path(&config);
+        let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
+
         for package_id in &self.packages {
-            while let Some(issue) = verifier.next_package_issue(package_id, &register).unwrap_or_exit(1) {
+            while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
                 println!("{issue}")
             }
 

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -9,7 +9,7 @@ use crate::{
 /// Checks for any inconsistencies or mistakes in the installed packages or in the Packit files itself.
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// A vec of packages to fix. Could be empty, then all packages are checked.
+    /// A vec of packages to check. Could be empty, then all packages are checked.
     pub packages: Vec<PackageId>,
 }
 
@@ -20,25 +20,32 @@ impl HandleCommand for CheckArgs {
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
         let mut verifier = Verifier::new(&config);
 
-        let error_message = "An error occured during the check, this error could be caused by one of the issues above and might still be fixed by `pit fix`. It's possible that not all issues were found (especially when checking a single package).";
-        if self.packages.is_empty() {
-            while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit_msg(error_message, 1) {
-                println!("{issue}")
-            }
+        match self.packages.is_empty() {
+            true => self.check_all(&mut verifier, &register),
+            false => self.check_packages(&mut verifier, &register),
+        }
+    }
+}
 
-            // Return correct message based on found issues
-            if verifier.issues_found() {
-                println!("Consider running `pit fix` to resolve the issues above.");
-            } else {
-                println!("No issues were found");
-            }
-
-            return;
+impl CheckArgs {
+    /// Checks all packages.
+    fn check_all(&self, verifier: &mut Verifier, register: &PackageRegister) {
+        while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit(1) {
+            println!("{issue}")
         }
 
+        // Return correct message based on found issues
+        if verifier.issues_found() {
+            println!("Consider running `pit fix` to resolve the issues above.");
+        } else {
+            println!("No issues were found");
+        }
+    }
+
+    /// Checks the packages specified by the user.
+    fn check_packages(&self, verifier: &mut Verifier, register: &PackageRegister) {
         for package_id in &self.packages {
-            // TODO: Don't throw an error when some issues are already found (not only here, but for every call to the verifier)
-            while let Some(issue) = verifier.next_package_issue(package_id, &register).unwrap_or_exit_msg(error_message, 1) {
+            while let Some(issue) = verifier.next_package_issue(package_id, &register).unwrap_or_exit(1) {
                 println!("{issue}")
             }
 

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -1,15 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, process::exit};
-
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
-    config::Config,
-    installer::types::PackageId,
-    storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
-    verifier::Verifier,
+    cli::commands::HandleCommand, config::Config, installer::types::PackageId, storage::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit, verifier::Verifier,
 };
 
 /// Checks for any inconsistencies or mistakes in the installed packages or in the Packit files itself.
@@ -43,32 +37,7 @@ impl HandleCommand for CheckArgs {
         }
 
         for package_id in &self.packages {
-            // Check if the package exists in the register or in storage before doing any checks
-            // TODO: The verifier should handle this (at the places where it currently says "note doesn't check for existance in xyz")
-            let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
-            if register.get_package_version(package_id).is_none() && !fs::exists(installed_directory).unwrap_or_exit(1) {
-                error!(msg: "Cannot perform checks, package '{package_id}' doesn't exist in register or storage.");
-
-                // Show possible versions if a package with the given name exists
-                if let Some(package_name) = register.get_package(&package_id.name) {
-                    print!("Did you mean version(s): ");
-                    let versions = package_name.versions.keys();
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-
-                    println!();
-                    return;
-                }
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &package_id.name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1);
-            }
-
+            // TODO: Don't throw an error when some issues are already found (not only here, but for every call to the verifier)
             while let Some(issue) = verifier.next_package_issue(package_id, &register).unwrap_or_exit_msg(error_message, 1) {
                 println!("{issue}")
             }

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -13,6 +13,9 @@ pub struct CheckArgs {
     pub packages: Vec<PackageId>,
 }
 
+const ISSUE_FOUND_MESSAGE: &str = "Consider running `pit fix` to resolve the issues above.";
+const NO_ISSUE_FOUND_MESSAGE: &str = "No issues were found";
+
 impl HandleCommand for CheckArgs {
     fn handle(&self) {
         match self.packages.is_empty() {
@@ -30,6 +33,14 @@ impl CheckArgs {
             println!("{issue}")
         }
 
+        // Return correct message based on found issues
+        if verifier.issues_found() {
+            println!("{ISSUE_FOUND_MESSAGE}");
+            return;
+        } else {
+            println!("{NO_ISSUE_FOUND_MESSAGE}");
+        }
+
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let register_dir = PackageRegister::get_default_path(&config);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
@@ -40,9 +51,9 @@ impl CheckArgs {
 
         // Return correct message based on found issues
         if verifier.issues_found() {
-            println!("Consider running `pit fix` to resolve the issues above.");
+            println!("{ISSUE_FOUND_MESSAGE}");
         } else {
-            println!("No issues were found");
+            println!("{NO_ISSUE_FOUND_MESSAGE}");
         }
     }
 
@@ -60,9 +71,9 @@ impl CheckArgs {
 
             // Return correct message based on found issues
             if verifier.issues_found() {
-                println!("Consider running `pit fix` to resolve the issues above.");
+                println!("{ISSUE_FOUND_MESSAGE}");
             } else {
-                println!("No issues were found");
+                println!("{NO_ISSUE_FOUND_MESSAGE}");
             }
         }
     }

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -9,7 +9,7 @@ use crate::{
 /// Checks for any inconsistencies or mistakes in the installed packages or in the Packit files itself.
 #[derive(Args, Debug)]
 pub struct CheckArgs {
-    /// A vec of packages to check. Could be empty, then all packages are checked.
+    /// A list of packages to check. Could be empty, then all packages are checked.
     pub packages: Vec<PackageId>,
 }
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -84,17 +84,7 @@ impl HandleCommand for ConfigArgs {
 impl ConfigArgs {
     /// Handles the config show command.
     fn handle_show(&self, config: EditableConfig) {
-        let config = config.get_config();
-        println!("Prefix directory: {}", config.prefix_directory.display());
-
-        print!("Multiuser mode: ");
-        if config.multiuser {
-            println!("on");
-        } else {
-            println!("off");
-        }
-
-        println!("Repositories rank: {}", config.repositories_rank.join(", "));
+        config.get_config().display();
     }
 
     /// Handles the config set-prefix command.

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -25,43 +25,62 @@ pub struct FixArgs {
 
 impl HandleCommand for FixArgs {
     fn handle(&self) {
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
-        let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
-        let mut verifier = Verifier::new(&config);
-        let mut repairer = Repairer::new(&config, &manager);
+        let mut verifier = Verifier::new();
+        let mut repairer = Repairer::new();
 
         match self.packages.is_empty() {
-            true => self.fix_all(&mut verifier, &mut repairer, &mut register, &register_dir),
-            false => self.fix_packages(&mut verifier, &mut repairer, &mut register, &register_dir),
+            true => self.fix_all(&mut verifier, &mut repairer),
+            false => self.fix_packages(&mut verifier, &mut repairer),
         }
-
-        // Save changes
-        register.save_to(&register_dir).unwrap_or_exit(1);
     }
 }
 
 impl FixArgs {
     /// Fixes all packages.
-    fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
+    fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
+        while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
+            println!("{issue}");
+
+            println!("{}", issue.get_fix_message());
+            let question = "Would you like to automatically apply the fix above?";
+            if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
+                return;
+            }
+
+            // Repair the found issues
+            repairer.fix_initial_issues(issue).unwrap_or_exit(1);
+        }
+
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
+        let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
+
         // Retrieve and fix the issues one by one
-        while let Some(issue) = verifier.next_issue(register).unwrap_or_exit(1) {
-            self.fix_issue(issue, repairer, register, register_dir);
+        while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
+            self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
         }
 
         // Return correct message based on found issues
         if !verifier.issues_found() {
             println!("No issues were found");
         }
+
+        // Save changes
+        register.save_to(&register_dir).unwrap_or_exit(1);
     }
 
     /// Fixes the packages specified by the user.
-    fn fix_packages(&self, verifier: &mut Verifier, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
+    fn fix_packages(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
+        let register_dir = PackageRegister::get_default_path(&config);
+        let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
+
         for package_id in &self.packages {
             // Retrieve and fix the issues one by one
-            while let Some(issue) = verifier.next_package_issue(package_id, register).unwrap_or_exit(1) {
-                self.fix_issue(issue, repairer, register, register_dir);
+            while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
+                self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
             }
 
             // Show when no errors are found for the current package
@@ -69,10 +88,21 @@ impl FixArgs {
                 println!("No issues were found for {package_id}");
             }
         }
+
+        // Save changes
+        register.save_to(&register_dir).unwrap_or_exit(1);
     }
 
     /// Fixes a specific issue.
-    fn fix_issue(&self, issue: Issue, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
+    fn fix_issue(
+        &self,
+        issue: Issue,
+        repairer: &mut Repairer,
+        register: &mut PackageRegister,
+        register_dir: &Path,
+        config: &Config,
+        manager: &RepositoryManager,
+    ) {
         println!("{issue}");
 
         println!("{}", issue.get_fix_message());
@@ -82,7 +112,7 @@ impl FixArgs {
         }
 
         // Repair the found issues
-        repairer.fix(issue, register).unwrap_or_exit(1);
+        repairer.fix(issue, register, config, manager).unwrap_or_exit(1);
 
         // Save register after each fix
         register.save_to(&register_dir).unwrap_or_exit(1);

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -31,7 +31,8 @@ impl HandleCommand for FixArgs {
         while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit(1) {
             println!("{issue}");
 
-            let question = "Would you like to automatically fix the above issue with `pit fix`?";
+            println!("{}", issue.get_fix_message());
+            let question = "Would you like to automatically apply the fix above?";
             if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
                 continue;
             }

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -49,6 +49,9 @@ impl FixArgs {
 
             // Repair the found issues
             repairer.fix_initial_issues(issue).unwrap_or_exit(1);
+
+            // Reverse the verifier to redo the check to make sure the fix worked
+            verifier.reverse_initial_check();
         }
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
@@ -59,6 +62,9 @@ impl FixArgs {
         // Retrieve and fix the issues one by one
         while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
             self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
+
+            // Reverse the verifier to redo the check to make sure the fix worked
+            verifier.reverse_general_check();
         }
 
         // Return correct message based on found issues
@@ -81,6 +87,9 @@ impl FixArgs {
             // Retrieve and fix the issues one by one
             while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
                 self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
+
+                // Reverse the verifier to redo the check to make sure the fix worked
+                verifier.reverse_package_check();
             }
 
             // Show when no errors are found for the current package

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -19,7 +19,7 @@ use crate::{
 /// Fixes all issues found by the check command. The user will be asked if they want to fix an issue for each issue type.
 #[derive(Args, Debug)]
 pub struct FixArgs {
-    /// A vec of packages to fix. Could be empty, then all packages are fixed.
+    /// A list of packages to fix. Could be empty, then all packages are fixed.
     pub packages: Vec<PackageId>,
 }
 
@@ -43,6 +43,7 @@ impl FixArgs {
     fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
         let mut issue_index = -1;
         while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
+            // Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
             if verifier.get_initial_check_index() as i32 - 1 == issue_index {
                 error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                 exit(1);
@@ -69,6 +70,7 @@ impl FixArgs {
         // Retrieve and fix the issues one by one
         let mut issue_index = -1;
         while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
+            // Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
             if verifier.get_general_check_index() as i32 - 1 == issue_index {
                 error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                 exit(1);
@@ -110,6 +112,7 @@ impl FixArgs {
             // Retrieve and fix the issues one by one
             let mut issue_index = -1;
             while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
+                // Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
                 if verifier.get_package_check_index() as i32 - 1 == issue_index {
                     error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                     exit(1);

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use std::process::exit;
+
 use clap::Args;
 
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{QuestionResponse, ask_user},
+        display::{QuestionResponse, ask_user, logging::error},
     },
     config::Config,
     installer::types::PackageId,
@@ -22,6 +24,7 @@ pub struct FixArgs {
 }
 
 const FIX_MESSAGE: &str = "Would you like to automatically apply the fix above?";
+const UNSUCCESSFUL_FIX_MESSAGE: &str = "The issue could not be fixed, due to unknown reasons";
 
 impl HandleCommand for FixArgs {
     fn handle(&self) {
@@ -38,7 +41,13 @@ impl HandleCommand for FixArgs {
 impl FixArgs {
     /// Fixes all packages.
     fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
+        let mut issue_index = -1;
         while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
+            if verifier.get_initial_check_index() as i32 - 1 == issue_index {
+                error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
+                exit(1);
+            }
+
             println!("{issue}");
             println!("{}", issue.get_fix_message());
             if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
@@ -49,7 +58,7 @@ impl FixArgs {
             repairer.fix_initial_issues(issue).unwrap_or_exit(1);
 
             // Reverse the verifier to redo the check to make sure the fix worked
-            verifier.reverse_initial_check();
+            issue_index = verifier.reverse_initial_check() as i32;
         }
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
@@ -58,7 +67,13 @@ impl FixArgs {
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Retrieve and fix the issues one by one
+        let mut issue_index = -1;
         while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
+            if verifier.get_general_check_index() as i32 - 1 == issue_index {
+                error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
+                exit(1);
+            }
+
             println!("{issue}");
             println!("{}", issue.get_fix_message());
             if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
@@ -72,7 +87,7 @@ impl FixArgs {
             register.save_to(&register_dir).unwrap_or_exit(1);
 
             // Reverse the verifier to redo the check to make sure the fix worked
-            verifier.reverse_general_check();
+            issue_index = verifier.reverse_general_check() as i32;
         }
 
         // Return correct message based on found issues
@@ -93,7 +108,13 @@ impl FixArgs {
 
         for package_id in &self.packages {
             // Retrieve and fix the issues one by one
+            let mut issue_index = -1;
             while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
+                if verifier.get_package_check_index() as i32 - 1 == issue_index {
+                    error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
+                    exit(1);
+                }
+
                 println!("{issue}");
                 println!("{}", issue.get_fix_message());
                 if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
@@ -107,7 +128,7 @@ impl FixArgs {
                 register.save_to(&register_dir).unwrap_or_exit(1);
 
                 // Reverse the verifier to redo the check to make sure the fix worked
-                verifier.reverse_package_check();
+                issue_index = verifier.reverse_package_check() as i32;
             }
 
             // Show when no errors are found for the current package

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -104,7 +104,6 @@ impl FixArgs {
         manager: &RepositoryManager,
     ) {
         println!("{issue}");
-
         println!("{}", issue.get_fix_message());
         let question = "Would you like to automatically apply the fix above?";
         if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -1,6 +1,4 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::path::Path;
-
 use clap::Args;
 
 use crate::{
@@ -13,7 +11,7 @@ use crate::{
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
-    verifier::{Issue, Repairer, Verifier},
+    verifier::{Repairer, Verifier},
 };
 
 /// Fixes all issues found by the check command. The user will be asked if they want to fix an issue for each issue type.
@@ -22,6 +20,8 @@ pub struct FixArgs {
     /// A vec of packages to fix. Could be empty, then all packages are fixed.
     pub packages: Vec<PackageId>,
 }
+
+const FIX_MESSAGE: &str = "Would you like to automatically apply the fix above?";
 
 impl HandleCommand for FixArgs {
     fn handle(&self) {
@@ -40,10 +40,8 @@ impl FixArgs {
     fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
         while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
             println!("{issue}");
-
             println!("{}", issue.get_fix_message());
-            let question = "Would you like to automatically apply the fix above?";
-            if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
+            if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
                 return;
             }
 
@@ -61,7 +59,17 @@ impl FixArgs {
 
         // Retrieve and fix the issues one by one
         while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
-            self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
+            println!("{issue}");
+            println!("{}", issue.get_fix_message());
+            if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
+                return;
+            }
+
+            // Repair the found issues
+            repairer.fix(issue, &mut register, &config, &manager).unwrap_or_exit(1);
+
+            // Save register after each fix
+            register.save_to(&register_dir).unwrap_or_exit(1);
 
             // Reverse the verifier to redo the check to make sure the fix worked
             verifier.reverse_general_check();
@@ -86,7 +94,17 @@ impl FixArgs {
         for package_id in &self.packages {
             // Retrieve and fix the issues one by one
             while let Some(issue) = verifier.next_package_issue(package_id, &register, &config).unwrap_or_exit(1) {
-                self.fix_issue(issue, repairer, &mut register, &register_dir, &config, &manager);
+                println!("{issue}");
+                println!("{}", issue.get_fix_message());
+                if ask_user(FIX_MESSAGE, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
+                    return;
+                }
+
+                // Repair the found issues
+                repairer.fix(issue, &mut register, &config, &manager).unwrap_or_exit(1);
+
+                // Save register after each fix
+                register.save_to(&register_dir).unwrap_or_exit(1);
 
                 // Reverse the verifier to redo the check to make sure the fix worked
                 verifier.reverse_package_check();
@@ -99,30 +117,6 @@ impl FixArgs {
         }
 
         // Save changes
-        register.save_to(&register_dir).unwrap_or_exit(1);
-    }
-
-    /// Fixes a specific issue.
-    fn fix_issue(
-        &self,
-        issue: Issue,
-        repairer: &mut Repairer,
-        register: &mut PackageRegister,
-        register_dir: &Path,
-        config: &Config,
-        manager: &RepositoryManager,
-    ) {
-        println!("{issue}");
-        println!("{}", issue.get_fix_message());
-        let question = "Would you like to automatically apply the fix above?";
-        if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
-            return;
-        }
-
-        // Repair the found issues
-        repairer.fix(issue, register, config, manager).unwrap_or_exit(1);
-
-        // Save register after each fix
         register.save_to(&register_dir).unwrap_or_exit(1);
     }
 }

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -1,4 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
+use std::path::Path;
+
 use clap::Args;
 
 use crate::{
@@ -7,15 +9,19 @@ use crate::{
         display::{QuestionResponse, ask_user},
     },
     config::Config,
+    installer::types::PackageId,
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
-    verifier::{Repairer, Verifier},
+    verifier::{Issue, Repairer, Verifier},
 };
 
 /// Fixes all issues found by the check command. The user will be asked if they want to fix an issue for each issue type.
 #[derive(Args, Debug)]
-pub struct FixArgs;
+pub struct FixArgs {
+    /// A vec of packages to fix. Could be empty, then all packages are fixed.
+    pub packages: Vec<PackageId>,
+}
 
 impl HandleCommand for FixArgs {
     fn handle(&self) {
@@ -24,32 +30,61 @@ impl HandleCommand for FixArgs {
         let register_dir = PackageRegister::get_default_path(&config);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
         let mut verifier = Verifier::new(&config);
-
         let mut repairer = Repairer::new(&config, &manager);
 
+        match self.packages.is_empty() {
+            true => self.fix_all(&mut verifier, &mut repairer, &mut register, &register_dir),
+            false => self.fix_packages(&mut verifier, &mut repairer, &mut register, &register_dir),
+        }
+
+        // Save changes
+        register.save_to(&register_dir).unwrap_or_exit(1);
+    }
+}
+
+impl FixArgs {
+    /// Fixes all packages.
+    fn fix_all(&self, verifier: &mut Verifier, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
         // Retrieve and fix the issues one by one
-        while let Some(issue) = verifier.next_issue(&register).unwrap_or_exit(1) {
-            println!("{issue}");
-
-            println!("{}", issue.get_fix_message());
-            let question = "Would you like to automatically apply the fix above?";
-            if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
-                continue;
-            }
-
-            // Repair the found issues
-            repairer.fix(issue, &mut register).unwrap_or_exit(1);
-
-            // Save register after the fix
-            register.save_to(&register_dir).unwrap_or_exit(1);
+        while let Some(issue) = verifier.next_issue(register).unwrap_or_exit(1) {
+            self.fix_issue(issue, repairer, register, register_dir);
         }
 
         // Return correct message based on found issues
         if !verifier.issues_found() {
             println!("No issues were found");
         }
+    }
 
-        // Save changes
+    /// Fixes the packages specified by the user.
+    fn fix_packages(&self, verifier: &mut Verifier, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
+        for package_id in &self.packages {
+            // Retrieve and fix the issues one by one
+            while let Some(issue) = verifier.next_package_issue(package_id, register).unwrap_or_exit(1) {
+                self.fix_issue(issue, repairer, register, register_dir);
+            }
+
+            // Show when no errors are found for the current package
+            if !verifier.issues_found() {
+                println!("No issues were found for {package_id}");
+            }
+        }
+    }
+
+    /// Fixes a specific issue.
+    fn fix_issue(&self, issue: Issue, repairer: &mut Repairer, register: &mut PackageRegister, register_dir: &Path) {
+        println!("{issue}");
+
+        println!("{}", issue.get_fix_message());
+        let question = "Would you like to automatically apply the fix above?";
+        if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no() {
+            return;
+        }
+
+        // Repair the found issues
+        repairer.fix(issue, register).unwrap_or_exit(1);
+
+        // Save register after each fix
         register.save_to(&register_dir).unwrap_or_exit(1);
     }
 }

--- a/src/cli/display/mod.rs
+++ b/src/cli/display/mod.rs
@@ -13,6 +13,7 @@ pub use progressbar::ProgressBar;
 
 pub use prompts::QuestionResponse;
 pub use prompts::ask_user;
+pub use prompts::ask_user_input;
 
 pub use reader::ReaderWithProgress;
 

--- a/src/cli/display/prompts.rs
+++ b/src/cli/display/prompts.rs
@@ -58,3 +58,20 @@ pub fn ask_user(question: &str, default: QuestionResponse) -> Result<QuestionRes
     warning!("Invalid input");
     Ok(QuestionResponse::Invalid)
 }
+
+/// Prompts the user to give input. The user can skip by pressing enter.
+pub fn ask_user_input(question: &str) -> Result<Option<String>, DisplayError> {
+    print!("{question} [press enter to skip]: ");
+
+    // Get user input
+    io::stdout().flush()?;
+    let mut input = String::new();
+    io::stdin().read_line(&mut input)?;
+    let input = input.trim();
+
+    if input.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(input.to_string()))
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
 use thiserror::Error;
 use toml_edit::DocumentMut;
 
@@ -14,7 +14,9 @@ use crate::{
     cli::display::logging::warning,
     platforms::{DEFAULT_CONFIG_DIR, DEFAULT_PREFIX},
     repositories::metadata::DEFAULT_METADATA_PROVIDER_ID,
-    utils::constants::{CONFIG_FILENAME, DEFAULT_METADATA_REPOSITORY_NAME, DEFAULT_METADATA_REPOSITORY_PATH},
+    utils::constants::{
+        CONFIG_FILENAME, DEFAULT_METADATA_REPOSITORY_NAME, DEFAULT_METADATA_REPOSITORY_PATH, DEFAULT_METADATA_REPOSITORY_PROVIDER,
+    },
 };
 
 #[derive(Debug)]
@@ -24,7 +26,7 @@ pub struct EditableConfig {
 }
 
 /// Represents the main config file of Packit.
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Debug)]
 pub struct Config {
     /// Contains all repositories
     pub repositories: HashMap<String, Repository>,
@@ -42,7 +44,7 @@ pub struct Config {
 }
 
 /// Represents a repository, containing connection information.
-#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Hash)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Repository {
     /// The path to the repository
     pub path: String,
@@ -86,9 +88,6 @@ pub enum ConfigError {
 
     #[error("Cannot parse config file from string")]
     TomlError(#[from] toml_edit::TomlError),
-
-    #[error("Cannot serialize config")]
-    SerializeError(#[from] toml::ser::Error),
 }
 
 pub type Result<T> = core::result::Result<T, ConfigError>;
@@ -123,30 +122,9 @@ impl Config {
         Ok(config)
     }
 
-    /// Creates a default instance of Config.
-    pub fn default() -> Config {
-        Config {
-            repositories: Self::default_repositories(),
-            repositories_rank: vec![DEFAULT_METADATA_REPOSITORY_NAME.to_string()],
-            prefix_directory: PathBuf::from(DEFAULT_PREFIX),
-            multiuser: false,
-        }
-    }
-
     /// Gets the default path of the Packit config file.
     pub fn get_default_path() -> PathBuf {
         Path::new(DEFAULT_CONFIG_DIR).join(CONFIG_FILENAME)
-    }
-
-    fn default_repositories() -> HashMap<String, Repository> {
-        let repository = Repository {
-            path: DEFAULT_METADATA_REPOSITORY_PATH.to_string(),
-            provider: DEFAULT_METADATA_PROVIDER_ID.to_string(),
-            prebuilds_url: None,
-            prebuilds_provider: None,
-        };
-
-        HashMap::from([(DEFAULT_METADATA_REPOSITORY_NAME.to_string(), repository)])
     }
 
     fn default_prefix_directory() -> PathBuf {
@@ -180,6 +158,39 @@ impl Config {
     }
 }
 
+impl Default for EditableConfig {
+    /// Creates a default `EditableConfig`.
+    fn default() -> Self {
+        let default_repository = Repository {
+            path: DEFAULT_METADATA_REPOSITORY_PATH.to_string(),
+            provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.to_string(),
+            prebuilds_url: None,
+            prebuilds_provider: None,
+        };
+
+        let config = Config {
+            repositories: HashMap::from([(DEFAULT_METADATA_REPOSITORY_NAME.to_string(), default_repository)]),
+            repositories_rank: vec![DEFAULT_METADATA_REPOSITORY_NAME.to_string()],
+            prefix_directory: Config::default_prefix_directory(),
+            multiuser: Config::default_multiuser(),
+        };
+
+        let repositories_rank = config.repositories_rank.clone();
+        let repositories = config.repositories.clone();
+
+        let document = DocumentMut::new();
+
+        let mut editable_config = Self { config, document };
+        editable_config.set_repositories_rank(repositories_rank);
+        for (id, repository) in repositories {
+            editable_config.set_repository(&id, repository);
+        }
+        // We don't need to set prefix_directory or multiuser, since the default value is automatically deserialized.
+
+        editable_config
+    }
+}
+
 impl EditableConfig {
     /// Loads the Packit config from a file.
     ///
@@ -191,17 +202,6 @@ impl EditableConfig {
         let file_content = fs::read_to_string(file_path)?;
         let document = DocumentMut::from_str(&file_content)?;
 
-        Ok(Self { config, document })
-    }
-
-    /// Creates a default `EditableConfig`.
-    ///
-    /// # Errors
-    ///
-    /// This will return an error if the default config cannot be parsed or serialized.
-    pub fn default() -> Result<Self> {
-        let config = Config::default();
-        let document = DocumentMut::from_str(&toml::to_string(&config)?)?;
         Ok(Self { config, document })
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -169,13 +169,13 @@ impl Config {
         println!("Repositories rank: {}", self.repositories_rank.join(", "));
         for (name, repo) in &self.repositories {
             println!("{name}");
-            println!("    Path: {}", repo.path);
-            println!("    Provider: {}", repo.provider);
+            println!("\tPath: {}", repo.path);
+            println!("\tProvider: {}", repo.provider);
             println!(
-                "    Prebuilds provider: {}",
+                "\tPrebuilds provider: {}",
                 repo.prebuilds_provider.as_ref().unwrap_or(&"None".to_string())
             );
-            println!("    Prebuilds url: {}", repo.prebuilds_url.as_ref().unwrap_or(&"None".to_string()));
+            println!("\tPrebuilds url: {}", repo.prebuilds_url.as_ref().unwrap_or(&"None".to_string()));
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,7 +42,7 @@ pub struct Config {
 }
 
 /// Represents a repository, containing connection information.
-#[derive(Deserialize, Serialize, Debug)]
+#[derive(Deserialize, Serialize, Debug, PartialEq, Eq, Hash)]
 pub struct Repository {
     /// The path to the repository
     pub path: String,
@@ -156,6 +156,28 @@ impl Config {
     fn default_multiuser() -> bool {
         false
     }
+
+    /// Displays the Config settings.
+    pub fn display(&self) {
+        println!("Prefix directory: {}", self.prefix_directory.display());
+        print!("Multiuser mode: ");
+        match self.multiuser {
+            true => println!("on"),
+            false => println!("off"),
+        }
+
+        println!("Repositories rank: {}", self.repositories_rank.join(", "));
+        for (name, repo) in &self.repositories {
+            println!("{name}");
+            println!("    Path: {}", repo.path);
+            println!("    Provider: {}", repo.provider);
+            println!(
+                "    Prebuilds provider: {}",
+                repo.prebuilds_provider.as_ref().unwrap_or(&"None".to_string())
+            );
+            println!("    Prebuilds url: {}", repo.prebuilds_url.as_ref().unwrap_or(&"None".to_string()));
+        }
+    }
 }
 
 impl EditableConfig {
@@ -221,6 +243,21 @@ impl EditableConfig {
         self.document["repositories"][id] = new_value.into();
 
         self.config.repositories.insert(id.into(), repository);
+    }
+
+    // Removes a repository with the given id from the config.
+    // TODO: Implement this for the config command (making sure that we handle packages which currently use this repo)
+    pub fn remove_repository(&mut self, id: &str) {
+        if let Some(repositories) = self.document.get_mut("repositories").and_then(|r| r.as_table_mut()) {
+            repositories.remove(id);
+        }
+
+        if let Some(repositories) = self.document.get_mut("repositories_rank").and_then(|r| r.as_array_mut()) {
+            repositories.retain(|v| v.as_str() != Some(id));
+        }
+
+        self.config.repositories.remove(id);
+        self.config.repositories_rank.retain(|v| v != id);
     }
 
     /// Sets the repositories rank.

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use std::{
     str::FromStr,
 };
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use toml_edit::DocumentMut;
 
@@ -14,7 +14,7 @@ use crate::{
     cli::display::logging::warning,
     platforms::{DEFAULT_CONFIG_DIR, DEFAULT_PREFIX},
     repositories::metadata::DEFAULT_METADATA_PROVIDER_ID,
-    utils::constants::CONFIG_FILENAME,
+    utils::constants::{CONFIG_FILENAME, DEFAULT_METADATA_REPOSITORY_NAME, DEFAULT_METADATA_REPOSITORY_PATH},
 };
 
 #[derive(Debug)]
@@ -24,7 +24,7 @@ pub struct EditableConfig {
 }
 
 /// Represents the main config file of Packit.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Config {
     /// Contains all repositories
     pub repositories: HashMap<String, Repository>,
@@ -42,7 +42,7 @@ pub struct Config {
 }
 
 /// Represents a repository, containing connection information.
-#[derive(Deserialize, Debug)]
+#[derive(Deserialize, Serialize, Debug)]
 pub struct Repository {
     /// The path to the repository
     pub path: String,
@@ -83,6 +83,12 @@ pub enum ConfigError {
 
     #[error("Cannot parse config file")]
     ParseError(#[from] toml::de::Error),
+
+    #[error("Cannot parse config file from string")]
+    TomlError(#[from] toml_edit::TomlError),
+
+    #[error("Cannot serialize config")]
+    SerializeError(#[from] toml::ser::Error),
 }
 
 pub type Result<T> = core::result::Result<T, ConfigError>;
@@ -117,9 +123,30 @@ impl Config {
         Ok(config)
     }
 
+    /// Creates a default instance of Config.
+    pub fn default() -> Config {
+        Config {
+            repositories: Self::default_repositories(),
+            repositories_rank: vec![DEFAULT_METADATA_REPOSITORY_NAME.to_string()],
+            prefix_directory: PathBuf::from(DEFAULT_PREFIX),
+            multiuser: false,
+        }
+    }
+
     /// Gets the default path of the Packit config file.
     pub fn get_default_path() -> PathBuf {
         Path::new(DEFAULT_CONFIG_DIR).join(CONFIG_FILENAME)
+    }
+
+    fn default_repositories() -> HashMap<String, Repository> {
+        let repository = Repository {
+            path: DEFAULT_METADATA_REPOSITORY_PATH.to_string(),
+            provider: DEFAULT_METADATA_PROVIDER_ID.to_string(),
+            prebuilds_url: None,
+            prebuilds_provider: None,
+        };
+
+        HashMap::from([(DEFAULT_METADATA_REPOSITORY_NAME.to_string(), repository)])
     }
 
     fn default_prefix_directory() -> PathBuf {
@@ -140,8 +167,19 @@ impl EditableConfig {
     pub fn from(file_path: &Path) -> Result<Self> {
         let config = Config::from(file_path)?;
         let file_content = fs::read_to_string(file_path)?;
-        let document = DocumentMut::from_str(&file_content).unwrap();
+        let document = DocumentMut::from_str(&file_content)?;
 
+        Ok(Self { config, document })
+    }
+
+    /// Creates a default `EditableConfig`.
+    ///
+    /// # Errors
+    ///
+    /// This will return an error if the default config cannot be parsed or serialized.
+    pub fn default() -> Result<Self> {
+        let config = Config::default();
+        let document = DocumentMut::from_str(&toml::to_string(&config)?)?;
         Ok(Self { config, document })
     }
 

--- a/src/platforms/permissions.rs
+++ b/src/platforms/permissions.rs
@@ -41,7 +41,7 @@ pub fn is_writable(path: &PathBuf) -> Result<bool> {
 pub use self::platform::set_packit_permissions;
 
 /// Checks if the packit group exists.
-pub use self::platform::packit_group_exists;
+pub use self::platform::does_packit_group_exist;
 
 pub use self::platform::PlatformError;
 
@@ -63,5 +63,9 @@ mod platform {
 
     pub fn set_packit_permissions(_path: &PathBuf, _is_multiuser: bool, _recurse: bool) -> Result<()> {
         panic!("Cannot set ownership for target, target is not supported.");
+    }
+
+    pub fn does_packit_group_exist() -> Result<bool> {
+        panic!("Cannot check if group exists, target is not supported.")
     }
 }

--- a/src/platforms/permissions.rs
+++ b/src/platforms/permissions.rs
@@ -37,8 +37,11 @@ pub fn is_writable(path: &PathBuf) -> Result<bool> {
     platform::is_writable(path, metadata)
 }
 
-/// Sets the permissions of packit files
+/// Sets the permissions of packit files.
 pub use self::platform::set_packit_permissions;
+
+/// Checks if the packit group exists.
+pub use self::platform::packit_group_exists;
 
 pub use self::platform::PlatformError;
 

--- a/src/platforms/permissions/unix.rs
+++ b/src/platforms/permissions/unix.rs
@@ -70,6 +70,11 @@ pub fn set_packit_permissions(path: &PathBuf, is_multiuser: bool, recurse: bool)
     set_file_permissions(path, metadata.permissions(), group_id, recurse)
 }
 
+/// Checks if the packit group exists.
+pub fn packit_group_exists() -> bool {
+    get_group_id(PACKIT_GROUP_NAME).is_ok()
+}
+
 /// Sets the permissions of a given directory. It does so recursively if the recurse parameter is true.
 /// Could return an IO error.
 fn set_file_permissions(path: &PathBuf, mut old_permissions: Permissions, group_id: Option<u32>, recurse: bool) -> Result<()> {

--- a/src/platforms/permissions/unix.rs
+++ b/src/platforms/permissions/unix.rs
@@ -71,8 +71,12 @@ pub fn set_packit_permissions(path: &PathBuf, is_multiuser: bool, recurse: bool)
 }
 
 /// Checks if the packit group exists.
-pub fn packit_group_exists() -> bool {
-    get_group_id(PACKIT_GROUP_NAME).is_ok()
+pub fn does_packit_group_exist() -> Result<bool> {
+    match get_group_id(PACKIT_GROUP_NAME) {
+        Ok(_) => Ok(true),
+        Err(PermissionError::GroupDoesNotExist) => Ok(false),
+        Err(e) => Err(e),
+    }
 }
 
 /// Sets the permissions of a given directory. It does so recursively if the recurse parameter is true.

--- a/src/platforms/permissions/windows.rs
+++ b/src/platforms/permissions/windows.rs
@@ -265,6 +265,11 @@ pub fn set_packit_permissions(path: &PathBuf, is_multiuser: bool, recurse: bool)
     }
 }
 
+/// Checks if the packit group exists.
+pub fn packit_group_exists() -> bool {
+    get_group_sid().is_ok()
+}
+
 /// Enables a given privilege.
 /// Could return a `PlatformError::WindowsAPIError` error.
 fn enable_privilege(name: &str) -> Result<()> {

--- a/src/platforms/permissions/windows.rs
+++ b/src/platforms/permissions/windows.rs
@@ -266,7 +266,7 @@ pub fn set_packit_permissions(path: &PathBuf, is_multiuser: bool, recurse: bool)
 }
 
 /// Checks if the packit group exists.
-pub fn packit_group_exists() -> Result<bool> {
+pub fn does_packit_group_exist() -> Result<bool> {
     match get_group_sid(PACKIT_GROUP_NAME) {
         Ok(_) => Ok(true),
         Err(PermissionError::GroupDoesNotExist) => Ok(false),

--- a/src/platforms/permissions/windows.rs
+++ b/src/platforms/permissions/windows.rs
@@ -266,8 +266,12 @@ pub fn set_packit_permissions(path: &PathBuf, is_multiuser: bool, recurse: bool)
 }
 
 /// Checks if the packit group exists.
-pub fn packit_group_exists() -> bool {
-    get_group_sid().is_ok()
+pub fn packit_group_exists() -> Result<bool> {
+    match get_group_sid(PACKIT_GROUP_NAME) {
+        Ok(_) => Ok(true),
+        Err(PermissionError::GroupDoesNotExist) => Ok(false),
+        Err(e) => Err(e),
+    }
 }
 
 /// Enables a given privilege.

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -119,6 +119,7 @@ impl PackageRegister {
             if let Some(package) = self.get_package_version_mut(dependency) {
                 package.dependents.insert(installed_package_version.package_id.clone());
             } else {
+                // TODO: This should be an error
                 warning!("Cannot retrieve package {dependency} from register to insert dependents");
             }
         }

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -27,6 +27,12 @@ pub struct PackageRegister {
 }
 
 impl PackageRegister {
+    /// Creates a new `PackageRegister`. Should normally never be used.
+    /// This is mainly used in the `Verifier`. Under normal circumstances use `PackageRegister::from`.
+    pub fn new() -> Self {
+        Self { packages: HashMap::new() }
+    }
+
     /// Loads the register file from the given path.
     ///
     /// # Errors
@@ -35,7 +41,7 @@ impl PackageRegister {
     pub fn from(path: &Path) -> Result<Self> {
         // If the file does not exist, we return an empty storage
         if !fs::exists(path)? {
-            return Ok(PackageRegister { packages: HashMap::new() });
+            return Ok(Self { packages: HashMap::new() });
         }
 
         // Read data from file
@@ -43,7 +49,7 @@ impl PackageRegister {
 
         // If the file is empty, return an empty storage
         if file_content.trim().is_empty() {
-            return Ok(PackageRegister { packages: HashMap::new() });
+            return Ok(Self { packages: HashMap::new() });
         }
 
         // Parse data and return

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -27,9 +27,9 @@ pub struct PackageRegister {
 }
 
 impl PackageRegister {
-    /// Creates a new `PackageRegister`. Should normally never be used.
+    /// Creates a new empty `PackageRegister`. Should normally never be used.
     /// This is mainly used in the `Verifier`. Under normal circumstances use `PackageRegister::from`.
-    pub fn new() -> Self {
+    pub fn new_empty() -> Self {
         Self { packages: HashMap::new() }
     }
 

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -5,3 +5,5 @@
 
 pub const REGISTER_FILENAME: &str = "Installed.toml";
 pub const CONFIG_FILENAME: &str = "Config.toml";
+pub const DEFAULT_METADATA_REPOSITORY_NAME: &str = "core";
+pub const DEFAULT_METADATA_REPOSITORY_PATH: &str = "https://raw.githubusercontent.com/pack-it/core/main/";

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -5,5 +5,6 @@
 
 pub const REGISTER_FILENAME: &str = "Installed.toml";
 pub const CONFIG_FILENAME: &str = "Config.toml";
+
 pub const DEFAULT_METADATA_REPOSITORY_NAME: &str = "core";
 pub const DEFAULT_METADATA_REPOSITORY_PATH: &str = "https://raw.githubusercontent.com/pack-it/core/main/";

--- a/src/utils/constants.rs
+++ b/src/utils/constants.rs
@@ -2,9 +2,11 @@
 /*
  * A constants file to keep global constants.
  */
+use crate::repositories::metadata::WEB_METADATA_PROVIDER_ID;
 
 pub const REGISTER_FILENAME: &str = "Installed.toml";
 pub const CONFIG_FILENAME: &str = "Config.toml";
 
 pub const DEFAULT_METADATA_REPOSITORY_NAME: &str = "core";
 pub const DEFAULT_METADATA_REPOSITORY_PATH: &str = "https://raw.githubusercontent.com/pack-it/core/main/";
+pub const DEFAULT_METADATA_REPOSITORY_PROVIDER: &str = WEB_METADATA_PROVIDER_ID;

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -82,3 +82,21 @@ pub fn parse_path_from_bytes(bytes: &[u8]) -> Result<&Path, Utf8Error> {
 
     Ok(Path::new(string))
 }
+
+/// Checks recursively if a directory is empty (contains nothing but empty directories).
+/// Returns true if empty, false if not.
+pub fn directory_is_empty(directory: &Path) -> Result<bool, std::io::Error> {
+    for package in directory.read_dir()? {
+        let package = package?;
+
+        if !package.path().is_dir() {
+            return Ok(false);
+        }
+
+        if !directory_is_empty(&package.path())? {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Check {
-    // Initial checks (checks which verify methods which the verifier uses internally)
+    // Initial checks (which verify methods that the verifier uses internally)
     Permissions,
     ConfigExistence,
     ConfigSyntax, // Separate from ConfigExistence, because in the future we implement a different fix (reconstruct from Config.toml)
@@ -27,7 +27,7 @@ pub enum Check {
 
 impl Check {
     /// Gets the dependencies of a check (the checks which should happen before the given check).
-    fn get_dependencies(&self) -> &[Self] {
+    const fn get_dependencies(&self) -> &[Self] {
         match self {
             // Initial checks
             Self::Permissions => &[],
@@ -67,7 +67,7 @@ impl Check {
     }
 
     /// Gets all intial checks.
-    pub fn get_initial_checks<'a>() -> &'a [Self] {
+    pub const fn get_initial_checks<'a>() -> &'a [Self] {
         &[
             Self::Permissions,
             Self::ConfigExistence,
@@ -78,7 +78,7 @@ impl Check {
     }
 
     /// Gets all general checks.
-    pub fn get_general_checks<'a>() -> &'a [Self] {
+    pub const fn get_general_checks<'a>() -> &'a [Self] {
         &[
             Self::StorageConsistency,
             Self::RegisterConsistency,
@@ -90,7 +90,7 @@ impl Check {
     }
 
     /// Gets all package specific checks.
-    pub fn get_package_checks<'a>() -> &'a [Self] {
+    pub const fn get_package_checks<'a>() -> &'a [Self] {
         &[
             Self::PackageExistence,
             Self::PackageStorageConsistency,

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -4,6 +4,7 @@ use std::collections::HashSet;
 pub enum Check {
     // Initial checks (checks which verify methods which the verifier uses internally)
     ConfigExistance,
+    ConfigSyntax, // Separate from ConfigExistance, because in the future we implement a different fix (reconstruct from Config.toml)
 
     // General package checks
     StorageConsistency,
@@ -26,6 +27,7 @@ impl Check {
         match self {
             // Initial checks
             Self::ConfigExistance => &[],
+            Self::ConfigSyntax => &[Self::ConfigExistance],
 
             // General checks
             Self::PackitGroup => &[],
@@ -53,7 +55,7 @@ impl Check {
 
     /// Gets all intial checks.
     pub fn get_initial_checks<'a>() -> &'a [Self] {
-        &[Self::ConfigExistance]
+        &[Self::ConfigExistance, Self::ConfigSyntax]
     }
 
     /// Gets all general checks.

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -4,10 +4,10 @@ use std::collections::HashSet;
 pub enum Check {
     // Initial checks (checks which verify methods which the verifier uses internally)
     Permissions,
-    ConfigExistance,
-    ConfigSyntax, // Separate from ConfigExistance, because in the future we implement a different fix (reconstruct from Config.toml)
-    RegisterExistance,
-    RegisterSyntax, // Separate from RegisterExistance, same reason as for ConfigSyntax
+    ConfigExistence,
+    ConfigSyntax, // Separate from ConfigExistence, because in the future we implement a different fix (reconstruct from Config.toml)
+    RegisterExistence,
+    RegisterSyntax, // Separate from RegisterExistence, same reason as for ConfigSyntax
 
     // General package checks
     StrayDirectory,
@@ -18,8 +18,8 @@ pub enum Check {
     PackitGroup,
 
     // Checks which are specific to a package
-    PackageExistance,
-    PackageStorageConsistancy,
+    PackageExistence,
+    PackageStorageConsistency,
     PackageRegisterConsistency,
     PackageDependencyTree,
     PackageAlterations,
@@ -31,14 +31,14 @@ impl Check {
         match self {
             // Initial checks
             Self::Permissions => &[],
-            Self::ConfigExistance => &[Self::Permissions],
-            Self::ConfigSyntax => &[Self::Permissions, Self::ConfigExistance],
-            Self::RegisterExistance => &[Self::Permissions, Self::ConfigExistance, Self::ConfigSyntax],
+            Self::ConfigExistence => &[Self::Permissions],
+            Self::ConfigSyntax => &[Self::Permissions, Self::ConfigExistence],
+            Self::RegisterExistence => &[Self::Permissions, Self::ConfigExistence, Self::ConfigSyntax],
             Self::RegisterSyntax => &[
                 Self::Permissions,
-                Self::ConfigExistance,
+                Self::ConfigExistence,
                 Self::ConfigSyntax,
-                Self::RegisterExistance,
+                Self::RegisterExistence,
             ],
 
             // General checks
@@ -50,17 +50,17 @@ impl Check {
             Self::Alterations => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
 
             // Package specific checks
-            Self::PackageExistance => &[],
-            Self::PackageStorageConsistancy => &[Self::PackageExistance],
-            Self::PackageRegisterConsistency => &[Self::PackageExistance],
+            Self::PackageExistence => &[],
+            Self::PackageStorageConsistency => &[Self::PackageExistence],
+            Self::PackageRegisterConsistency => &[Self::PackageExistence],
             Self::PackageDependencyTree => &[
-                Self::PackageExistance,
-                Self::PackageStorageConsistancy,
+                Self::PackageExistence,
+                Self::PackageStorageConsistency,
                 Self::PackageRegisterConsistency,
             ],
             Self::PackageAlterations => &[
-                Self::PackageExistance,
-                Self::PackageStorageConsistancy,
+                Self::PackageExistence,
+                Self::PackageStorageConsistency,
                 Self::PackageRegisterConsistency,
             ],
         }
@@ -70,9 +70,9 @@ impl Check {
     pub fn get_initial_checks<'a>() -> &'a [Self] {
         &[
             Self::Permissions,
-            Self::ConfigExistance,
+            Self::ConfigExistence,
             Self::ConfigSyntax,
-            Self::RegisterExistance,
+            Self::RegisterExistence,
             Self::RegisterSyntax,
         ]
     }
@@ -92,8 +92,8 @@ impl Check {
     /// Gets all package specific checks.
     pub fn get_package_checks<'a>() -> &'a [Self] {
         &[
-            Self::PackageExistance,
-            Self::PackageStorageConsistancy,
+            Self::PackageExistence,
+            Self::PackageStorageConsistency,
             Self::PackageRegisterConsistency,
             Self::PackageDependencyTree,
             Self::PackageAlterations,
@@ -102,7 +102,7 @@ impl Check {
 
     /// Gets the checks in the correct order based on the 'check dependency tree'.
     /// Returns a flattened 'check dependency tree'
-    pub fn get_ordered_checks<'a>(checks: &'a [Self]) -> Vec<&'a Self> {
+    pub fn get_ordered_checks(checks: &[Self]) -> Vec<&Self> {
         let mut ordered = Vec::new();
         for check in checks {
             ordered.extend(Self::get_ordered_checks(check.get_dependencies()));
@@ -128,16 +128,13 @@ mod tests {
 
     #[test]
     fn check_order() {
-        assert_eq!(
-            Check::get_ordered_checks(&[Check::ConfigExistance]),
-            Vec::from([&Check::ConfigExistance])
-        );
+        assert_eq!(Check::get_ordered_checks(&[Check::Permissions]), Vec::from([&Check::Permissions]));
 
         assert_eq!(
             Check::get_ordered_checks(&[Check::PackageAlterations, Check::PackageRegisterConsistency]),
             Vec::from([
-                &Check::PackageExistance,
-                &Check::PackageStorageConsistancy,
+                &Check::PackageExistence,
+                &Check::PackageStorageConsistency,
                 &Check::PackageRegisterConsistency,
                 &Check::PackageAlterations
             ])
@@ -147,6 +144,7 @@ mod tests {
             Check::get_ordered_checks(&[Check::DependencyTree]),
             Vec::from([
                 &Check::PackitGroup,
+                &Check::StrayDirectory,
                 &Check::StorageConsistency,
                 &Check::RegisterConsistency,
                 &Check::DependencyTree,

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -1,0 +1,157 @@
+use std::collections::HashSet;
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum Check {
+    // Initial checks (checks which verify methods which the verifier uses internally)
+    ConfigExistance,
+
+    // General package checks
+    StorageConsistency,
+    RegisterConsistency,
+    DependencyTree,
+    Alterations,
+    PackitGroup,
+
+    // Checks which are specific to a package
+    PackageExistance,
+    PackageStorageConsistancy,
+    PackageRegisterConsistency,
+    PackageDependencyTree,
+    PackageAlterations,
+}
+
+impl Check {
+    /// Gets the dependencies of a check (the checks which should happen before the given check).
+    fn get_dependencies(&self) -> &[Self] {
+        match self {
+            // Initial checks
+            Self::ConfigExistance => &[],
+
+            // General checks
+            Self::PackitGroup => &[],
+            Self::StorageConsistency => &[Self::PackitGroup],
+            Self::RegisterConsistency => &[Self::PackitGroup],
+            Self::DependencyTree => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
+            Self::Alterations => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
+
+            // Package specific checks
+            Self::PackageExistance => &[],
+            Self::PackageStorageConsistancy => &[Self::PackageExistance],
+            Self::PackageRegisterConsistency => &[Self::PackageExistance],
+            Self::PackageDependencyTree => &[
+                Self::PackageExistance,
+                Self::PackageStorageConsistancy,
+                Self::PackageRegisterConsistency,
+            ],
+            Self::PackageAlterations => &[
+                Self::PackageExistance,
+                Self::PackageStorageConsistancy,
+                Self::PackageRegisterConsistency,
+            ],
+        }
+    }
+
+    /// Gets all intial checks.
+    pub fn get_initial_checks<'a>() -> &'a [Self] {
+        &[Self::ConfigExistance]
+    }
+
+    /// Gets all general checks.
+    pub fn get_general_checks<'a>() -> &'a [Self] {
+        &[
+            Self::StorageConsistency,
+            Self::RegisterConsistency,
+            Self::DependencyTree,
+            Self::Alterations,
+            Self::PackitGroup,
+        ]
+    }
+
+    /// Gets all package specific checks.
+    pub fn get_package_checks<'a>() -> &'a [Self] {
+        &[
+            Self::PackageExistance,
+            Self::PackageStorageConsistancy,
+            Self::PackageRegisterConsistency,
+            Self::PackageDependencyTree,
+            Self::PackageAlterations,
+        ]
+    }
+
+    /// Gets the checks in the correct order based on the 'check dependency tree'.
+    /// Returns a flattened 'check dependency tree'
+    pub fn get_ordered_checks<'a>(checks: &'a [Self]) -> Vec<&'a Self> {
+        let mut ordered = Vec::new();
+        for check in checks {
+            ordered.extend(Self::get_ordered_checks(check.get_dependencies()));
+            ordered.push(check);
+        }
+
+        let mut seen = HashSet::new();
+        let mut unique_ordered = Vec::new();
+        for check in ordered {
+            if !seen.contains(check) {
+                unique_ordered.push(check);
+                seen.insert(check);
+            }
+        }
+
+        unique_ordered
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn check_order() {
+        assert_eq!(
+            Check::get_ordered_checks(&[Check::ConfigExistance]),
+            Vec::from([&Check::ConfigExistance])
+        );
+
+        assert_eq!(
+            Check::get_ordered_checks(&[Check::PackageAlterations, Check::PackageRegisterConsistency]),
+            Vec::from([
+                &Check::PackageExistance,
+                &Check::PackageStorageConsistancy,
+                &Check::PackageRegisterConsistency,
+                &Check::PackageAlterations
+            ])
+        );
+
+        assert_eq!(
+            Check::get_ordered_checks(&[Check::DependencyTree]),
+            Vec::from([
+                &Check::PackitGroup,
+                &Check::StorageConsistency,
+                &Check::RegisterConsistency,
+                &Check::DependencyTree,
+            ])
+        );
+    }
+
+    #[test]
+    fn check_cycles() {
+        let mut all_checks = Check::get_initial_checks().to_vec();
+        all_checks.extend(Check::get_general_checks().to_vec());
+        all_checks.extend(Check::get_package_checks().to_vec());
+
+        for check in all_checks {
+            check_cylces_impl(&check.clone(), &mut HashSet::from([check]));
+        }
+    }
+
+    fn check_cylces_impl(parent: &Check, seen: &mut HashSet<Check>) {
+        for check in parent.get_dependencies() {
+            if seen.contains(check) {
+                panic!("Cycle found in verifier checks")
+            }
+
+            seen.insert(check.clone());
+            check_cylces_impl(check, seen);
+            seen.remove(check);
+        }
+    }
+}

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -3,6 +3,7 @@ use std::collections::HashSet;
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum Check {
     // Initial checks (checks which verify methods which the verifier uses internally)
+    Permissions,
     ConfigExistance,
     ConfigSyntax, // Separate from ConfigExistance, because in the future we implement a different fix (reconstruct from Config.toml)
 
@@ -27,8 +28,9 @@ impl Check {
     fn get_dependencies(&self) -> &[Self] {
         match self {
             // Initial checks
-            Self::ConfigExistance => &[],
-            Self::ConfigSyntax => &[Self::ConfigExistance],
+            Self::Permissions => &[],
+            Self::ConfigExistance => &[Self::Permissions],
+            Self::ConfigSyntax => &[Self::Permissions, Self::ConfigExistance],
 
             // General checks
             Self::PackitGroup => &[],
@@ -57,7 +59,7 @@ impl Check {
 
     /// Gets all intial checks.
     pub fn get_initial_checks<'a>() -> &'a [Self] {
-        &[Self::ConfigExistance, Self::ConfigSyntax]
+        &[Self::Permissions, Self::ConfigExistance, Self::ConfigSyntax]
     }
 
     /// Gets all general checks.

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -6,6 +6,8 @@ pub enum Check {
     Permissions,
     ConfigExistance,
     ConfigSyntax, // Separate from ConfigExistance, because in the future we implement a different fix (reconstruct from Config.toml)
+    RegisterExistance,
+    RegisterSyntax, // Separate from RegisterExistance, same reason as for ConfigSyntax
 
     // General package checks
     StrayDirectory,
@@ -31,6 +33,13 @@ impl Check {
             Self::Permissions => &[],
             Self::ConfigExistance => &[Self::Permissions],
             Self::ConfigSyntax => &[Self::Permissions, Self::ConfigExistance],
+            Self::RegisterExistance => &[Self::Permissions, Self::ConfigExistance, Self::ConfigSyntax],
+            Self::RegisterSyntax => &[
+                Self::Permissions,
+                Self::ConfigExistance,
+                Self::ConfigSyntax,
+                Self::RegisterExistance,
+            ],
 
             // General checks
             Self::PackitGroup => &[],
@@ -59,7 +68,13 @@ impl Check {
 
     /// Gets all intial checks.
     pub fn get_initial_checks<'a>() -> &'a [Self] {
-        &[Self::Permissions, Self::ConfigExistance, Self::ConfigSyntax]
+        &[
+            Self::Permissions,
+            Self::ConfigExistance,
+            Self::ConfigSyntax,
+            Self::RegisterExistance,
+            Self::RegisterSyntax,
+        ]
     }
 
     /// Gets all general checks.

--- a/src/verifier/checks.rs
+++ b/src/verifier/checks.rs
@@ -7,6 +7,7 @@ pub enum Check {
     ConfigSyntax, // Separate from ConfigExistance, because in the future we implement a different fix (reconstruct from Config.toml)
 
     // General package checks
+    StrayDirectory,
     StorageConsistency,
     RegisterConsistency,
     DependencyTree,
@@ -31,8 +32,9 @@ impl Check {
 
             // General checks
             Self::PackitGroup => &[],
-            Self::StorageConsistency => &[Self::PackitGroup],
-            Self::RegisterConsistency => &[Self::PackitGroup],
+            Self::StrayDirectory => &[Self::PackitGroup],
+            Self::StorageConsistency => &[Self::PackitGroup, Self::StrayDirectory],
+            Self::RegisterConsistency => &[Self::PackitGroup, Self::StrayDirectory],
             Self::DependencyTree => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
             Self::Alterations => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
 
@@ -66,6 +68,7 @@ impl Check {
             Self::DependencyTree,
             Self::Alterations,
             Self::PackitGroup,
+            Self::StrayDirectory,
         ]
     }
 

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -22,6 +22,9 @@ pub enum VerifierError {
     #[error("Cannot parse filename, because it contains invalid unicode")]
     InvalidUnicodeError,
 
+    #[error("Cannot do general checks before doing intial checks")]
+    InitialChecksSkippedError,
+
     #[error("Could not verify")]
     IOError(#[from] std::io::Error),
 

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -10,6 +10,7 @@ use crate::{
     },
     packager::PackagerError,
     platforms::{permissions::error::PermissionError, symlink::SymlinkError},
+    repositories::error::RepositoryError,
     storage::error::RegisterError,
 };
 
@@ -57,6 +58,9 @@ pub enum VerifierError {
 
     #[error("Could not check permissions")]
     PermissionError(#[from] PermissionError),
+
+    #[error("Could not use repository manager for check or fix")]
+    RepositoryError(#[from] RepositoryError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, VerifierError>;

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -28,7 +28,7 @@ pub enum VerifierError {
     #[error("Cannot continue with checks, missing check implementation")]
     UnimplementedCheckError,
 
-    #[error("Could not verify")]
+    #[error("Could not verify or fix")]
     IOError(#[from] std::io::Error),
 
     #[error("Could not display issues")]

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -9,7 +9,7 @@ use crate::{
         types::{PackageNameError, VersionError},
     },
     packager::PackagerError,
-    platforms::symlink::SymlinkError,
+    platforms::{permissions::error::PermissionError, symlink::SymlinkError},
     storage::error::RegisterError,
 };
 
@@ -54,6 +54,9 @@ pub enum VerifierError {
 
     #[error("Could not use config for fix")]
     ConfigError(#[from] ConfigError),
+
+    #[error("Could not check permissions")]
+    PermissionError(#[from] PermissionError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, VerifierError>;

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -3,12 +3,14 @@ use thiserror::Error;
 
 use crate::{
     cli::display::error::DisplayError,
+    config::ConfigError,
     installer::{
         error::InstallerError,
         types::{PackageNameError, VersionError},
     },
     packager::PackagerError,
     platforms::symlink::SymlinkError,
+    storage::error::RegisterError,
 };
 
 /// The errors that occur during verification.
@@ -40,6 +42,12 @@ pub enum VerifierError {
 
     #[error("Could not verify because of an invalid package name")]
     PackageNameError(#[from] PackageNameError),
+
+    #[error("Could not use register for fix")]
+    RegisterError(#[from] RegisterError),
+
+    #[error("Could not use config for fix")]
+    ConfigError(#[from] ConfigError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, VerifierError>;

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -23,13 +23,13 @@ pub enum VerifierError {
     #[error("Cannot parse filename, because it contains invalid unicode")]
     InvalidUnicodeError,
 
-    #[error("Cannot do general checks before doing intial checks")]
+    #[error("Cannot do general checks before doing initial checks")]
     InitialChecksSkippedError,
 
     #[error("Cannot continue with checks, missing check implementation")]
     UnimplementedCheckError,
 
-    #[error("Could not verify or fix")]
+    #[error("Cannot perform check or fix, because of an error while interacting with the filesystem")]
     IOError(#[from] std::io::Error),
 
     #[error("Could not display issues")]

--- a/src/verifier/error.rs
+++ b/src/verifier/error.rs
@@ -25,6 +25,9 @@ pub enum VerifierError {
     #[error("Cannot do general checks before doing intial checks")]
     InitialChecksSkippedError,
 
+    #[error("Cannot continue with checks, missing check implementation")]
+    UnimplementedCheckError,
+
     #[error("Could not verify")]
     IOError(#[from] std::io::Error),
 

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -20,6 +20,9 @@ pub enum Issue {
 
     /// The 'packit' group is missing.
     MissingPackitGroup,
+
+    /// A list of packages which are in the register, but have an empty corresponding package directory.
+    EmptyPackageDirectory(Vec<PackageId>),
 }
 
 impl Display for Issue {
@@ -50,6 +53,23 @@ impl Display for Issue {
             Issue::InconsistentStorage(package_ids) => {
                 write!(f, "Inconsistent storage\n")?;
                 let issue_explanation = "The following packages were found in Installed.toml, but not in the Packit package directory:\n";
+                write!(f, "{issue_explanation}")?;
+
+                for package in package_ids {
+                    write!(f, "  - {}\n", package.to_string().bold().blue())?;
+                }
+            },
+            Issue::EmptyPackageDirectory(package_ids) if package_ids.len() == 1 => {
+                write!(f, "Inconsistent storage\n")?;
+                let issue_explanation = format!(
+                    "{} has an empty package directory.\n",
+                    package_ids.first().expect("Expected one package id.").to_string().bold().blue()
+                );
+                write!(f, "{issue_explanation}")?;
+            },
+            Issue::EmptyPackageDirectory(package_ids) => {
+                write!(f, "Empty package directory\n")?;
+                let issue_explanation = "The following packages have an empty package directory:\n";
                 write!(f, "{issue_explanation}")?;
 
                 for package in package_ids {

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -6,6 +6,9 @@ use crate::installer::types::PackageId;
 
 /// Holds a single issue and the data regarding that issue.
 pub enum Issue {
+    /// The user cannot write to the prefix directory (or one if its sub directories).
+    IncorrectPermissions(HashSet<PathBuf>),
+
     /// The Packit Config.toml is missing.
     MissingConfig,
 
@@ -35,6 +38,15 @@ impl Display for Issue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", "ISSUE: ".bold().yellow())?;
         match self {
+            Issue::IncorrectPermissions(directories) => {
+                writeln!(f, "Incorrect permissions")?;
+                let issue_explanation = "The following directories were not writable:";
+                writeln!(f, "{issue_explanation}")?;
+
+                for directory in directories {
+                    writeln!(f, "  - {}", directory.display())?;
+                }
+            },
             Issue::MissingConfig => {
                 writeln!(f, "Missing Config.toml file")?;
             },
@@ -108,6 +120,7 @@ impl Issue {
     /// Gets a message which descripes the fix for each issue.
     pub fn get_fix_message(&self) -> &str {
         match &self {
+            Issue::IncorrectPermissions(_) => "To fix this issue we set the permissions again.",
             Issue::MissingConfig => "To fix this issue we try to reconstruct the Config.toml based on data still in the Packit directory.",
             Issue::StrayDirectories(_) => "To fix this issue we remove the stray directories.",
             Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.",

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -19,7 +19,7 @@ pub enum Issue {
     InconsistentStorage(Vec<PackageId>),
 
     /// A list of packages which are present in the package directory, but not in the Installed.toml.
-    InconsistentRegister(Vec<PackageId>),
+    InconsistentRegister(HashSet<PackageId>),
 
     /// A list of packages which are changed (when they shouldn't be).
     AlteredPackage(Vec<PackageId>),

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -83,3 +83,19 @@ impl Display for Issue {
         Ok(())
     }
 }
+
+impl Issue {
+    /// Gets a message which descripes the fix for each issue.
+    pub fn get_fix_message(&self) -> String {
+        match &self {
+            Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.".to_string(),
+            Issue::InconsistentStorage(_) => {
+                "To fix this issue the packages are temporarily removed from the register and then reinstalled.".to_string()
+            },
+            Issue::InconsistentRegister(_) => {
+                "To fix this issue the packages are temporarily removed from storage and then reinstalled.".to_string()
+            },
+            _ => "There is no automatic fix for this issue available yet.".to_string(),
+        }
+    }
+}

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -26,65 +26,57 @@ pub enum Issue {
 }
 
 impl Display for Issue {
-    // TODO: Unsure more uniform printing (get issue name from issue with a method) and package listing should be separated logic
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", "ISSUE: ".bold().yellow())?;
         match self {
             Issue::BrokenTree(missing) => {
-                write!(f, "Broken dependency tree\n")?;
-                write!(f, "The following dependencies are missing:\n")?;
+                writeln!(f, "Broken dependency tree")?;
+                writeln!(f, "The following dependencies are missing:")?;
 
                 for (parent, missing_package) in missing {
                     let item = format!(
-                        "  - {} missing {}\n",
+                        "  - {} missing {}",
                         parent.to_string().bold().blue(),
                         missing_package.to_string().bold().blue()
                     );
-                    write!(f, "{}", item)?;
+
+                    writeln!(f, "{}", item)?;
                 }
             },
-            Issue::InconsistentStorage(package_ids) if package_ids.len() == 1 => {
-                write!(f, "Inconsistent storage\n")?;
-                let issue_explanation = format!(
-                    "{} was found in Installed.toml, but not in the Packit package directory.\n",
-                    package_ids.first().expect("Expected one package id.").to_string().bold().blue()
-                );
-                write!(f, "{issue_explanation}")?;
-            },
             Issue::InconsistentStorage(package_ids) => {
-                write!(f, "Inconsistent storage\n")?;
-                let issue_explanation = "The following packages were found in Installed.toml, but not in the Packit package directory:\n";
-                write!(f, "{issue_explanation}")?;
+                writeln!(f, "Inconsistent storage")?;
+                let issue_explanation = "The following packages were found in Installed.toml, but not in the Packit package directory:";
+                writeln!(f, "{issue_explanation}")?;
 
                 for package in package_ids {
-                    write!(f, "  - {}\n", package.to_string().bold().blue())?;
+                    writeln!(f, "  - {}", package.to_string().bold().blue())?;
                 }
             },
             Issue::InconsistentRegister(package_ids) => {
-                write!(f, "Inconsistent register\n")?;
-                let issue_explanation = "The following packages were found in the Packit packages directory, but not in the register:\n";
-                write!(f, "{issue_explanation}")?;
+                writeln!(f, "Inconsistent register")?;
+                let issue_explanation = "The following packages were found in the Packit packages directory, but not in the register:";
+                writeln!(f, "{issue_explanation}")?;
 
                 for package in package_ids {
-                    write!(f, "  - {}\n", package.to_string().bold().blue())?;
+                    writeln!(f, "  - {}", package.to_string().bold().blue())?;
                 }
             },
             Issue::AlteredPackage(altered) => {
-                write!(f, "Altered packages\n")?;
-                let issue_explanation = "The following packages were found to be changed when they shouldn't be:\n";
-                write!(f, "{issue_explanation}")?;
+                writeln!(f, "Altered packages")?;
+                let issue_explanation = "The following packages were found to be changed when they shouldn't be:";
+                writeln!(f, "{issue_explanation}")?;
 
                 for package in altered {
-                    write!(f, "  - {}\n", package.to_string().bold().blue())?;
+                    writeln!(f, "  - {}", package.to_string().bold().blue())?;
                 }
             },
             Issue::MissingPackitGroup => {
-                write!(f, "Packit group missing\n")?;
-                write!(f, "The 'packit' group is missing while multiuser mode is turned on.\n")?;
+                writeln!(f, "Packit group missing")?;
+                writeln!(f, "The 'packit' group is missing while multiuser mode is turned on.")?;
             },
             Issue::NotFound(package_id) => {
-                write!(f, "Package existance\n")?;
-                write!(f, "{} cannot be found anywhere in Packit.\n", package_id.to_string().bold().blue())?
+                writeln!(f, "Package existance")?;
+                writeln!(f, "{} cannot be found anywhere in Packit.", package_id.to_string().bold().blue())?
 
                 // TODO: Somehow show result of fuzzy search here
             },
@@ -96,16 +88,16 @@ impl Display for Issue {
 
 impl Issue {
     /// Gets a message which descripes the fix for each issue.
-    pub fn get_fix_message(&self) -> String {
+    pub fn get_fix_message(&self) -> &str {
         match &self {
-            Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.".to_string(),
+            Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.",
             Issue::InconsistentStorage(_) => {
-                "To fix this issue the packages are temporarily removed from the register and then reinstalled.".to_string()
+                "To fix this issue the packages are temporarily removed from the register and then reinstalled."
             },
-            Issue::InconsistentRegister(_) => {
-                "To fix this issue the packages are temporarily removed from storage and then reinstalled.".to_string()
+            Issue::InconsistentRegister(_) => "To fix this issue the packages are temporarily removed from storage and then reinstalled.",
+            Issue::AlteredPackage(_) | Issue::MissingPackitGroup | Issue::NotFound(_) => {
+                "There is no automatic fix for this issue available yet."
             },
-            _ => "There is no automatic fix for this issue available yet.".to_string(),
         }
     }
 }

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -6,7 +6,7 @@ use crate::installer::types::PackageId;
 
 /// Holds a single issue and the data regarding that issue.
 pub enum Issue {
-    /// The user cannot write to the prefix directory (or one if its sub directories).
+    /// The user cannot write to the prefix directory (or one of its sub directories).
     IncorrectPermissions(HashSet<PathBuf>),
 
     /// The Packit Config.toml is missing.

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -102,7 +102,7 @@ impl Display for Issue {
                 writeln!(f, "The 'packit' group is missing while multiuser mode is turned on.")?;
             },
             Issue::NotFound(package_id) => {
-                writeln!(f, "Package existance")?;
+                writeln!(f, "Package existence")?;
                 writeln!(f, "{} cannot be found anywhere in Packit.", package_id.to_string().bold().blue())?
 
                 // TODO: Somehow show result of fuzzy search here

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use colored::Colorize;
-use std::fmt::Display;
+use std::{collections::HashSet, fmt::Display, path::PathBuf};
 
 use crate::installer::types::PackageId;
 
@@ -26,6 +26,9 @@ pub enum Issue {
 
     /// The given package cannot be found anywhere. This issue only applies when a package is specified by the user.
     NotFound(PackageId),
+
+    /// A list of stray directories.
+    StrayDirectories(HashSet<PathBuf>),
 }
 
 impl Display for Issue {
@@ -86,6 +89,15 @@ impl Display for Issue {
 
                 // TODO: Somehow show result of fuzzy search here
             },
+            Issue::StrayDirectories(directories) => {
+                writeln!(f, "Stray directories")?;
+                let issue_explanation = "The following stray directories were found inside of prefix/packages:";
+                writeln!(f, "{issue_explanation}")?;
+
+                for directory in directories {
+                    writeln!(f, "  - {}", directory.display())?;
+                }
+            },
         }
 
         Ok(())
@@ -97,6 +109,7 @@ impl Issue {
     pub fn get_fix_message(&self) -> &str {
         match &self {
             Issue::MissingConfig => "To fix this issue we try to reconstruct the Config.toml based on data still in the Packit directory.",
+            Issue::StrayDirectories(_) => "To fix this issue we remove the stray directories.",
             Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.",
             Issue::InconsistentStorage(_) => {
                 "To fix this issue the packages are temporarily removed from the register and then reinstalled."

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -12,6 +12,9 @@ pub enum Issue {
     /// The Packit Config.toml is missing.
     MissingConfig,
 
+    /// The Packit Installed.toml is missing.
+    MissingRegister,
+
     /// A list of parents and their missing dependencies `<parent> : <missing>`.
     BrokenTree(Vec<(PackageId, PackageId)>),
 
@@ -49,6 +52,9 @@ impl Display for Issue {
             },
             Issue::MissingConfig => {
                 writeln!(f, "Missing Config.toml file")?;
+            },
+            Issue::MissingRegister => {
+                writeln!(f, "Missing Installed.toml file")?;
             },
             Issue::BrokenTree(missing) => {
                 writeln!(f, "Broken dependency tree")?;
@@ -121,7 +127,8 @@ impl Issue {
     pub fn get_fix_message(&self) -> &str {
         match &self {
             Issue::IncorrectPermissions(_) => "To fix this issue we set the permissions again.",
-            Issue::MissingConfig => "To fix this issue we try to reconstruct the Config.toml based on data still in the Packit directory.",
+            Issue::MissingConfig => "To fix this issue we try to reconstruct the Config.toml with data still in the Packit directory.",
+            Issue::MissingRegister => "To fix this issue we try to reconstruct the Installed.toml with data still in the Packit directory.",
             Issue::StrayDirectories(_) => "To fix this issue we remove the stray directories.",
             Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.",
             Issue::InconsistentStorage(_) => {

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -6,6 +6,9 @@ use crate::installer::types::PackageId;
 
 /// Holds a single issue and the data regarding that issue.
 pub enum Issue {
+    /// The Packit Config.toml is missing.
+    MissingConfig,
+
     /// A list of parents and their missing dependencies `<parent> : <missing>`.
     BrokenTree(Vec<(PackageId, PackageId)>),
 
@@ -29,6 +32,9 @@ impl Display for Issue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", "ISSUE: ".bold().yellow())?;
         match self {
+            Issue::MissingConfig => {
+                writeln!(f, "Missing Config.toml file")?;
+            },
             Issue::BrokenTree(missing) => {
                 writeln!(f, "Broken dependency tree")?;
                 writeln!(f, "The following dependencies are missing:")?;
@@ -90,6 +96,7 @@ impl Issue {
     /// Gets a message which descripes the fix for each issue.
     pub fn get_fix_message(&self) -> &str {
         match &self {
+            Issue::MissingConfig => "To fix this issue we try to reconstruct the Config.toml based on data still in the Packit directory.",
             Issue::BrokenTree(_) => "To fix this issue the missing packages will be installed.",
             Issue::InconsistentStorage(_) => {
                 "To fix this issue the packages are temporarily removed from the register and then reinstalled."

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -20,9 +20,13 @@ pub enum Issue {
 
     /// The 'packit' group is missing.
     MissingPackitGroup,
+
+    /// The given package cannot be found anywhere. This issue only applies when a package is specified by the user.
+    NotFound(PackageId),
 }
 
 impl Display for Issue {
+    // TODO: Unsure more uniform printing (get issue name from issue with a method) and package listing should be separated logic
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", "ISSUE: ".bold().yellow())?;
         match self {
@@ -77,6 +81,12 @@ impl Display for Issue {
             Issue::MissingPackitGroup => {
                 write!(f, "Packit group missing\n")?;
                 write!(f, "The 'packit' group is missing while multiuser mode is turned on.\n")?;
+            },
+            Issue::NotFound(package_id) => {
+                write!(f, "Package existance\n")?;
+                write!(f, "{} cannot be found anywhere in Packit.\n", package_id.to_string().bold().blue())?
+
+                // TODO: Somehow show result of fuzzy search here
             },
         }
 

--- a/src/verifier/issue.rs
+++ b/src/verifier/issue.rs
@@ -20,9 +20,6 @@ pub enum Issue {
 
     /// The 'packit' group is missing.
     MissingPackitGroup,
-
-    /// A list of packages which are in the register, but have an empty corresponding package directory.
-    EmptyPackageDirectory(Vec<PackageId>),
 }
 
 impl Display for Issue {
@@ -53,23 +50,6 @@ impl Display for Issue {
             Issue::InconsistentStorage(package_ids) => {
                 write!(f, "Inconsistent storage\n")?;
                 let issue_explanation = "The following packages were found in Installed.toml, but not in the Packit package directory:\n";
-                write!(f, "{issue_explanation}")?;
-
-                for package in package_ids {
-                    write!(f, "  - {}\n", package.to_string().bold().blue())?;
-                }
-            },
-            Issue::EmptyPackageDirectory(package_ids) if package_ids.len() == 1 => {
-                write!(f, "Inconsistent storage\n")?;
-                let issue_explanation = format!(
-                    "{} has an empty package directory.\n",
-                    package_ids.first().expect("Expected one package id.").to_string().bold().blue()
-                );
-                write!(f, "{issue_explanation}")?;
-            },
-            Issue::EmptyPackageDirectory(package_ids) => {
-                write!(f, "Empty package directory\n")?;
-                let issue_explanation = "The following packages have an empty package directory:\n";
                 write!(f, "{issue_explanation}")?;
 
                 for package in package_ids {

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -3,6 +3,7 @@ mod checks;
 pub mod error;
 mod issue;
 mod repairer;
+mod utils;
 mod verifier;
 
 pub use issue::Issue;

--- a/src/verifier/mod.rs
+++ b/src/verifier/mod.rs
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
+mod checks;
 pub mod error;
 mod issue;
 mod repairer;

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -65,16 +65,13 @@ impl Repairer {
     /// Fixes a missing Config.toml. Either by rebuilding the config from known information or using default values.
     fn fix_missing_config(&self) -> Result<()> {
         // Create a default config and adjust when fields can be recovered so new config fields don't create bugs
-        let mut default_config = EditableConfig::default()?;
+        let mut default_config = EditableConfig::default();
 
         // Figure out the prefix path
         let mut prefix_path = PathBuf::from(DEFAULT_PREFIX);
         loop {
             if fs::exists(&prefix_path)? {
-                let question = format!(
-                    "Prefix directory '{}' was found, do you wish to use this?",
-                    prefix_path.to_string_lossy()
-                );
+                let question = format!("Prefix directory '{}' was found, do you wish to use this?", prefix_path.display());
                 if ask_user(&question, QuestionResponse::Yes)?.is_yes() {
                     break;
                 }
@@ -111,7 +108,7 @@ impl Repairer {
         } else {
             println!(
                 "Could not open or parse '{REGISTER_FILENAME}' from '{}', using the default repositories instead",
-                prefix_path.to_string_lossy()
+                prefix_path.display()
             );
         }
 

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -256,6 +256,11 @@ impl Repairer {
         let bin_directory = config.prefix_directory.join("bin");
         let package_directory = config.prefix_directory.join("packages");
         for package_id in &missing {
+            // Skip if the package already exists in the register (from recursive step)
+            if register.get_package_version(package_id).is_some() {
+                continue;
+            }
+
             // Figure out the active version
             let active_target = fs::read_link(active_directory.join(&package_id.name))?;
             let target_name = active_target.file_name().ok_or(VerifierError::InvalidSymlink)?;
@@ -282,7 +287,7 @@ impl Repairer {
             )?;
 
             // Make sure that all dependencies are registered as well
-            let missing_dependencies = dependencies.iter().filter(|d| missing.contains(d)).cloned().collect();
+            let missing_dependencies = dependencies.iter().filter(|d| register.get_package_version(d).is_none()).cloned().collect();
             self.fix_inconsistent_register(missing_dependencies, register, config, manager)?;
 
             register.add_package(

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -83,6 +83,7 @@ impl<'a> Repairer<'a> {
         Ok(())
     }
 
+    // TODO: Somehow store the package info somewhere before deleting, so package history is preserved
     /// Fixes an inconsistent register by temporarily removing the missing packages from storage and then re-installing the packages.
     /// Note that it's not possible to recreate the register entries, because some entries like the source repository cannot be defered from the package storage.
     fn fix_inconsistent_register(&mut self, missing: Vec<PackageId>, register: &mut PackageRegister) -> Result<()> {

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -1,16 +1,25 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::Path, str::FromStr};
+use std::{
+    collections::HashMap,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use crate::{
-    cli::display::logging::warning,
-    config::{Config, EditableConfig},
+    cli::display::{QuestionResponse, ask_user, ask_user_input, logging::warning},
+    config::{Config, EditableConfig, Repository},
     installer::{
         Installer, InstallerOptions,
         types::{PackageId, Version},
     },
+    platforms::{DEFAULT_PREFIX, permissions::packit_group_exists},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::io::remove_symlinks,
+    utils::{
+        constants::{DEFAULT_METADATA_REPOSITORY_NAME, REGISTER_FILENAME},
+        io::remove_symlinks,
+    },
     verifier::{
         Issue,
         error::{Result, VerifierError},
@@ -50,11 +59,99 @@ impl Repairer {
     }
 
     /// Fixes a missing Config.toml. Either by rebuilding the config from known information or using default values.
-    /// TODO: Implement rebuilding config from known data
     fn fix_missing_config(&self) -> Result<()> {
         // Create a default config and adjust when fields can be recovered so new config fields don't create bugs
-        EditableConfig::default()?.save_to(&Config::get_default_path())?;
+        let mut default_config = EditableConfig::default()?;
+
+        // Figure out the prefix path
+        let mut prefix_string = DEFAULT_PREFIX.to_string();
+        let mut prefix_path = PathBuf::from(&prefix_string);
+        loop {
+            if fs::exists(&prefix_path)? {
+                let question = format!("Prefix directory '{prefix_string}' was found, do you wish to use this?");
+                if ask_user(&question, QuestionResponse::Yes)?.is_yes() {
+                    break;
+                }
+            }
+
+            let question = format!("Please provide a different prefix path");
+            match ask_user_input(&question)? {
+                Some(path) => {
+                    prefix_string = path.to_string();
+                    prefix_path = PathBuf::from(&prefix_string);
+                },
+
+                // Return if no valid prefix path can be found (no possibility for reconstruction)
+                None => return self.confirm_config_construction(&mut default_config),
+            }
+        }
+
+        default_config.set_prefix_directory(prefix_path.clone());
+
+        // Try to recover the repositories, repository names cannot be recovered
+        let register_dir = prefix_path.join(REGISTER_FILENAME);
+        if fs::exists(&register_dir)? {
+            if let Ok(register) = PackageRegister::from(&register_dir) {
+                default_config.remove_repository(DEFAULT_METADATA_REPOSITORY_NAME);
+                let mut new_rank = Vec::new();
+                for (i, repository) in self.get_used_repositories(&register).into_iter().enumerate() {
+                    // Create a unique name for each repository (we can't infer this from anything)
+                    let name = format!("repository_{}", i);
+                    default_config.set_repository(&name, repository);
+                    new_rank.push(name);
+                }
+
+                default_config.set_repositories_rank(new_rank);
+            }
+        } else {
+            println!("Could not open or parse '{REGISTER_FILENAME}' from '{prefix_string}', using the default repositories instead");
+        }
+
+        // Set multi-user to true if the packit group exists
+        default_config.set_multiuser(packit_group_exists());
+
+        self.confirm_config_construction(&mut default_config)?;
+
         Ok(())
+    }
+
+    /// Saves the reconstructed Config.toml to the default config path if the user confirms it.
+    fn confirm_config_construction(&self, default_config: &mut EditableConfig) -> Result<()> {
+        println!();
+        println!("Reconstructed Config.toml");
+        default_config.get_config().display();
+        println!();
+
+        let question = "The Config.toml above has been constructed. Do you wish to use this as your config?";
+        if ask_user(question, QuestionResponse::Yes)?.is_yes() {
+            default_config.save_to(&Config::get_default_path())?;
+        }
+
+        Ok(())
+    }
+
+    /// Gets the used repositories from the register metadata in order based on occurance rate.
+    fn get_used_repositories(&self, register: &PackageRegister) -> Vec<Repository> {
+        // Find used repositories in package metadata, and keep track of how many times they are used
+        let mut seen_repositories = HashMap::new();
+        for package in register.iterate_all() {
+            let repository = Repository {
+                path: package.source_repository_url.clone(),
+                provider: package.source_repository_provider.clone(),
+                prebuilds_url: package.source_prebuild_repository_url.clone(),
+                prebuilds_provider: package.source_prebuild_repository_provider.clone(),
+            };
+
+            match seen_repositories.get_mut(&repository) {
+                Some(count) => *count += 1,
+                None => _ = seen_repositories.insert(repository, 1),
+            };
+        }
+
+        // Return the repositories in the correct order
+        let mut repositories: Vec<_> = seen_repositories.into_iter().collect();
+        repositories.sort_by_key(|(_, v)| *v);
+        repositories.into_iter().map(|(k, _)| k).collect()
     }
 
     /// Fixes broken dependency trees by installing the missing packages.

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -40,6 +40,7 @@ impl Repairer {
         match issue {
             Issue::MissingConfig => self.fix_missing_config()?,
             Issue::IncorrectPermissions(directories) => self.fix_unwritable_directories(directories)?,
+            Issue::MissingRegister => self.fix_missing_register()?,
 
             _ => warning!("Fix not executed, because it is not an initial issue"),
         }
@@ -229,8 +230,20 @@ impl Repairer {
         Ok(())
     }
 
-    /// Fixes an inconsistent register by temporarily removing the missing packages from storage and then re-installing the packages.
-    /// Note that it's not possible to recreate the register entries, because some entries like the source repository cannot be defered from the package storage.
+    /// Fixes a missing register. It considders all packages as missing and makes use of the inconsistent register fix.
+    fn fix_missing_register(&mut self) -> Result<()> {
+        // Note that the config can be used, because the check for a missing register depends on the config checks
+        let config = Config::from(&Config::get_default_path())?;
+        let mut register = PackageRegister::new();
+        let missing_packages = get_storage_packages(&config)?;
+        let manager = RepositoryManager::new(&config);
+        self.fix_inconsistent_register(missing_packages, &mut register, &config, &manager)?;
+        register.save_to(&PackageRegister::get_default_path(&config))?;
+        Ok(())
+    }
+
+    /// Fixes an inconsistent register by gathering still existing data from the Packit directories.
+    /// TODO: Expand with a check with package checksums, to make sure that the found repository has the same checksum
     fn fix_inconsistent_register(
         &mut self,
         missing: HashSet<PackageId>,
@@ -258,10 +271,7 @@ impl Repairer {
             // Note that this information is valid, but necessarily the same as before the issue arised
             let (_, package_meta) = manager.read_package(&package_id.name)?;
             let (repository_id, package_version_meta) = manager.read_package_version(&package_id, &Target::current())?;
-            let dependencies = match self.get_latest_satisfying_packages(&package_id, &package_version_meta, &storage_packages) {
-                Some(dependencies) => dependencies,
-                None => continue,
-            };
+            let dependencies = self.get_latest_satisfying_packages(&package_version_meta, &storage_packages);
             let source_repository = config.repositories.get(&repository_id).expect("Expected repository in config");
             let install_path = &package_directory.join(&package_id.name).join(package_id.version.to_string());
             let prebuild_url = manager.get_prebuild_url(
@@ -291,13 +301,13 @@ impl Repairer {
     }
 
     /// Gets the latest satisfying dependencies for a given package from the given storage packages.
+    /// Assumes that all dependencies are present in the given storage packages.
     /// Returns a `HashSet` with all the latest packages which satisfy the dependencies of the given package id.
     fn get_latest_satisfying_packages(
         &self,
-        package_id: &PackageId,
         package_version_meta: &PackageVersionMeta,
         storage_packages: &HashSet<PackageId>,
-    ) -> Option<HashSet<PackageId>> {
+    ) -> HashSet<PackageId> {
         // Find the latest satisfying dependency
         let mut dependencies = HashSet::new();
         for dependency in &package_version_meta.dependencies {
@@ -314,17 +324,13 @@ impl Repairer {
                 }
             }
 
-            match latest {
-                Some(latest) => _ = dependencies.insert(latest.clone()),
-                None => {
-                    // TODO: Add promt for user to install dependency
-                    println!("Could not fix {package_id}, because its dependencies couldn't be found");
-                    return None;
-                },
+            // This assumes that all dependencies can be satisfied with packages in the given storage packages
+            if let Some(latest) = latest {
+                dependencies.insert(latest.clone());
             }
         }
 
-        Some(dependencies)
+        dependencies
     }
 
     /// Fixes stray directories by removing them.

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs,
     path::{Path, PathBuf},
     str::FromStr,
@@ -52,6 +52,7 @@ impl Repairer {
             Issue::BrokenTree(missing) => self.fix_broken_tree(missing, register, config, manager)?,
             Issue::InconsistentStorage(missing) => self.fix_inconsistent_storage(missing, register, config, manager)?,
             Issue::InconsistentRegister(missing) => self.fix_inconsistent_register(missing, register, config, manager)?,
+            Issue::StrayDirectories(strays) => self.fix_stray_directories(strays)?,
             _ => warning!("Fix not executed, because the issue fix is not yet implemented"),
         }
 
@@ -247,6 +248,25 @@ impl Repairer {
             let mut installer = Installer::new(config, register, manager, installer_options);
 
             installer.install(&package_id.into())?;
+        }
+
+        Ok(())
+    }
+
+    /// Fixes stray directories by removing them.
+    fn fix_stray_directories(&self, strays: HashSet<PathBuf>) -> Result<()> {
+        for directory in strays {
+            if !fs::exists(&directory)? {
+                warning!(
+                    "Skipping deletion of stray directory '{}' because it doesn't exist.",
+                    directory.display()
+                );
+            }
+
+            match directory.is_dir() {
+                true => fs::remove_dir_all(directory)?,
+                false => fs::remove_file(directory)?,
+            }
         }
 
         Ok(())

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -13,7 +13,10 @@ use crate::{
         Installer, InstallerOptions,
         types::{PackageId, Version},
     },
-    platforms::{DEFAULT_PREFIX, permissions::packit_group_exists},
+    platforms::{
+        DEFAULT_PREFIX,
+        permissions::{packit_group_exists, set_packit_permissions},
+    },
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
     utils::{
@@ -38,6 +41,7 @@ impl Repairer {
     pub fn fix_initial_issues(&mut self, issue: Issue) -> Result<()> {
         match issue {
             Issue::MissingConfig => self.fix_missing_config()?,
+            Issue::IncorrectPermissions(directories) => self.fix_unwritable_directories(directories)?,
 
             _ => warning!("Fix not executed, because it is not an initial issue"),
         }
@@ -153,6 +157,25 @@ impl Repairer {
         let mut repositories: Vec<_> = seen_repositories.into_iter().collect();
         repositories.sort_by_key(|(_, v)| *v);
         repositories.into_iter().map(|(k, _)| k).collect()
+    }
+
+    /// Fix unwritable directories by setting the permissions again.
+    fn fix_unwritable_directories(&self, directories: HashSet<PathBuf>) -> Result<()> {
+        // Check for multiuser, promt the user if the config doesn't work
+        let multiuser = match Config::from(&Config::get_default_path()) {
+            Ok(config) => config.multiuser,
+            Err(_) => {
+                let question = "Config.toml could not be loaded, do you wish to set permissions for multiuser?";
+                if ask_user(question, QuestionResponse::No)?.is_no() { false } else { true }
+            },
+        };
+
+        // Set permissions for all unwritable directories
+        for directory in directories {
+            set_packit_permissions(&directory, multiuser, false)?;
+        }
+
+        Ok(())
     }
 
     /// Fixes broken dependency trees by installing the missing packages.

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -78,7 +78,7 @@ impl Repairer {
                 }
             }
 
-            let question = format!("Please provide a different prefix path");
+            let question = "Please provide a different prefix path".to_string();
             match ask_user_input(&question)? {
                 Some(path) => {
                     prefix_string = path.to_string();
@@ -165,7 +165,7 @@ impl Repairer {
             Ok(config) => config.multiuser,
             Err(_) => {
                 let question = "Config.toml could not be loaded, do you wish to set permissions for multiuser?";
-                if ask_user(question, QuestionResponse::No)?.is_no() { false } else { true }
+                ask_user(question, QuestionResponse::No)?.is_yes()
             },
         };
 
@@ -234,7 +234,7 @@ impl Repairer {
     fn fix_missing_register(&mut self) -> Result<()> {
         // Note that the config can be used, because the check for a missing register depends on the config checks
         let config = Config::from(&Config::get_default_path())?;
-        let mut register = PackageRegister::new();
+        let mut register = PackageRegister::new_empty();
         let missing_packages = get_storage_packages(&config)?;
         let manager = RepositoryManager::new(&config);
         self.fix_inconsistent_register(missing_packages, &mut register, &config, &manager)?;
@@ -275,13 +275,13 @@ impl Repairer {
             // Get information with the manager
             // Note that this information is valid, but necessarily the same as before the issue arised
             let (_, package_meta) = manager.read_package(&package_id.name)?;
-            let (repository_id, package_version_meta) = manager.read_package_version(&package_id, &Target::current())?;
+            let (repository_id, package_version_meta) = manager.read_package_version(package_id, &Target::current())?;
             let dependencies = self.get_latest_satisfying_packages(&package_version_meta, &storage_packages);
             let source_repository = config.repositories.get(&repository_id).expect("Expected repository in config");
             let install_path = &package_directory.join(&package_id.name).join(package_id.version.to_string());
             let prebuild_url = manager.get_prebuild_url(
                 &repository_id,
-                &package_id,
+                package_id,
                 package_version_meta.revisions.len() as u64,
                 &Target::current(),
             )?;

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -2,7 +2,7 @@
 use std::{
     collections::{HashMap, HashSet},
     fs,
-    path::{Path, PathBuf},
+    path::PathBuf,
     str::FromStr,
 };
 
@@ -14,18 +14,16 @@ use crate::{
         types::{PackageId, Version},
     },
     platforms::{
-        DEFAULT_PREFIX,
+        DEFAULT_PREFIX, Target,
         permissions::{packit_group_exists, set_packit_permissions},
     },
-    repositories::manager::RepositoryManager,
+    repositories::{manager::RepositoryManager, types::PackageVersionMeta},
     storage::package_register::PackageRegister,
-    utils::{
-        constants::{DEFAULT_METADATA_REPOSITORY_NAME, REGISTER_FILENAME},
-        io::remove_symlinks,
-    },
+    utils::constants::{DEFAULT_METADATA_REPOSITORY_NAME, REGISTER_FILENAME},
     verifier::{
         Issue,
         error::{Result, VerifierError},
+        utils::get_storage_packages,
     },
 };
 
@@ -231,49 +229,102 @@ impl Repairer {
         Ok(())
     }
 
-    // TODO: Somehow store the package info somewhere before deleting, so package history is preserved
     /// Fixes an inconsistent register by temporarily removing the missing packages from storage and then re-installing the packages.
     /// Note that it's not possible to recreate the register entries, because some entries like the source repository cannot be defered from the package storage.
     fn fix_inconsistent_register(
         &mut self,
-        missing: Vec<PackageId>,
+        missing: HashSet<PackageId>,
         register: &mut PackageRegister,
         config: &Config,
         manager: &RepositoryManager,
     ) -> Result<()> {
+        let storage_packages = get_storage_packages(config)?;
         let active_directory = config.prefix_directory.join("active");
         let bin_directory = config.prefix_directory.join("bin");
         let package_directory = config.prefix_directory.join("packages");
-        for package_id in missing {
+        for package_id in &missing {
             // Figure out the active version
             let active_target = fs::read_link(active_directory.join(&package_id.name))?;
             let target_name = active_target.file_name().ok_or(VerifierError::InvalidSymlink)?;
             let version = Version::from_str(target_name.to_str().ok_or(VerifierError::InvalidUnicodeError)?)?;
 
-            // Check if the package should be the active package when installed
+            // Check if the package is the active package version
             let active = package_id.version == version;
 
             // Figure out if symlinked
             let symlinked = fs::symlink_metadata(bin_directory.join(&package_id.name)).is_ok();
 
-            // Temporarily remove the package from the storage
-            // We have to uninstall and install, because we can't know the repository source otherwise
-            // Remove the symlinks first
-            if symlinked {
-                remove_symlinks(Path::new(&config.prefix_directory), &package_directory)?;
-            }
+            // Get information with the manager
+            // Note that this information is valid, but necessarily the same as before the issue arised
+            let (_, package_meta) = manager.read_package(&package_id.name)?;
+            let (repository_id, package_version_meta) = manager.read_package_version(&package_id, &Target::current())?;
+            let dependencies = match self.get_latest_satisfying_packages(&package_id, &package_version_meta, &storage_packages) {
+                Some(dependencies) => dependencies,
+                None => continue,
+            };
+            let source_repository = config.repositories.get(&repository_id).expect("Expected repository in config");
+            let install_path = &package_directory.join(&package_id.name).join(package_id.version.to_string());
+            let prebuild_url = manager.get_prebuild_url(
+                &repository_id,
+                &package_id,
+                package_version_meta.revisions.len() as u64,
+                &Target::current(),
+            )?;
 
-            // Remove the package
-            fs::remove_dir_all(&package_directory.join(&package_id.name).join(package_id.version.to_string()))?;
+            // Make sure that all dependencies are registered as well
+            let missing_dependencies = dependencies.iter().filter(|d| missing.contains(d)).cloned().collect();
+            self.fix_inconsistent_register(missing_dependencies, register, config, manager)?;
 
-            // Re-install the package
-            let installer_options = InstallerOptions::default().skip_symlinking(!symlinked).skip_active(!active);
-            let mut installer = Installer::new(config, register, manager, installer_options);
-
-            installer.install(&package_id.into())?;
+            register.add_package(
+                &package_meta,
+                &package_version_meta,
+                dependencies,
+                source_repository,
+                install_path,
+                symlinked,
+                active,
+                prebuild_url.is_some(),
+            )?;
         }
 
         Ok(())
+    }
+
+    /// Gets the latest satisfying dependencies for a given package from the given storage packages.
+    /// Returns a `HashSet` with all the latest packages which satisfy the dependencies of the given package id.
+    fn get_latest_satisfying_packages(
+        &self,
+        package_id: &PackageId,
+        package_version_meta: &PackageVersionMeta,
+        storage_packages: &HashSet<PackageId>,
+    ) -> Option<HashSet<PackageId>> {
+        // Find the latest satisfying dependency
+        let mut dependencies = HashSet::new();
+        for dependency in &package_version_meta.dependencies {
+            let mut latest: Option<&PackageId> = None;
+            for package in storage_packages {
+                if !dependency.satisfied(&package.name, &package.version) {
+                    continue;
+                }
+
+                match latest {
+                    Some(id) if id.version < package.version => latest = Some(package),
+                    Some(_) => {},
+                    None => latest = Some(package),
+                }
+            }
+
+            match latest {
+                Some(latest) => _ = dependencies.insert(latest.clone()),
+                None => {
+                    // TODO: Add promt for user to install dependency
+                    println!("Could not fix {package_id}, because its dependencies couldn't be found");
+                    return None;
+                },
+            }
+        }
+
+        Some(dependencies)
     }
 
     /// Fixes stray directories by removing them.

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     platforms::{
         DEFAULT_PREFIX, Target,
-        permissions::{packit_group_exists, set_packit_permissions},
+        permissions::{does_packit_group_exist, set_packit_permissions},
     },
     repositories::{manager::RepositoryManager, types::PackageVersionMeta},
     storage::package_register::PackageRegister,
@@ -68,11 +68,13 @@ impl Repairer {
         let mut default_config = EditableConfig::default()?;
 
         // Figure out the prefix path
-        let mut prefix_string = DEFAULT_PREFIX.to_string();
-        let mut prefix_path = PathBuf::from(&prefix_string);
+        let mut prefix_path = PathBuf::from(DEFAULT_PREFIX);
         loop {
             if fs::exists(&prefix_path)? {
-                let question = format!("Prefix directory '{prefix_string}' was found, do you wish to use this?");
+                let question = format!(
+                    "Prefix directory '{}' was found, do you wish to use this?",
+                    prefix_path.to_string_lossy()
+                );
                 if ask_user(&question, QuestionResponse::Yes)?.is_yes() {
                     break;
                 }
@@ -81,8 +83,7 @@ impl Repairer {
             let question = "Please provide a different prefix path".to_string();
             match ask_user_input(&question)? {
                 Some(path) => {
-                    prefix_string = path.to_string();
-                    prefix_path = PathBuf::from(&prefix_string);
+                    prefix_path = PathBuf::from(path);
                 },
 
                 // Return if no valid prefix path can be found (no possibility for reconstruction)
@@ -108,15 +109,16 @@ impl Repairer {
                 default_config.set_repositories_rank(new_rank);
             }
         } else {
-            println!("Could not open or parse '{REGISTER_FILENAME}' from '{prefix_string}', using the default repositories instead");
+            println!(
+                "Could not open or parse '{REGISTER_FILENAME}' from '{}', using the default repositories instead",
+                prefix_path.to_string_lossy()
+            );
         }
 
         // Set multi-user to true if the packit group exists
-        default_config.set_multiuser(packit_group_exists());
+        default_config.set_multiuser(does_packit_group_exist()?);
 
-        self.confirm_config_construction(&mut default_config)?;
-
-        Ok(())
+        self.confirm_config_construction(&mut default_config)
     }
 
     /// Saves the reconstructed Config.toml to the default config path if the user confirms it.

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -3,7 +3,7 @@ use std::{fs, path::Path, str::FromStr};
 
 use crate::{
     cli::display::logging::warning,
-    config::Config,
+    config::{Config, EditableConfig},
     installer::{
         Installer, InstallerOptions,
         types::{PackageId, Version},
@@ -18,32 +18,53 @@ use crate::{
 };
 
 /// Repairer that fixes issues found by the verifier.
-pub struct Repairer<'a> {
-    config: &'a Config,
-    manager: &'a RepositoryManager<'a>,
-}
+pub struct Repairer;
 
-impl<'a> Repairer<'a> {
+impl Repairer {
     /// Creates a new repairer.
-    pub fn new(config: &'a Config, manager: &'a RepositoryManager) -> Self {
-        Self { config, manager }
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn fix_initial_issues(&mut self, issue: Issue) -> Result<()> {
+        match issue {
+            Issue::MissingConfig => self.fix_missing_config()?,
+
+            _ => warning!("Fix not executed, because it is not an initial issue"),
+        }
+
+        Ok(())
     }
 
     /// Fixes the given issue by executing the fix for that issue.
     /// Note: The register is not saved after the fix is applied.
-    pub fn fix(&mut self, issue: Issue, register: &mut PackageRegister) -> Result<()> {
+    pub fn fix(&mut self, issue: Issue, register: &mut PackageRegister, config: &Config, manager: &RepositoryManager) -> Result<()> {
         match issue {
-            Issue::BrokenTree(missing) => self.fix_broken_tree(missing, register)?,
-            Issue::InconsistentStorage(missing) => self.fix_inconsistent_storage(missing, register)?,
-            Issue::InconsistentRegister(missing) => self.fix_inconsistent_register(missing, register)?,
+            Issue::BrokenTree(missing) => self.fix_broken_tree(missing, register, config, manager)?,
+            Issue::InconsistentStorage(missing) => self.fix_inconsistent_storage(missing, register, config, manager)?,
+            Issue::InconsistentRegister(missing) => self.fix_inconsistent_register(missing, register, config, manager)?,
             _ => warning!("Fix not executed, because the issue fix is not yet implemented"),
         }
 
         Ok(())
     }
 
+    /// Fixes a missing Config.toml. Either by rebuilding the config from known information or using default values.
+    /// TODO: Implement rebuilding config from known data
+    fn fix_missing_config(&self) -> Result<()> {
+        // Create a default config and adjust when fields can be recovered so new config fields don't create bugs
+        EditableConfig::default()?.save_to(&Config::get_default_path())?;
+        Ok(())
+    }
+
     /// Fixes broken dependency trees by installing the missing packages.
-    fn fix_broken_tree(&mut self, missing: Vec<(PackageId, PackageId)>, register: &mut PackageRegister) -> Result<()> {
+    fn fix_broken_tree(
+        &self,
+        missing: Vec<(PackageId, PackageId)>,
+        register: &mut PackageRegister,
+        config: &Config,
+        manager: &RepositoryManager,
+    ) -> Result<()> {
         for (_, missing_package) in missing {
             // There could be duplicates in the missing packages, so skip when already seen
             if register.get_package_version(&missing_package).is_some() {
@@ -52,7 +73,7 @@ impl<'a> Repairer<'a> {
 
             // Install the package
             let installer_options = InstallerOptions::default().skip_symlinking(true);
-            let mut installer = Installer::new(self.config, register, self.manager, installer_options);
+            let mut installer = Installer::new(config, register, manager, installer_options);
             installer.install(&missing_package.clone().into())?;
         }
 
@@ -60,7 +81,13 @@ impl<'a> Repairer<'a> {
     }
 
     /// Fixes inconsistent storage by temporarily removing the missing package from the register and then re-installing the packages.
-    fn fix_inconsistent_storage(&mut self, missing: Vec<PackageId>, register: &mut PackageRegister) -> Result<()> {
+    fn fix_inconsistent_storage(
+        &mut self,
+        missing: Vec<PackageId>,
+        register: &mut PackageRegister,
+        config: &Config,
+        manager: &RepositoryManager,
+    ) -> Result<()> {
         for missing_package in missing {
             // Gather the package settings before removing the package from the register
             let (symlinked, active) = match register.get_package(&missing_package.name) {
@@ -75,7 +102,7 @@ impl<'a> Repairer<'a> {
             register.remove_package_version(&missing_package);
 
             let installer_options = InstallerOptions::default().skip_symlinking(!symlinked).skip_active(!active);
-            let mut installer = Installer::new(self.config, register, self.manager, installer_options);
+            let mut installer = Installer::new(config, register, manager, installer_options);
 
             installer.install(&missing_package.into())?;
         }
@@ -86,10 +113,16 @@ impl<'a> Repairer<'a> {
     // TODO: Somehow store the package info somewhere before deleting, so package history is preserved
     /// Fixes an inconsistent register by temporarily removing the missing packages from storage and then re-installing the packages.
     /// Note that it's not possible to recreate the register entries, because some entries like the source repository cannot be defered from the package storage.
-    fn fix_inconsistent_register(&mut self, missing: Vec<PackageId>, register: &mut PackageRegister) -> Result<()> {
-        let active_directory = self.config.prefix_directory.join("active");
-        let bin_directory = self.config.prefix_directory.join("bin");
-        let package_directory = self.config.prefix_directory.join("packages");
+    fn fix_inconsistent_register(
+        &mut self,
+        missing: Vec<PackageId>,
+        register: &mut PackageRegister,
+        config: &Config,
+        manager: &RepositoryManager,
+    ) -> Result<()> {
+        let active_directory = config.prefix_directory.join("active");
+        let bin_directory = config.prefix_directory.join("bin");
+        let package_directory = config.prefix_directory.join("packages");
         for package_id in missing {
             // Figure out the active version
             let active_target = fs::read_link(active_directory.join(&package_id.name))?;
@@ -106,7 +139,7 @@ impl<'a> Repairer<'a> {
             // We have to uninstall and install, because we can't know the repository source otherwise
             // Remove the symlinks first
             if symlinked {
-                remove_symlinks(Path::new(&self.config.prefix_directory), &package_directory)?;
+                remove_symlinks(Path::new(&config.prefix_directory), &package_directory)?;
             }
 
             // Remove the package
@@ -114,7 +147,7 @@ impl<'a> Repairer<'a> {
 
             // Re-install the package
             let installer_options = InstallerOptions::default().skip_symlinking(!symlinked).skip_active(!active);
-            let mut installer = Installer::new(self.config, register, self.manager, installer_options);
+            let mut installer = Installer::new(config, register, manager, installer_options);
 
             installer.install(&package_id.into())?;
         }

--- a/src/verifier/utils.rs
+++ b/src/verifier/utils.rs
@@ -1,0 +1,39 @@
+use std::{collections::HashSet, fs, str::FromStr};
+
+use crate::{
+    config::Config,
+    installer::types::{PackageId, PackageName, Version},
+    verifier::error::{Result, VerifierError},
+};
+
+/// Gets all the packages stored in the prefix/packages directory.
+pub fn get_storage_packages(config: &Config) -> Result<HashSet<PackageId>> {
+    let package_directory = config.prefix_directory.join("packages");
+    let mut packages = Vec::new();
+    for file_package in fs::read_dir(package_directory)? {
+        let file_package = file_package?;
+        if !file_package.path().is_dir() {
+            continue;
+        }
+
+        // Get the package name
+        let package_name = file_package.file_name();
+        let package_name = package_name.to_str().ok_or(VerifierError::InvalidUnicodeError)?;
+        let package_name = PackageName::from_str(package_name)?;
+
+        for file_version in fs::read_dir(file_package.path())? {
+            let file_version = file_version?;
+            if !file_version.path().is_dir() {
+                continue;
+            }
+
+            // Get the version, and create the package id
+            let version = Version::from_str(file_version.file_name().to_str().ok_or(VerifierError::InvalidUnicodeError)?)?;
+            let package_id = PackageId::new(package_name.clone(), version);
+
+            packages.push(package_id);
+        }
+    }
+
+    Ok(packages.into_iter().collect())
+}

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -175,6 +175,11 @@ impl Verifier {
     /// Returns the next issue if it exists.
     /// Returns an error if an error is returned and no issues have been found yet.
     pub fn next_issue(&mut self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+        // Make sure the initial checks have been run before doing general checks
+        if self.current_intial_check != Check::get_initial_checks().len() {
+            return Err(VerifierError::InitialChecksSkippedError);
+        }
+
         match self.next_issue_impl(register, config) {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -67,7 +67,7 @@ impl Verifier {
                 Check::ConfigExistance => self.check_config_existance()?,
 
                 // Make sure that the check is not an initial check
-                _ if Check::get_initial_checks().contains(check) => panic!("TODO"),
+                _ if Check::get_initial_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
 
                 // Continue if the check is not an initial check
                 _ => continue,
@@ -121,7 +121,7 @@ impl Verifier {
                 Check::PackitGroup => self.check_packit_group(config),
 
                 // Make sure that the check is not a general check
-                _ if Check::get_general_checks().contains(check) => panic!("TODO"),
+                _ if Check::get_general_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
 
                 // Continue if the check is package specific or is an initial check
                 _ => continue,
@@ -177,7 +177,7 @@ impl Verifier {
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
 
                 // Make sure that the check is not a package specific check
-                _ if Check::get_package_checks().contains(check) => panic!("TODO"),
+                _ if Check::get_package_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
 
                 // Continue if the check is not package specific
                 _ => continue,

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -603,29 +603,47 @@ impl Verifier {
     }
 
     /// Reverses the initial checks counter by 1. Except if the current is 0.
-    pub fn reverse_initial_check(&mut self) {
-        if self.current_intial_check == 0 {
-            return;
+    /// Returns the new value of current_intial_check.
+    pub fn reverse_initial_check(&mut self) -> usize {
+        if self.current_intial_check > 0 {
+        self.current_intial_check -= 1;
         }
 
-        self.current_intial_check -= 1;
+        self.current_intial_check
     }
 
     /// Reverses the general checks counter by 1. Except if the current is 0.
-    pub fn reverse_general_check(&mut self) {
-        if self.current_general_check == 0 {
-            return;
+    /// Returns the new value of current_general_check.
+    pub fn reverse_general_check(&mut self) -> usize {
+        if self.current_general_check > 0 {
+        self.current_general_check -= 1;
         }
 
-        self.current_general_check -= 1;
+        self.current_general_check
     }
 
     /// Reverses the package checks counter by 1. Except if the current is 0.
-    pub fn reverse_package_check(&mut self) {
-        if self.current_package_check == 0 {
-            return;
+    /// Returns the new value of current_package_check.
+    pub fn reverse_package_check(&mut self) -> usize {
+        if self.current_package_check > 0 {
+            self.current_package_check -= 1;
         }
 
-        self.current_package_check -= 1;
+        self.current_package_check
+    }
+
+    /// Gets the current initial check index.
+    pub fn get_initial_check_index(&self) -> usize {
+        self.current_intial_check
+    }
+
+    /// Gets the current general check index.
+    pub fn get_general_check_index(&self) -> usize {
+        self.current_general_check
+    }
+
+    /// Gets the current package check index.
+    pub fn get_package_check_index(&self) -> usize {
+        self.current_package_check
     }
 }

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -576,4 +576,31 @@ impl Verifier {
     pub fn issues_found(&self) -> bool {
         self.issues_found
     }
+
+    /// Reverses the initial checks counter by 1. Except if the current is 0.
+    pub fn reverse_initial_check(&mut self) {
+        if self.current_intial_check == 0 {
+            return;
+        }
+
+        self.current_intial_check -= 1;
+    }
+
+    /// Reverses the general checks counter by 1. Except if the current is 0.
+    pub fn reverse_general_check(&mut self) {
+        if self.current_general_check == 0 {
+            return;
+        }
+
+        self.current_general_check -= 1;
+    }
+
+    /// Reverses the package checks counter by 1. Except if the current is 0.
+    pub fn reverse_package_check(&mut self) {
+        if self.current_package_check == 0 {
+            return;
+        }
+
+        self.current_package_check -= 1;
+    }
 }

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -149,7 +149,10 @@ impl<'a> Verifier<'a> {
 
     /// Checks for alterations in all packages using a checksum which is compared to the checksum from the pre-build.
     /// Returns an alteration issue or None if no packages can be found that are altered.
+    #[expect(unused_variables)]
     fn check_alterations(&self, register: &PackageRegister) -> Result<Option<Issue>> {
+        // TODO: For now skip this check, because it will never work (yet)
+        return Ok(None);
         warning!("This is an experimental check, issues from this check could be inaccurate.");
 
         // Check issue for all installed packages
@@ -169,7 +172,11 @@ impl<'a> Verifier<'a> {
 
     /// Checks for alterations in a single package using a checksum which is compared to the checksum from the pre-build.
     /// Returns true if the package was altered, false if not.
+    #[expect(unused_variables, unreachable_code)]
     fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
+        // TODO: For now skip this check, because it will never work (yet)
+        return Ok(false);
+
         // Get the installed package from the register
         let Some(package_version) = register.get_package_version(package_id) else {
             warning!("Cannot retrieve package '{package_id}' from register for package alterations check, skipping check");

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
+use std::{fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::logging::{debug, warning},
@@ -11,101 +11,10 @@ use crate::{
     storage::package_register::PackageRegister,
     verifier::{
         Issue,
+        checks::Check,
         error::{Result, VerifierError},
     },
 };
-
-#[derive(Debug, PartialEq, Eq, Hash)]
-enum Check {
-    // Initial checks (checks which verify methods which the verifier uses internally)
-    ConfigExistance,
-
-    // General package checks
-    StorageConsistency,
-    RegisterConsistency,
-    DependencyTree,
-    Alterations,
-    PackitGroup,
-
-    // Checks which are specific to a package
-    PackageExistance,
-    PackageStorageConsistancy,
-    PackageRegisterConsistency,
-    PackageDependencyTree,
-    PackageAlterations,
-}
-
-impl Check {
-    /// Gets the dependencies of a check (the checks which should happen before the given check).
-    fn get_dependencies(&self) -> &[Self] {
-        match self {
-            // Initial checks
-            Self::ConfigExistance => &[],
-
-            // General checks
-            Self::PackitGroup => &[],
-            Self::StorageConsistency => &[Self::PackitGroup],
-            Self::RegisterConsistency => &[Self::PackitGroup],
-            Self::DependencyTree => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
-            Self::Alterations => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
-
-            // Package specific checks
-            Self::PackageExistance => &[],
-            Self::PackageStorageConsistancy => &[Self::PackageExistance],
-            Self::PackageRegisterConsistency => &[Self::PackageExistance],
-            Self::PackageDependencyTree => &[Self::PackageExistance, Self::PackageStorageConsistancy, Self::PackageDependencyTree],
-            Self::PackageAlterations => &[Self::PackageExistance, Self::PackageStorageConsistancy, Self::PackageDependencyTree],
-        }
-    }
-
-    /// Gets all intial checks.
-    fn get_initial_checks<'a>() -> &'a [Self] {
-        &[Self::ConfigExistance]
-    }
-
-    /// Gets all general checks.
-    fn get_general_checks<'a>() -> &'a [Self] {
-        &[
-            Self::StorageConsistency,
-            Self::RegisterConsistency,
-            Self::DependencyTree,
-            Self::Alterations,
-            Self::PackitGroup,
-        ]
-    }
-
-    /// Gets all package specific checks.
-    fn get_package_checks<'a>() -> &'a [Self] {
-        &[
-            Self::PackageExistance,
-            Self::PackageStorageConsistancy,
-            Self::PackageRegisterConsistency,
-            Self::PackageDependencyTree,
-            Self::PackageAlterations,
-        ]
-    }
-
-    /// Gets the checks in the correct order based on the 'check dependency tree'.
-    /// Returns a flattened 'check dependency tree'
-    fn get_ordered_checks<'a>(checks: &'a [Self]) -> Vec<&'a Self> {
-        let mut ordered = Vec::new();
-        for check in checks {
-            ordered.extend(Self::get_ordered_checks(check.get_dependencies()));
-            ordered.push(check);
-        }
-
-        let mut seen = HashSet::new();
-        let mut unique_ordered = Vec::new();
-        for check in ordered {
-            if !seen.contains(check) {
-                unique_ordered.push(check);
-                seen.insert(check);
-            }
-        }
-
-        unique_ordered
-    }
-}
 
 /// Verifier that scans the Packit environment for issues.
 pub struct Verifier {

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,10 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{
-    collections::HashSet,
-    fs,
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::logging::{debug, warning},
@@ -13,10 +8,11 @@ use crate::{
     packager,
     platforms::{
         DEFAULT_PREFIX, Target,
-        permissions::{is_writable, packit_group_exists},
+        permissions::{does_packit_group_exist, is_writable},
     },
     repositories::{provider, types::Checksum},
     storage::package_register::PackageRegister,
+    utils::io::directory_is_empty,
     verifier::{
         Issue,
         checks::Check,
@@ -44,9 +40,8 @@ impl Verifier {
         }
     }
 
-    /// A wrapper around the `next_initial_issue_impl` method.
-    /// Returns the next issue if it exists.
-    /// Returns an error if an error is returned and no issues have been found yet.
+    /// Gets the next initial issue if it exists.
+    /// If an error occurs during the check it's only returned if no previous issues were found.
     pub fn next_initial_issue(&mut self) -> Result<Option<Issue>> {
         match self.next_initial_issue_impl() {
             Ok(issue) => Ok(issue),
@@ -93,9 +88,8 @@ impl Verifier {
         }
     }
 
-    /// A wrapper around the `next_package_issue_impl` method.
-    /// Returns the next issue if it exists.
-    /// Returns an error if an error is returned and no issues have been found yet.
+    /// Gets the next general issue if it exists.
+    /// If an error occurs during the check it's only returned if no previous issues were found.
     pub fn next_issue(&mut self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         // Make sure the initial checks have been run before doing general checks
         if self.current_intial_check != Check::get_initial_checks().len() {
@@ -131,7 +125,7 @@ impl Verifier {
                 Check::RegisterConsistency => self.check_register_consistency(register, config)?,
                 Check::DependencyTree => self.check_dependency_tree(register),
                 Check::Alterations => self.check_alterations(register, config)?,
-                Check::PackitGroup => self.check_packit_group(config),
+                Check::PackitGroup => self.check_packit_group(config)?,
                 Check::StrayDirectory => self.check_stray_directories(config)?,
 
                 // Make sure that the check is not a general check
@@ -148,9 +142,8 @@ impl Verifier {
         }
     }
 
-    /// A wrapper around the `next_package_issue_impl` method.
-    /// Returns the next package issue if it exists.
-    /// Returns an error if an error is returned and no issues have been found yet.
+    /// Gets the next package issue if it exists.
+    /// If an error occurs during the check it's only returned if no previous issues were found.
     pub fn next_package_issue(&mut self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         match self.next_package_issue_impl(package_id, register, config) {
             Ok(issue) => Ok(issue),
@@ -416,40 +409,22 @@ impl Verifier {
         let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
         // Check if the directory exists, if so return true
-        if fs::exists(&installed_directory)? && !self.directory_is_empty(&installed_directory)? {
+        if fs::exists(&installed_directory)? && !directory_is_empty(&installed_directory)? {
             return Ok(true);
         }
 
         Ok(false)
     }
 
-    /// Checks recursively if a directory is empty (contains nothing but empty directories).
-    /// Returns true if empty, false if not.
-    fn directory_is_empty(&self, directory: &Path) -> Result<bool> {
-        for package in directory.read_dir()? {
-            let package = package?;
-
-            if !package.path().is_dir() {
-                return Ok(false);
-            }
-
-            if !self.directory_is_empty(&package.path())? {
-                return Ok(false);
-            }
-        }
-
-        Ok(true)
-    }
-
     /// Checks if all packages in storage also exist in the register.
     /// Returns a register consistency issue or None if there are packages missing from the register.
     fn check_register_consistency(&self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         let storage_packages = get_storage_packages(config)?;
-        let mut missing = Vec::new();
+        let mut missing = HashSet::new();
         for package_id in storage_packages {
             // Check if the package version also exists in the register, if not add it to missing
             if register.get_package_version(&package_id).is_none() {
-                missing.push(package_id);
+                missing.insert(package_id);
             }
         }
 
@@ -457,7 +432,7 @@ impl Verifier {
             return Ok(None);
         }
 
-        Ok(Some(Issue::InconsistentRegister(missing.into_iter().collect())))
+        Ok(Some(Issue::InconsistentRegister(missing)))
     }
 
     /// Checks if a specific package exists in the register. Note that it doesn't check if the package also exists in storage.
@@ -525,13 +500,13 @@ impl Verifier {
 
     /// Checks if the packit group exists if multiuser mode is enabled in the config.
     /// Returns the issue if the group does not exist, None otherwise.
-    fn check_packit_group(&self, config: &Config) -> Option<Issue> {
+    fn check_packit_group(&self, config: &Config) -> Result<Option<Issue>> {
         // We don't need the packit group if multiuser mode is not enabled
-        if config.multiuser && !packit_group_exists() {
-            return Some(Issue::MissingPackitGroup);
+        if config.multiuser && !does_packit_group_exist()? {
+            return Ok(Some(Issue::MissingPackitGroup));
         }
 
-        None
+        Ok(None)
     }
 
     /// Checks for directories which shouldn't be in the prefix/packages directory.
@@ -561,7 +536,7 @@ impl Verifier {
             }
 
             // Check if the name directory is empty
-            if self.directory_is_empty(&directory.path())? {
+            if directory_is_empty(&directory.path())? {
                 strays.insert(directory.path());
                 continue;
             }
@@ -587,7 +562,7 @@ impl Verifier {
                 };
 
                 // Check if the version directory is empty
-                if self.directory_is_empty(&version_directory.path())? {
+                if directory_is_empty(&version_directory.path())? {
                     strays.insert(version_directory.path());
                     continue;
                 }

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -16,6 +16,7 @@ use crate::{
         Issue,
         checks::Check,
         error::{Result, VerifierError},
+        utils::get_storage_packages,
     },
 };
 
@@ -174,7 +175,7 @@ impl Verifier {
                 Check::StorageConsistency if self.package_storage_is_consistent(package_id, config)? => continue,
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
-                Check::RegisterConsistency => Issue::InconsistentRegister(vec![package_id.clone()]),
+                Check::RegisterConsistency => Issue::InconsistentRegister(HashSet::from([package_id.clone()])),
                 Check::DependencyTree => match self.check_package_dependency_tree(package_id, register) {
                     Some(issue) => issue,
                     None => continue,
@@ -414,33 +415,12 @@ impl Verifier {
     /// Checks if all packages in storage also exist in the register.
     /// Returns a register consistency issue or None if there are packages missing from the register.
     fn check_register_consistency(&self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
-        let package_directory = config.prefix_directory.join("packages");
+        let storage_packages = get_storage_packages(config)?;
         let mut missing = Vec::new();
-        for file_package in fs::read_dir(package_directory)? {
-            let file_package = file_package?;
-            if !file_package.path().is_dir() {
-                continue;
-            }
-
-            // Get the package name
-            let package_name = file_package.file_name();
-            let package_name = package_name.to_str().ok_or(VerifierError::InvalidUnicodeError)?;
-            let package_name = PackageName::from_str(package_name)?;
-
-            for file_version in fs::read_dir(file_package.path())? {
-                let file_version = file_version?;
-                if !file_version.path().is_dir() {
-                    continue;
-                }
-
-                // Get the version, and create the package id
-                let version = Version::from_str(file_version.file_name().to_str().ok_or(VerifierError::InvalidUnicodeError)?)?;
-                let package_id = PackageId::new(package_name.clone(), version);
-
-                // Check if the package version also exists in the register, if not add it to missing
-                if register.get_package_version(&package_id).is_none() {
-                    missing.push(package_id);
-                }
+        for package_id in storage_packages {
+            // Check if the package version also exists in the register, if not add it to missing
+            if register.get_package_version(&package_id).is_none() {
+                missing.push(package_id);
             }
         }
 
@@ -448,7 +428,7 @@ impl Verifier {
             return Ok(None);
         }
 
-        Ok(Some(Issue::InconsistentRegister(missing)))
+        Ok(Some(Issue::InconsistentRegister(missing.into_iter().collect())))
     }
 
     /// Checks if a specific package exists in the register. Note that it doesn't check if the package also exists in storage.

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -26,11 +26,11 @@ enum Check {
 
 /// Defines the correct order to do verifier checks.
 const VERIFY_ORDER: &[Check] = &[
-    Check::PackitGroup,
-    Check::StorageConsistency,
-    Check::RegisterConsistency,
-    Check::Alterations,
-    Check::DependencyTree,
+    Check::PackitGroup,         // Permission related check should happen before check which require permissions
+    Check::StorageConsistency,  // Storage consistency must be checked before assuming consistency (in alteration check for example)
+    Check::RegisterConsistency, // Register consistency must be checked before assuming consistency (in alteration check for example)
+    Check::Alterations,         // Alteration check doesn't HAVE to happen before the dependency check
+    Check::DependencyTree,      // This check happens last, assumes most things work already
 ];
 
 /// Verifier that scans the Packit environment for issues.
@@ -185,9 +185,7 @@ impl<'a> Verifier<'a> {
         let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &Target::current()) {
             Ok(Some(checksum)) => checksum,
             Ok(None) => {
-                warning!(
-                    "Cannot perform alterations check for package '{package_id}', because no prebuild version of the package can be found"
-                );
+                warning!("Cannot perform alterations check for package '{package_id}', because no checksum of the prebuild can be found");
                 return Ok(false);
             },
             Err(e) => {

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -22,13 +22,11 @@ enum Check {
     DependencyTree,
     Alterations,
     PackitGroup,
-    EmptyPackageDirectory,
 }
 
 /// Defines the correct order to do verifier checks.
 const VERIFY_ORDER: &[Check] = &[
     Check::PackitGroup,
-    Check::EmptyPackageDirectory,
     Check::StorageConsistency,
     Check::RegisterConsistency,
     Check::Alterations,
@@ -66,7 +64,6 @@ impl<'a> Verifier<'a> {
 
             let issue = match check {
                 Check::StorageConsistency => self.check_storage_consistency(register)?,
-                Check::EmptyPackageDirectory => self.check_empty_packages(register)?,
                 Check::RegisterConsistency => self.check_register_consistency(register)?,
                 Check::DependencyTree => self.check_dependency_tree(register),
                 Check::Alterations => {
@@ -99,8 +96,6 @@ impl<'a> Verifier<'a> {
             let issue = match check {
                 Check::StorageConsistency if self.package_storage_is_consistent(package_id)? => continue,
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
-                Check::EmptyPackageDirectory if !self.check_empty_package(package_id)? => continue,
-                Check::EmptyPackageDirectory => Issue::EmptyPackageDirectory(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
                 Check::RegisterConsistency => Issue::InconsistentRegister(vec![package_id.clone()]),
                 Check::DependencyTree => {
@@ -234,37 +229,11 @@ impl<'a> Verifier<'a> {
         let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
         // Check if the directory exists, if so return true
-        if fs::exists(installed_directory)? {
+        if fs::exists(&installed_directory)? && !self.directory_is_empty(&installed_directory)? {
             return Ok(true);
         }
 
         Ok(false)
-    }
-
-    /// Checks for packages with an empty package directory.
-    /// Returns None if all packages have a non-empty package directory, an `Issue::EmptyPackageDirectory` otherwise.
-    fn check_empty_packages(&self, register: &PackageRegister) -> Result<Option<Issue>> {
-        let mut empty_packages = Vec::new();
-        for package in register.iterate_all() {
-            if self.check_empty_package(&package.package_id)? {
-                empty_packages.push(package.package_id.clone());
-            }
-        }
-
-        if empty_packages.is_empty() {
-            return Ok(None);
-        }
-
-        Ok(Some(Issue::EmptyPackageDirectory(empty_packages)))
-    }
-
-    /// Checks for a specific package if its package directory is empty.
-    /// Returns true if it's empty, false if not.
-    fn check_empty_package(&self, package_id: &PackageId) -> Result<bool> {
-        dbg!("HERE");
-        let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
-        dbg!(&installed_directory);
-        self.directory_is_empty(&installed_directory)
     }
 
     /// Checks recursively if a directory is empty (contains nothing but empty directories).

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -6,7 +6,7 @@ use crate::{
     config::{Config, Repository},
     installer::types::{PackageId, PackageName, Version},
     packager,
-    platforms::Target,
+    platforms::{Target, permissions::packit_group_exists},
     repositories::{provider, types::Checksum},
     storage::package_register::PackageRegister,
     verifier::{
@@ -65,6 +65,7 @@ impl Verifier {
 
             let issue = match check {
                 Check::ConfigExistance => self.check_config_existance()?,
+                Check::ConfigSyntax => self.check_config_syntax()?,
 
                 // Make sure that the check is not an initial check
                 _ if Check::get_initial_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
@@ -220,6 +221,16 @@ impl Verifier {
         }
 
         Ok(Some(Issue::MissingConfig))
+    }
+
+    /// Checks if the config syntax is valid.
+    /// Returns `None` if the config syntax is valid or an `Issue::MissingConfig` otherwise.
+    /// Could return an IO error.
+    fn check_config_syntax(&self) -> Result<Option<Issue>> {
+        match Config::from(&Config::get_default_path()) {
+            Ok(_) => Ok(None),
+            Err(_) => Ok(Some(Issue::MissingConfig)),
+        }
     }
 
     /// Checks for alterations in a single package using a checksum which is compared to the checksum from the pre-build.
@@ -463,18 +474,9 @@ impl Verifier {
     /// Checks if the packit group exists if multiuser mode is enabled in the config.
     /// Returns the issue if the group does not exist, None otherwise.
     fn check_packit_group(&self, config: &Config) -> Option<Issue> {
-        if !config.multiuser {
-            return None; // We don't need the packit group if multiuser mode is not enabled
-        }
-
-        // TODO: Also implement for Windows
-        #[cfg(any(target_os = "macos", target_os = "linux"))]
-        {
-            use crate::platforms::permissions;
-
-            if permissions::platform::get_group_id(permissions::PACKIT_GROUP_NAME).is_err() {
-                return Some(Issue::MissingPackitGroup);
-            }
+        // We don't need the packit group if multiuser mode is not enabled
+        if config.multiuser && !packit_group_exists() {
+            return Some(Issue::MissingPackitGroup);
         }
 
         None

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -23,10 +23,12 @@ enum Check {
     Alterations,
     PackitGroup,
     PackageExistance,
+    ConfigExistance,
 }
 
 /// Defines the correct order to do verifier checks.
 const VERIFY_ORDER: &[Check] = &[
+    Check::ConfigExistance,     // This is one of the initial checks, everything needs the config to work
     Check::PackitGroup,         // Permission related check should happen before check which require permissions
     Check::PackageExistance,    // Checked before storage and register consistency, because they assume a specified package exists somewhere
     Check::StorageConsistency,  // Storage consistency must be checked before assuming consistency (in alteration check for example)
@@ -36,27 +38,71 @@ const VERIFY_ORDER: &[Check] = &[
 ];
 
 /// Verifier that scans the Packit environment for issues.
-pub struct Verifier<'a> {
-    config: &'a Config,
+pub struct Verifier {
     current_issue: usize,
     issues_found: bool,
 }
 
-impl<'a> Verifier<'a> {
+impl Verifier {
     /// Creates a new verifier.
-    pub fn new(config: &'a Config) -> Self {
+    pub fn new() -> Self {
         Self {
-            config,
             current_issue: 0,
             issues_found: false,
+        }
+    }
+
+    pub fn next_initial_issue(&mut self) -> Result<Option<Issue>> {
+        match self.next_initial_issue_impl() {
+            Ok(issue) => Ok(issue),
+            Err(e) if self.issues_found => {
+                debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
+                self.current_issue = VERIFY_ORDER.len();
+                return Ok(None);
+            },
+            Err(e) => return Err(e),
+        }
+    }
+
+    fn next_initial_issue_impl(&mut self) -> Result<Option<Issue>> {
+        loop {
+            let check = match VERIFY_ORDER.get(self.current_issue) {
+                Some(check) => check,
+                None => return Ok(None),
+            };
+
+            // Increase current issue
+            self.current_issue += 1;
+
+            let issue = match check {
+                Check::ConfigExistance => self.check_config_existance()?,
+
+                // Continue if the check is not an initial check. Explicitly state them, because it's easy to forgot.
+                Check::StorageConsistency
+                | Check::RegisterConsistency
+                | Check::DependencyTree
+                | Check::Alterations
+                | Check::PackitGroup
+                | Check::PackageExistance => continue,
+            };
+
+            if let Some(issue) = issue {
+                self.issues_found = true;
+                return Ok(Some(issue));
+            }
+
+            // TODO: Temporary ugly check
+            if matches!(check, Check::ConfigExistance) {
+                return Ok(None);
+            }
         }
     }
 
     /// A wrapper around the `next_package_issue_impl` method.
     /// Returns the next issue if it exists.
     /// Returns an error if an error is returned and no issues have been found yet.
-    pub fn next_issue(&mut self, register: &PackageRegister) -> Result<Option<Issue>> {
-        match self.next_issue_impl(register) {
+    pub fn next_issue(&mut self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+        match self.next_issue_impl(register, config) {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
@@ -69,7 +115,7 @@ impl<'a> Verifier<'a> {
 
     /// Gets the next issue in the order defined in VERIFY_ORDER.
     /// Returns None if there are no more issues to return.
-    fn next_issue_impl(&mut self, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn next_issue_impl(&mut self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         loop {
             let check = match VERIFY_ORDER.get(self.current_issue) {
                 Some(check) => check,
@@ -80,14 +126,14 @@ impl<'a> Verifier<'a> {
             self.current_issue += 1;
 
             let issue = match check {
-                Check::StorageConsistency => self.check_storage_consistency(register)?,
-                Check::RegisterConsistency => self.check_register_consistency(register)?,
+                Check::StorageConsistency => self.check_storage_consistency(register, config)?,
+                Check::RegisterConsistency => self.check_register_consistency(register, config)?,
                 Check::DependencyTree => self.check_dependency_tree(register),
-                Check::Alterations => self.check_alterations(register)?,
-                Check::PackitGroup => self.check_packit_group(),
+                Check::Alterations => self.check_alterations(register, config)?,
+                Check::PackitGroup => self.check_packit_group(config),
 
-                // Continue if the check is package specific. Explicitly state them, because it's easy to forgot.
-                Check::PackageExistance => continue,
+                // Continue if the check is package specific or is an initial check. Explicitly state them, because it's easy to forgot.
+                Check::PackageExistance | Check::ConfigExistance => continue,
             };
 
             if let Some(issue) = issue {
@@ -100,8 +146,8 @@ impl<'a> Verifier<'a> {
     /// A wrapper around the `next_package_issue_impl` method.
     /// Returns the next package issue if it exists.
     /// Returns an error if an error is returned and no issues have been found yet.
-    pub fn next_package_issue(&mut self, package_id: &PackageId, register: &PackageRegister) -> Result<Option<Issue>> {
-        match self.next_package_issue_impl(package_id, register) {
+    pub fn next_package_issue(&mut self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+        match self.next_package_issue_impl(package_id, register, config) {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
@@ -114,7 +160,7 @@ impl<'a> Verifier<'a> {
 
     /// Gets the next issue for a specific package in the order defined in VERIFY_ORDER.
     /// Returns None if there are no more issues to return.
-    fn next_package_issue_impl(&mut self, package_id: &PackageId, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn next_package_issue_impl(&mut self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         loop {
             let check = match VERIFY_ORDER.get(self.current_issue) {
                 Some(check) => check,
@@ -125,9 +171,9 @@ impl<'a> Verifier<'a> {
             self.current_issue += 1;
 
             let issue = match check {
-                Check::PackageExistance if self.check_package_existance(package_id, register)? => continue,
+                Check::PackageExistance if self.check_package_existance(package_id, register, config)? => continue,
                 Check::PackageExistance => Issue::NotFound(package_id.clone()),
-                Check::StorageConsistency if self.package_storage_is_consistent(package_id)? => continue,
+                Check::StorageConsistency if self.package_storage_is_consistent(package_id, config)? => continue,
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
                 Check::RegisterConsistency => Issue::InconsistentRegister(vec![package_id.clone()]),
@@ -135,11 +181,11 @@ impl<'a> Verifier<'a> {
                     Some(issue) => issue,
                     None => continue,
                 },
-                Check::Alterations if !self.check_package_alterations(package_id, register)? => continue,
+                Check::Alterations if !self.check_package_alterations(package_id, register, config)? => continue,
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
 
                 // Continue if the check is not package specific. Explicitly state them, because it's easy to forgot.
-                Check::PackitGroup => continue,
+                Check::PackitGroup | Check::ConfigExistance => continue,
             };
 
             self.issues_found = true;
@@ -150,7 +196,7 @@ impl<'a> Verifier<'a> {
     /// Checks for alterations in all packages using a checksum which is compared to the checksum from the pre-build.
     /// Returns an alteration issue or None if no packages can be found that are altered.
     #[expect(unused_variables)]
-    fn check_alterations(&self, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn check_alterations(&self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         // TODO: For now skip this check, because it will never work (yet)
         return Ok(None);
         warning!("This is an experimental check, issues from this check could be inaccurate.");
@@ -158,7 +204,7 @@ impl<'a> Verifier<'a> {
         // Check issue for all installed packages
         let mut altered = Vec::new();
         for package in register.iterate_all() {
-            if self.check_package_alterations(&package.package_id, register)? {
+            if self.check_package_alterations(&package.package_id, register, config)? {
                 altered.push(package.package_id.clone());
             }
         }
@@ -170,10 +216,21 @@ impl<'a> Verifier<'a> {
         Ok(Some(Issue::AlteredPackage(altered)))
     }
 
+    /// Checks if the config exists.
+    /// Returns `None` if the config exists or an `Issue::MissingConfig` otherwise.
+    /// Could return an IO error.
+    fn check_config_existance(&self) -> Result<Option<Issue>> {
+        if fs::exists(&Config::get_default_path())? {
+            return Ok(None);
+        }
+
+        Ok(Some(Issue::MissingConfig))
+    }
+
     /// Checks for alterations in a single package using a checksum which is compared to the checksum from the pre-build.
     /// Returns true if the package was altered, false if not.
     #[expect(unused_variables, unreachable_code)]
-    fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
+    fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<bool> {
         // TODO: For now skip this check, because it will never work (yet)
         return Ok(false);
 
@@ -238,7 +295,7 @@ impl<'a> Verifier<'a> {
             },
         };
 
-        let install_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
+        let install_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
         let compressed = packager::compress(&install_directory)?;
         let checksum = Checksum::from_bytes(&compressed);
 
@@ -248,8 +305,8 @@ impl<'a> Verifier<'a> {
     /// Checks if a package exists in the register or in storage.
     /// Returns true if the package exists, false if not.
     /// Could return an IO error.
-    fn check_package_existance(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
-        let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
+    fn check_package_existance(&self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<bool> {
+        let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
         if register.get_package_version(package_id).is_none() && !fs::exists(installed_directory)? {
             return Ok(false);
         }
@@ -259,10 +316,10 @@ impl<'a> Verifier<'a> {
 
     /// Checks if all packages in the register also exist in the package storage in the prefix directory.
     /// Returns a storage consistency issue or None if there are no packages missing from storage.
-    fn check_storage_consistency(&self, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn check_storage_consistency(&self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         let mut missing = Vec::new();
         for package in register.iterate_all() {
-            if !self.package_storage_is_consistent(&package.package_id)? {
+            if !self.package_storage_is_consistent(&package.package_id, config)? {
                 missing.push(package.package_id.clone());
             }
         }
@@ -276,8 +333,8 @@ impl<'a> Verifier<'a> {
 
     /// Checks if a specific package exists in storage. Note that it doesn't check if the package also exists in the register.
     /// Returns false if the package can not be found in the storage, true if it can be found.
-    fn package_storage_is_consistent(&self, package_id: &PackageId) -> Result<bool> {
-        let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
+    fn package_storage_is_consistent(&self, package_id: &PackageId, config: &Config) -> Result<bool> {
+        let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
         // Check if the directory exists, if so return true
         if fs::exists(&installed_directory)? && !self.directory_is_empty(&installed_directory)? {
@@ -307,8 +364,8 @@ impl<'a> Verifier<'a> {
 
     /// Checks if all packages in storage also exist in the register.
     /// Returns a register consistency issue or None if there are packages missing from the register.
-    fn check_register_consistency(&self, register: &PackageRegister) -> Result<Option<Issue>> {
-        let package_directory = self.config.prefix_directory.join("packages");
+    fn check_register_consistency(&self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+        let package_directory = config.prefix_directory.join("packages");
         let mut missing = Vec::new();
         for file_package in fs::read_dir(package_directory)? {
             let file_package = file_package?;
@@ -410,8 +467,8 @@ impl<'a> Verifier<'a> {
 
     /// Checks if the packit group exists if multiuser mode is enabled in the config.
     /// Returns the issue if the group does not exist, None otherwise.
-    fn check_packit_group(&self) -> Option<Issue> {
-        if !self.config.multiuser {
+    fn check_packit_group(&self, config: &Config) -> Option<Issue> {
+        if !config.multiuser {
             return None; // We don't need the packit group if multiuser mode is not enabled
         }
 

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, str::FromStr};
+use std::{fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::logging::{error, warning},
@@ -22,11 +22,13 @@ enum Check {
     DependencyTree,
     Alterations,
     PackitGroup,
+    EmptyPackageDirectory,
 }
 
 /// Defines the correct order to do verifier checks.
 const VERIFY_ORDER: &[Check] = &[
     Check::PackitGroup,
+    Check::EmptyPackageDirectory,
     Check::StorageConsistency,
     Check::RegisterConsistency,
     Check::Alterations,
@@ -64,6 +66,7 @@ impl<'a> Verifier<'a> {
 
             let issue = match check {
                 Check::StorageConsistency => self.check_storage_consistency(register)?,
+                Check::EmptyPackageDirectory => self.check_empty_packages(register)?,
                 Check::RegisterConsistency => self.check_register_consistency(register)?,
                 Check::DependencyTree => self.check_dependency_tree(register),
                 Check::Alterations => {
@@ -96,6 +99,8 @@ impl<'a> Verifier<'a> {
             let issue = match check {
                 Check::StorageConsistency if self.package_storage_is_consistent(package_id)? => continue,
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
+                Check::EmptyPackageDirectory if !self.check_empty_package(package_id)? => continue,
+                Check::EmptyPackageDirectory => Issue::EmptyPackageDirectory(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
                 Check::RegisterConsistency => Issue::InconsistentRegister(vec![package_id.clone()]),
                 Check::DependencyTree => {
@@ -234,6 +239,50 @@ impl<'a> Verifier<'a> {
         }
 
         Ok(false)
+    }
+
+    /// Checks for packages with an empty package directory.
+    /// Returns None if all packages have a non-empty package directory, an `Issue::EmptyPackageDirectory` otherwise.
+    fn check_empty_packages(&self, register: &PackageRegister) -> Result<Option<Issue>> {
+        let mut empty_packages = Vec::new();
+        for package in register.iterate_all() {
+            if self.check_empty_package(&package.package_id)? {
+                empty_packages.push(package.package_id.clone());
+            }
+        }
+
+        if empty_packages.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Issue::EmptyPackageDirectory(empty_packages)))
+    }
+
+    /// Checks for a specific package if its package directory is empty.
+    /// Returns true if it's empty, false if not.
+    fn check_empty_package(&self, package_id: &PackageId) -> Result<bool> {
+        dbg!("HERE");
+        let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
+        dbg!(&installed_directory);
+        self.directory_is_empty(&installed_directory)
+    }
+
+    /// Checks recursively if a directory is empty (contains nothing but empty directories).
+    /// Returns true if empty, false if not.
+    fn directory_is_empty(&self, directory: &PathBuf) -> Result<bool> {
+        for package in directory.read_dir()? {
+            let package = package?;
+
+            if !package.path().is_dir() {
+                return Ok(false);
+            }
+
+            if !self.directory_is_empty(&package.path())? {
+                return Ok(false);
+            }
+        }
+
+        Ok(true)
     }
 
     /// Checks if all packages in storage also exist in the register.

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,5 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
+use std::{
+    collections::HashSet,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use crate::{
     cli::display::logging::{debug, warning},
@@ -48,9 +53,9 @@ impl Verifier {
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
                 self.current_intial_check = Check::get_initial_checks().len();
-                return Ok(None);
+                Ok(None)
             },
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         }
     }
 
@@ -69,9 +74,9 @@ impl Verifier {
 
             let issue = match check {
                 Check::Permissions => self.check_permissions()?,
-                Check::ConfigExistance => self.check_config_existance()?,
+                Check::ConfigExistence => self.check_config_existence()?,
                 Check::ConfigSyntax => self.check_config_syntax()?,
-                Check::RegisterExistance => self.check_register_existance()?,
+                Check::RegisterExistence => self.check_register_existence()?,
                 Check::RegisterSyntax => self.check_register_syntax()?,
 
                 // Make sure that the check is not an initial check
@@ -102,9 +107,9 @@ impl Verifier {
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
                 self.current_general_check = Check::get_general_checks().len();
-                return Ok(None);
+                Ok(None)
             },
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         }
     }
 
@@ -152,9 +157,9 @@ impl Verifier {
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
                 self.current_package_check = Check::get_package_checks().len();
-                return Ok(None);
+                Ok(None)
             },
-            Err(e) => return Err(e),
+            Err(e) => Err(e),
         }
     }
 
@@ -172,18 +177,18 @@ impl Verifier {
             self.current_package_check += 1;
 
             let issue = match check {
-                Check::PackageExistance if self.check_package_existance(package_id, register, config)? => continue,
-                Check::PackageExistance => Issue::NotFound(package_id.clone()),
-                Check::StorageConsistency if self.package_storage_is_consistent(package_id, config)? => continue,
-                Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
-                Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
-                Check::RegisterConsistency => Issue::InconsistentRegister(HashSet::from([package_id.clone()])),
-                Check::DependencyTree => match self.check_package_dependency_tree(package_id, register) {
+                Check::PackageExistence if self.check_package_existence(package_id, register, config)? => continue,
+                Check::PackageExistence => Issue::NotFound(package_id.clone()),
+                Check::PackageStorageConsistency if self.package_storage_is_consistent(package_id, config)? => continue,
+                Check::PackageStorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
+                Check::PackageRegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
+                Check::PackageRegisterConsistency => Issue::InconsistentRegister(HashSet::from([package_id.clone()])),
+                Check::PackageDependencyTree => match self.check_package_dependency_tree(package_id, register) {
                     Some(issue) => issue,
                     None => continue,
                 },
-                Check::Alterations if !self.check_package_alterations(package_id, register, config)? => continue,
-                Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
+                Check::PackageAlterations if !self.check_package_alterations(package_id, register, config)? => continue,
+                Check::PackageAlterations => Issue::AlteredPackage(vec![package_id.clone()]),
 
                 // Make sure that the check is not a package specific check
                 _ if Check::get_package_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
@@ -261,8 +266,8 @@ impl Verifier {
     /// Checks if the Config.toml exists.
     /// Returns `None` if the config exists or an `Issue::MissingConfig` otherwise.
     /// Could return an IO error.
-    fn check_config_existance(&self) -> Result<Option<Issue>> {
-        if fs::exists(&Config::get_default_path())? {
+    fn check_config_existence(&self) -> Result<Option<Issue>> {
+        if fs::exists(Config::get_default_path())? {
             return Ok(None);
         }
 
@@ -281,7 +286,7 @@ impl Verifier {
 
     /// Checks if the Installed.toml exists.
     /// Returns `None` if the register exists or an `Issue::MissingRegister` otherwise.
-    fn check_register_existance(&self) -> Result<Option<Issue>> {
+    fn check_register_existence(&self) -> Result<Option<Issue>> {
         let config = Config::from(&Config::get_default_path())?;
         let register_directory = &PackageRegister::get_default_path(&config);
         if fs::exists(register_directory)? {
@@ -379,7 +384,7 @@ impl Verifier {
     /// Checks if a package exists in the register or in storage.
     /// Returns true if the package exists, false if not.
     /// Could return an IO error.
-    fn check_package_existance(&self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<bool> {
+    fn check_package_existence(&self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<bool> {
         let installed_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
         if register.get_package_version(package_id).is_none() && !fs::exists(installed_directory)? {
             return Ok(false);
@@ -420,7 +425,7 @@ impl Verifier {
 
     /// Checks recursively if a directory is empty (contains nothing but empty directories).
     /// Returns true if empty, false if not.
-    fn directory_is_empty(&self, directory: &PathBuf) -> Result<bool> {
+    fn directory_is_empty(&self, directory: &Path) -> Result<bool> {
         for package in directory.read_dir()? {
             let package = package?;
 
@@ -490,7 +495,7 @@ impl Verifier {
             return None;
         }
 
-        return Some(Issue::BrokenTree(packages));
+        Some(Issue::BrokenTree(packages))
     }
 
     /// Checks the completeness of the dependency tree from a specific package.
@@ -606,7 +611,7 @@ impl Verifier {
     /// Returns the new value of current_intial_check.
     pub fn reverse_initial_check(&mut self) -> usize {
         if self.current_intial_check > 0 {
-        self.current_intial_check -= 1;
+            self.current_intial_check -= 1;
         }
 
         self.current_intial_check
@@ -616,7 +621,7 @@ impl Verifier {
     /// Returns the new value of current_general_check.
     pub fn reverse_general_check(&mut self) -> usize {
         if self.current_general_check > 0 {
-        self.current_general_check -= 1;
+            self.current_general_check -= 1;
         }
 
         self.current_general_check

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -6,7 +6,10 @@ use crate::{
     config::{Config, Repository},
     installer::types::{PackageId, PackageName, Version},
     packager,
-    platforms::{Target, permissions::packit_group_exists},
+    platforms::{
+        DEFAULT_PREFIX, Target,
+        permissions::{is_writable, packit_group_exists},
+    },
     repositories::{provider, types::Checksum},
     storage::package_register::PackageRegister,
     verifier::{
@@ -64,6 +67,7 @@ impl Verifier {
             self.current_intial_check += 1;
 
             let issue = match check {
+                Check::Permissions => self.check_permissions()?,
                 Check::ConfigExistance => self.check_config_existance()?,
                 Check::ConfigSyntax => self.check_config_syntax()?,
 
@@ -211,6 +215,44 @@ impl Verifier {
         }
 
         Ok(Some(Issue::AlteredPackage(altered)))
+    }
+
+    /// Checks the permissions of the prefix directory and all its sub directories.
+    /// If the config can be used it will use the prefix directory specified there,
+    /// otherwise the default prefix directory is checked.
+    fn check_permissions(&self) -> Result<Option<Issue>> {
+        let prefix_directory = match Config::from(&Config::get_default_path()) {
+            Ok(config) => config.prefix_directory,
+            Err(_) => DEFAULT_PREFIX.into(),
+        };
+
+        let unwritable = self.check_permissions_impl(&prefix_directory)?;
+        if unwritable.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Issue::IncorrectPermissions(unwritable.into_iter().collect())))
+    }
+
+    /// Recursively checks if all files in directory are writable.
+    /// Returns all directories which are not writable (could be empty).
+    fn check_permissions_impl(&self, directory: &PathBuf) -> Result<Vec<PathBuf>> {
+        let mut unwritable = Vec::new();
+        if !is_writable(directory)? {
+            unwritable.push(directory.clone());
+        }
+
+        if !directory.is_dir() {
+            return Ok(unwritable);
+        }
+
+        // Recurse
+        for sub_directory in fs::read_dir(directory)? {
+            let sub_directory = sub_directory?;
+            unwritable.extend(self.check_permissions_impl(&sub_directory.path())?);
+        }
+
+        Ok(unwritable)
     }
 
     /// Checks if the config exists.

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::logging::{debug, warning},
@@ -15,31 +15,103 @@ use crate::{
     },
 };
 
-/// Represents a specific check.
+#[derive(Debug, PartialEq, Eq, Hash)]
 enum Check {
+    // Initial checks (checks which verify methods which the verifier uses internally)
+    ConfigExistance,
+
+    // General package checks
     StorageConsistency,
     RegisterConsistency,
     DependencyTree,
     Alterations,
     PackitGroup,
+
+    // Checks which are specific to a package
     PackageExistance,
-    ConfigExistance,
+    PackageStorageConsistancy,
+    PackageRegisterConsistency,
+    PackageDependencyTree,
+    PackageAlterations,
 }
 
-/// Defines the correct order to do verifier checks.
-const VERIFY_ORDER: &[Check] = &[
-    Check::ConfigExistance,     // This is one of the initial checks, everything needs the config to work
-    Check::PackitGroup,         // Permission related check should happen before check which require permissions
-    Check::PackageExistance,    // Checked before storage and register consistency, because they assume a specified package exists somewhere
-    Check::StorageConsistency,  // Storage consistency must be checked before assuming consistency (in alteration check for example)
-    Check::RegisterConsistency, // Register consistency must be checked before assuming consistency (in alteration check for example)
-    Check::Alterations,         // Alteration check doesn't HAVE to happen before the dependency check
-    Check::DependencyTree,      // This check happens last, assumes most things work already
-];
+impl Check {
+    /// Gets the dependencies of a check (the checks which should happen before the given check).
+    fn get_dependencies(&self) -> &[Self] {
+        match self {
+            // Initial checks
+            Self::ConfigExistance => &[],
+
+            // General checks
+            Self::PackitGroup => &[],
+            Self::StorageConsistency => &[Self::PackitGroup],
+            Self::RegisterConsistency => &[Self::PackitGroup],
+            Self::DependencyTree => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
+            Self::Alterations => &[Self::PackitGroup, Self::StorageConsistency, Self::RegisterConsistency],
+
+            // Package specific checks
+            Self::PackageExistance => &[],
+            Self::PackageStorageConsistancy => &[Self::PackageExistance],
+            Self::PackageRegisterConsistency => &[Self::PackageExistance],
+            Self::PackageDependencyTree => &[Self::PackageExistance, Self::PackageStorageConsistancy, Self::PackageDependencyTree],
+            Self::PackageAlterations => &[Self::PackageExistance, Self::PackageStorageConsistancy, Self::PackageDependencyTree],
+        }
+    }
+
+    /// Gets all intial checks.
+    fn get_initial_checks<'a>() -> &'a [Self] {
+        &[Self::ConfigExistance]
+    }
+
+    /// Gets all general checks.
+    fn get_general_checks<'a>() -> &'a [Self] {
+        &[
+            Self::StorageConsistency,
+            Self::RegisterConsistency,
+            Self::DependencyTree,
+            Self::Alterations,
+            Self::PackitGroup,
+        ]
+    }
+
+    /// Gets all package specific checks.
+    fn get_package_checks<'a>() -> &'a [Self] {
+        &[
+            Self::PackageExistance,
+            Self::PackageStorageConsistancy,
+            Self::PackageRegisterConsistency,
+            Self::PackageDependencyTree,
+            Self::PackageAlterations,
+        ]
+    }
+
+    /// Gets the checks in the correct order based on the 'check dependency tree'.
+    /// Returns a flattened 'check dependency tree'
+    fn get_ordered_checks<'a>(checks: &'a [Self]) -> Vec<&'a Self> {
+        let mut ordered = Vec::new();
+        for check in checks {
+            ordered.extend(Self::get_ordered_checks(check.get_dependencies()));
+            ordered.push(check);
+        }
+
+        let mut seen = HashSet::new();
+        let mut unique_ordered = Vec::new();
+        for check in ordered {
+            if !seen.contains(check) {
+                unique_ordered.push(check);
+                seen.insert(check);
+            }
+        }
+
+        unique_ordered
+    }
+}
 
 /// Verifier that scans the Packit environment for issues.
 pub struct Verifier {
-    current_issue: usize,
+    current_intial_check: usize,
+    current_general_check: usize,
+    current_package_check: usize,
     issues_found: bool,
 }
 
@@ -47,53 +119,54 @@ impl Verifier {
     /// Creates a new verifier.
     pub fn new() -> Self {
         Self {
-            current_issue: 0,
+            current_intial_check: 0,
+            current_general_check: 0,
+            current_package_check: 0,
             issues_found: false,
         }
     }
 
+    /// A wrapper around the `next_initial_issue_impl` method.
+    /// Returns the next issue if it exists.
+    /// Returns an error if an error is returned and no issues have been found yet.
     pub fn next_initial_issue(&mut self) -> Result<Option<Issue>> {
         match self.next_initial_issue_impl() {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
-                self.current_issue = VERIFY_ORDER.len();
+                self.current_intial_check = Check::get_initial_checks().len();
                 return Ok(None);
             },
             Err(e) => return Err(e),
         }
     }
 
+    /// Gets the next initial issue.
+    /// Returns None if there are no issues to return.
     fn next_initial_issue_impl(&mut self) -> Result<Option<Issue>> {
         loop {
-            let check = match VERIFY_ORDER.get(self.current_issue) {
+            let ordered_checks = Check::get_ordered_checks(Check::get_initial_checks());
+            let check = match ordered_checks.get(self.current_intial_check) {
                 Some(check) => check,
                 None => return Ok(None),
             };
 
             // Increase current issue
-            self.current_issue += 1;
+            self.current_intial_check += 1;
 
             let issue = match check {
                 Check::ConfigExistance => self.check_config_existance()?,
 
-                // Continue if the check is not an initial check. Explicitly state them, because it's easy to forgot.
-                Check::StorageConsistency
-                | Check::RegisterConsistency
-                | Check::DependencyTree
-                | Check::Alterations
-                | Check::PackitGroup
-                | Check::PackageExistance => continue,
+                // Make sure that the check is not an initial check
+                _ if Check::get_initial_checks().contains(check) => panic!("TODO"),
+
+                // Continue if the check is not an initial check
+                _ => continue,
             };
 
             if let Some(issue) = issue {
                 self.issues_found = true;
                 return Ok(Some(issue));
-            }
-
-            // TODO: Temporary ugly check
-            if matches!(check, Check::ConfigExistance) {
-                return Ok(None);
             }
         }
     }
@@ -106,24 +179,25 @@ impl Verifier {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
-                self.current_issue = VERIFY_ORDER.len();
+                self.current_general_check = Check::get_general_checks().len();
                 return Ok(None);
             },
             Err(e) => return Err(e),
         }
     }
 
-    /// Gets the next issue in the order defined in VERIFY_ORDER.
-    /// Returns None if there are no more issues to return.
+    /// Gets the next general issue.
+    /// Returns None if there are no issues to return.
     fn next_issue_impl(&mut self, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         loop {
-            let check = match VERIFY_ORDER.get(self.current_issue) {
+            let ordered_checks = Check::get_ordered_checks(Check::get_general_checks());
+            let check = match ordered_checks.get(self.current_general_check) {
                 Some(check) => check,
                 None => return Ok(None),
             };
 
             // Increase current issue
-            self.current_issue += 1;
+            self.current_general_check += 1;
 
             let issue = match check {
                 Check::StorageConsistency => self.check_storage_consistency(register, config)?,
@@ -132,8 +206,11 @@ impl Verifier {
                 Check::Alterations => self.check_alterations(register, config)?,
                 Check::PackitGroup => self.check_packit_group(config),
 
-                // Continue if the check is package specific or is an initial check. Explicitly state them, because it's easy to forgot.
-                Check::PackageExistance | Check::ConfigExistance => continue,
+                // Make sure that the check is not a general check
+                _ if Check::get_general_checks().contains(check) => panic!("TODO"),
+
+                // Continue if the check is package specific or is an initial check
+                _ => continue,
             };
 
             if let Some(issue) = issue {
@@ -151,7 +228,7 @@ impl Verifier {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
                 debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
-                self.current_issue = VERIFY_ORDER.len();
+                self.current_package_check = Check::get_package_checks().len();
                 return Ok(None);
             },
             Err(e) => return Err(e),
@@ -162,13 +239,14 @@ impl Verifier {
     /// Returns None if there are no more issues to return.
     fn next_package_issue_impl(&mut self, package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         loop {
-            let check = match VERIFY_ORDER.get(self.current_issue) {
+            let ordered_checks = Check::get_ordered_checks(Check::get_package_checks());
+            let check = match ordered_checks.get(self.current_package_check) {
                 Some(check) => check,
                 None => return Ok(None),
             };
 
             // Increase current issue
-            self.current_issue += 1;
+            self.current_package_check += 1;
 
             let issue = match check {
                 Check::PackageExistance if self.check_package_existance(package_id, register, config)? => continue,
@@ -184,8 +262,11 @@ impl Verifier {
                 Check::Alterations if !self.check_package_alterations(package_id, register, config)? => continue,
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
 
-                // Continue if the check is not package specific. Explicitly state them, because it's easy to forgot.
-                Check::PackitGroup | Check::ConfigExistance => continue,
+                // Make sure that the check is not a package specific check
+                _ if Check::get_package_checks().contains(check) => panic!("TODO"),
+
+                // Continue if the check is not package specific
+                _ => continue,
             };
 
             self.issues_found = true;

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -2,7 +2,7 @@
 use std::{fs, path::PathBuf, str::FromStr};
 
 use crate::{
-    cli::display::logging::{debug, error, warning},
+    cli::display::logging::{debug, warning},
     config::{Config, Repository},
     installer::types::{PackageId, PackageName, Version},
     packager,
@@ -52,9 +52,24 @@ impl<'a> Verifier<'a> {
         }
     }
 
+    /// A wrapper around the `next_package_issue_impl` method.
+    /// Returns the next issue if it exists.
+    /// Returns an error if an error is returned and no issues have been found yet.
+    pub fn next_issue(&mut self, register: &PackageRegister) -> Result<Option<Issue>> {
+        match self.next_issue_impl(register) {
+            Ok(issue) => Ok(issue),
+            Err(e) if self.issues_found => {
+                debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
+                self.current_issue = VERIFY_ORDER.len();
+                return Ok(None);
+            },
+            Err(e) => return Err(e),
+        }
+    }
+
     /// Gets the next issue in the order defined in VERIFY_ORDER.
     /// Returns None if there are no more issues to return.
-    pub fn next_issue(&mut self, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn next_issue_impl(&mut self, register: &PackageRegister) -> Result<Option<Issue>> {
         loop {
             let check = match VERIFY_ORDER.get(self.current_issue) {
                 Some(check) => check,
@@ -68,10 +83,7 @@ impl<'a> Verifier<'a> {
                 Check::StorageConsistency => self.check_storage_consistency(register)?,
                 Check::RegisterConsistency => self.check_register_consistency(register)?,
                 Check::DependencyTree => self.check_dependency_tree(register),
-                Check::Alterations => {
-                    warning!("This is an experimental check, issues from this check could be inaccurate.");
-                    self.check_alterations(register)?
-                },
+                Check::Alterations => self.check_alterations(register)?,
                 Check::PackitGroup => self.check_packit_group(),
 
                 // Continue if the check is package specific. Explicitly state them, because it's easy to forgot.
@@ -85,10 +97,24 @@ impl<'a> Verifier<'a> {
         }
     }
 
+    /// A wrapper around the `next_package_issue_impl` method.
+    /// Returns the next package issue if it exists.
+    /// Returns an error if an error is returned and no issues have been found yet.
+    pub fn next_package_issue(&mut self, package_id: &PackageId, register: &PackageRegister) -> Result<Option<Issue>> {
+        match self.next_package_issue_impl(package_id, register) {
+            Ok(issue) => Ok(issue),
+            Err(e) if self.issues_found => {
+                debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
+                self.current_issue = VERIFY_ORDER.len();
+                return Ok(None);
+            },
+            Err(e) => return Err(e),
+        }
+    }
+
     /// Gets the next issue for a specific package in the order defined in VERIFY_ORDER.
     /// Returns None if there are no more issues to return.
-    /// Note that this method assumes that the package exists.
-    pub fn next_package_issue(&mut self, package_id: &PackageId, register: &PackageRegister) -> Result<Option<Issue>> {
+    fn next_package_issue_impl(&mut self, package_id: &PackageId, register: &PackageRegister) -> Result<Option<Issue>> {
         loop {
             let check = match VERIFY_ORDER.get(self.current_issue) {
                 Some(check) => check,
@@ -124,6 +150,8 @@ impl<'a> Verifier<'a> {
     /// Checks for alterations in all packages using a checksum which is compared to the checksum from the pre-build.
     /// Returns an alteration issue or None if no packages can be found that are altered.
     fn check_alterations(&self, register: &PackageRegister) -> Result<Option<Issue>> {
+        warning!("This is an experimental check, issues from this check could be inaccurate.");
+
         // Check issue for all installed packages
         let mut altered = Vec::new();
         for package in register.iterate_all() {
@@ -144,7 +172,7 @@ impl<'a> Verifier<'a> {
     fn check_package_alterations(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
         // Get the installed package from the register
         let Some(package_version) = register.get_package_version(package_id) else {
-            error!(msg: "Cannot retrieve package '{package_id}' from register for package alterations check");
+            warning!("Cannot retrieve package '{package_id}' from register for package alterations check, skipping check");
             return Ok(false);
         };
 
@@ -155,14 +183,15 @@ impl<'a> Verifier<'a> {
             let repository = Repository::new(&package_version.source_repository_url, &package_version.source_repository_provider);
 
             let Some(provider) = provider::create_metadata_provider(&repository) else {
-                error!(msg: "Cannot create metadata provider for '{package_id}'.");
+                warning!("Cannot create metadata provider for '{package_id}', skipping check");
                 return Ok(false);
             };
 
             let repo_metadata = match provider.read_repository_metadata() {
                 Ok(meta) => meta,
                 Err(e) => {
-                    error!(e, "Cannot retrieve repository metadata for '{package_id}'.");
+                    warning!("Cannot retrieve repository metadata for '{package_id}', skipping check");
+                    debug!(err: e, "Retrieving repository metadata failed");
                     return Ok(false);
                 },
             };
@@ -173,7 +202,7 @@ impl<'a> Verifier<'a> {
 
         let Some(prebuilds_url) = &prebuilds_url else {
             warning!(
-                "Cannot perform alterations check for package '{package_id}', because no prebuild repository for the package can be found"
+                "Cannot perform alterations check for package '{package_id}', because no prebuild repository for the package can be found, skipping check"
             );
             return Ok(false);
         };
@@ -181,7 +210,7 @@ impl<'a> Verifier<'a> {
         let provider = match provider::create_prebuild_provider_from_url(prebuilds_url, prebuilds_provider) {
             Some(provider) => provider,
             None => {
-                error!(msg: "Cannot create prebuild provider for '{package_id}'.");
+                warning!("Cannot create prebuild provider for '{package_id}', skipping check");
                 return Ok(false);
             },
         };
@@ -190,14 +219,14 @@ impl<'a> Verifier<'a> {
         let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &Target::current()) {
             Ok(Some(checksum)) => checksum,
             Ok(None) => {
-                warning!("Cannot perform alterations check for package '{package_id}', because no checksum of the prebuild can be found");
+                warning!(
+                    "Cannot perform alterations check for package '{package_id}', because no checksum of the prebuild can be found, skipping check"
+                );
                 return Ok(false);
             },
             Err(e) => {
-                error!(
-                    e,
-                    "Cannot perform alterations check for package '{package_id}', because checksum cannot be read"
-                );
+                warning!("Cannot perform alterations check for package '{package_id}', because checksum cannot be read, skipping check");
+                debug!(err: e, "Failed to read prebuild checksum");
                 return Ok(false);
             },
         };

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -2,7 +2,7 @@
 use std::{fs, path::PathBuf, str::FromStr};
 
 use crate::{
-    cli::display::logging::{error, warning},
+    cli::display::logging::{debug, error, warning},
     config::{Config, Repository},
     installer::types::{PackageId, PackageName, Version},
     packager,
@@ -22,11 +22,13 @@ enum Check {
     DependencyTree,
     Alterations,
     PackitGroup,
+    PackageExistance,
 }
 
 /// Defines the correct order to do verifier checks.
 const VERIFY_ORDER: &[Check] = &[
     Check::PackitGroup,         // Permission related check should happen before check which require permissions
+    Check::PackageExistance,    // Checked before storage and register consistency, because they assume a specified package exists somewhere
     Check::StorageConsistency,  // Storage consistency must be checked before assuming consistency (in alteration check for example)
     Check::RegisterConsistency, // Register consistency must be checked before assuming consistency (in alteration check for example)
     Check::Alterations,         // Alteration check doesn't HAVE to happen before the dependency check
@@ -71,6 +73,9 @@ impl<'a> Verifier<'a> {
                     self.check_alterations(register)?
                 },
                 Check::PackitGroup => self.check_packit_group(),
+
+                // Continue if the check is package specific. Explicitly state them, because it's easy to forgot.
+                Check::PackageExistance => continue,
             };
 
             if let Some(issue) = issue {
@@ -94,6 +99,8 @@ impl<'a> Verifier<'a> {
             self.current_issue += 1;
 
             let issue = match check {
+                Check::PackageExistance if self.check_package_existance(package_id, register)? => continue,
+                Check::PackageExistance => Issue::NotFound(package_id.clone()),
                 Check::StorageConsistency if self.package_storage_is_consistent(package_id)? => continue,
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
@@ -108,7 +115,9 @@ impl<'a> Verifier<'a> {
                 },
                 Check::Alterations if !self.check_package_alterations(package_id, register)? => continue,
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
-                _ => continue, // Continue if the check if not package specific
+
+                // Continue if the check is not package specific. Explicitly state them, because it's easy to forgot.
+                Check::PackitGroup => continue,
             };
 
             self.issues_found = true;
@@ -202,6 +211,18 @@ impl<'a> Verifier<'a> {
         let checksum = Checksum::from_bytes(&compressed);
 
         Ok(checksum != correct_checksum)
+    }
+
+    /// Checks if a package exists in the register or in storage.
+    /// Returns true if the package exists, false if not.
+    /// Could return an IO error.
+    fn check_package_existance(&self, package_id: &PackageId, register: &PackageRegister) -> Result<bool> {
+        let installed_directory = self.config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
+        if register.get_package_version(package_id).is_none() && !fs::exists(installed_directory)? {
+            return Ok(false);
+        }
+
+        Ok(true)
     }
 
     /// Checks if all packages in the register also exist in the package storage in the prefix directory.
@@ -321,11 +342,12 @@ impl<'a> Verifier<'a> {
 
     /// Checks the completeness of the dependency tree from a specific package.
     /// Returns a list of missing packages, can be empty if there are no packages missing from the tree.
+    /// TODO: Refactor to have a separate method for recursion, so it can return an Issue like the other methods.
     fn check_package_dependency_tree(&self, package_id: &PackageId, register: &PackageRegister) -> Vec<(PackageId, PackageId)> {
         let package = match register.get_package_version(package_id) {
             Some(package) => package,
             None => {
-                warning!("Parent node '{package_id}' doesn't exist, while checking dependency tree.");
+                debug!("Parent node '{package_id}' doesn't exist, while checking dependency tree.");
                 return Vec::new();
             },
         };

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::logging::{debug, warning},
@@ -120,6 +120,7 @@ impl Verifier {
                 Check::DependencyTree => self.check_dependency_tree(register),
                 Check::Alterations => self.check_alterations(register, config)?,
                 Check::PackitGroup => self.check_packit_group(config),
+                Check::StrayDirectory => self.check_stray_directories(config)?,
 
                 // Make sure that the check is not a general check
                 _ if Check::get_general_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
@@ -480,6 +481,73 @@ impl Verifier {
         }
 
         None
+    }
+
+    /// Checks for directories which shouldn't be in the prefix/packages directory.
+    /// This wil be any directory which is empty or doesn't have `<package-name>/<version>`.
+    /// Returns None if no stray directories are found, `Issue::StrayDirectories` otherwise.
+    fn check_stray_directories(&self, config: &Config) -> Result<Option<Issue>> {
+        let package_directory = config.prefix_directory.join("packages");
+        let mut strays = HashSet::new();
+        for directory in fs::read_dir(package_directory)? {
+            let directory = directory?;
+            if !directory.path().is_dir() {
+                strays.insert(directory.path());
+                continue;
+            }
+
+            // Try to get the package name
+            let package_name = directory.file_name();
+            let Some(package_name) = package_name.to_str() else {
+                strays.insert(directory.path());
+                continue;
+            };
+
+            // Try to create a `PackageName`
+            if PackageName::from_str(package_name).is_err() {
+                strays.insert(directory.path());
+                continue;
+            }
+
+            // Check if the name directory is empty
+            if self.directory_is_empty(&directory.path())? {
+                strays.insert(directory.path());
+                continue;
+            }
+
+            for version_directory in fs::read_dir(directory.path())? {
+                let version_directory = version_directory?;
+                if !version_directory.path().is_dir() {
+                    strays.insert(version_directory.path());
+                    continue;
+                }
+
+                // Try to get the version name
+                let version_name = version_directory.file_name();
+                let Some(version_str) = version_name.to_str() else {
+                    strays.insert(version_directory.path());
+                    continue;
+                };
+
+                // Try to create a `Version`
+                if Version::from_str(version_str).is_err() {
+                    strays.insert(version_directory.path());
+                    continue;
+                };
+
+                // Check if the version directory is empty
+                if self.directory_is_empty(&version_directory.path())? {
+                    strays.insert(version_directory.path());
+                    continue;
+                }
+            }
+        }
+
+        if strays.is_empty() {
+            return Ok(None);
+        }
+
+        Ok(Some(Issue::StrayDirectories(strays)))
     }
 
     /// Get the issues found states.

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -71,6 +71,8 @@ impl Verifier {
                 Check::Permissions => self.check_permissions()?,
                 Check::ConfigExistance => self.check_config_existance()?,
                 Check::ConfigSyntax => self.check_config_syntax()?,
+                Check::RegisterExistance => self.check_register_existance()?,
+                Check::RegisterSyntax => self.check_register_syntax()?,
 
                 // Make sure that the check is not an initial check
                 _ if Check::get_initial_checks().contains(check) => return Err(VerifierError::UnimplementedCheckError),
@@ -256,7 +258,7 @@ impl Verifier {
         Ok(unwritable)
     }
 
-    /// Checks if the config exists.
+    /// Checks if the Config.toml exists.
     /// Returns `None` if the config exists or an `Issue::MissingConfig` otherwise.
     /// Could return an IO error.
     fn check_config_existance(&self) -> Result<Option<Issue>> {
@@ -267,13 +269,35 @@ impl Verifier {
         Ok(Some(Issue::MissingConfig))
     }
 
-    /// Checks if the config syntax is valid.
+    /// Checks if the Config.toml syntax is valid.
     /// Returns `None` if the config syntax is valid or an `Issue::MissingConfig` otherwise.
     /// Could return an IO error.
     fn check_config_syntax(&self) -> Result<Option<Issue>> {
         match Config::from(&Config::get_default_path()) {
             Ok(_) => Ok(None),
             Err(_) => Ok(Some(Issue::MissingConfig)),
+        }
+    }
+
+    /// Checks if the Installed.toml exists.
+    /// Returns `None` if the register exists or an `Issue::MissingRegister` otherwise.
+    fn check_register_existance(&self) -> Result<Option<Issue>> {
+        let config = Config::from(&Config::get_default_path())?;
+        let register_directory = &PackageRegister::get_default_path(&config);
+        if fs::exists(register_directory)? {
+            return Ok(None);
+        }
+
+        Ok(Some(Issue::MissingRegister))
+    }
+
+    /// Checks if the Installed.toml syntax is valid.
+    /// Returns `None` if the register syntax is valid or an `Issue::MissingRegister` otherwise.
+    fn check_register_syntax(&self) -> Result<Option<Issue>> {
+        let config = Config::from(&Config::get_default_path())?;
+        match PackageRegister::from(&PackageRegister::get_default_path(&config)) {
+            Ok(_) => Ok(None),
+            Err(_) => Ok(Some(Issue::MissingRegister)),
         }
     }
 

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -105,13 +105,9 @@ impl<'a> Verifier<'a> {
                 Check::StorageConsistency => Issue::InconsistentStorage(vec![package_id.clone()]),
                 Check::RegisterConsistency if self.register_package_is_consistent(package_id, register) => continue,
                 Check::RegisterConsistency => Issue::InconsistentRegister(vec![package_id.clone()]),
-                Check::DependencyTree => {
-                    let missing_dependencies = self.check_package_dependency_tree(package_id, register);
-                    if missing_dependencies.is_empty() {
-                        continue;
-                    }
-
-                    Issue::BrokenTree(missing_dependencies)
+                Check::DependencyTree => match self.check_package_dependency_tree(package_id, register) {
+                    Some(issue) => issue,
+                    None => continue,
                 },
                 Check::Alterations if !self.check_package_alterations(package_id, register)? => continue,
                 Check::Alterations => Issue::AlteredPackage(vec![package_id.clone()]),
@@ -330,7 +326,7 @@ impl<'a> Verifier<'a> {
     fn check_dependency_tree(&self, register: &PackageRegister) -> Option<Issue> {
         let mut all_missing = Vec::new();
         for package in register.iterate_all() {
-            all_missing.extend(self.check_package_dependency_tree(&package.package_id, register));
+            all_missing.extend(self.check_package_dependency_tree_impl(&package.package_id, register));
         }
 
         if all_missing.is_empty() {
@@ -340,10 +336,20 @@ impl<'a> Verifier<'a> {
         Some(Issue::BrokenTree(all_missing))
     }
 
+    /// Wraps around the `check_package_dependency_tree_impl` method to convert it into an `Option<Issue>`.
+    /// Returns an `Issue::BrokenTree` if missing packages are found, None if not packages are missing.
+    fn check_package_dependency_tree(&self, package_id: &PackageId, register: &PackageRegister) -> Option<Issue> {
+        let packages = self.check_package_dependency_tree_impl(package_id, register);
+        if packages.is_empty() {
+            return None;
+        }
+
+        return Some(Issue::BrokenTree(packages));
+    }
+
     /// Checks the completeness of the dependency tree from a specific package.
     /// Returns a list of missing packages, can be empty if there are no packages missing from the tree.
-    /// TODO: Refactor to have a separate method for recursion, so it can return an Issue like the other methods.
-    fn check_package_dependency_tree(&self, package_id: &PackageId, register: &PackageRegister) -> Vec<(PackageId, PackageId)> {
+    fn check_package_dependency_tree_impl(&self, package_id: &PackageId, register: &PackageRegister) -> Vec<(PackageId, PackageId)> {
         let package = match register.get_package_version(package_id) {
             Some(package) => package,
             None => {
@@ -360,7 +366,7 @@ impl<'a> Verifier<'a> {
             }
 
             // Recursively check if all the dependencies are installed
-            missing.extend(self.check_package_dependency_tree(dependency, register));
+            missing.extend(self.check_package_dependency_tree_impl(dependency, register));
         }
 
         missing


### PR DESCRIPTION
- The check and fix command now except multiple package parameters.
- Add support for 'check dependencies'.
- The inconsistent register fix doesn't require a re-install anymore.
- Add check after fix (re-run check to make sure the fix worked).
- Add checks and fixes for: stray directories, empty directories, package existence, correct permissions, missing Config.toml and missing Installed.toml.