### PR TITLE
Add skip update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - The inconsistent register fix doesn't require a re-install anymore.
     - Add check after fix (re-run check to make sure the fix worked).
     - Add checks and fixes for: stray directories, empty directories, package existence, correct permissions, missing Config.toml and missing Installed.toml.
+- Skip uninstall option when update is not possible because of dependents which need the older version.
 
 ### Changes
 - The build system now includes a new `build-install` xtask to create a full Packit build in a `bin` directory structure.

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -87,7 +87,7 @@ impl HandleCommand for UpdateArgs {
             exit(1);
         }
 
-        let options = InstallerOptions::default().skip_active(true).skip_symlinking(true);
+        let options = InstallerOptions::default();
         let mut installer = Installer::new(&config, &mut register, &manager, options);
 
         let new_package_id = installer.update(&self.optional_id, new_version).unwrap_or_exit(1);

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -730,9 +730,15 @@ impl<'a> Installer<'a> {
             };
 
             if !dependency.satisfied(&new_package_id.name, new_version) {
-                return Err(InstallerError::SatisfyError {
-                    new_version: new_version.clone(),
-                });
+                let question = "Could not update, because the current version has dependents. Do you wish to install the newer version and set it as the active version?";
+                if ask_user(question, QuestionResponse::Yes)?.is_no() {
+                    return Err(InstallerError::SatisfyError {
+                        new_version: new_version.clone(),
+                    });
+                }
+
+                // Install the new beside the old package
+                return self.install(&OptionalPackageId::from(new_package_id));
             }
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -715,8 +715,8 @@ impl<'a> Installer<'a> {
         }
 
         // Check if the new version still satisfies all dependents
-        let mut skip_update = false;
         let mut dependents = HashSet::new();
+        let mut unsatisfied_dependents = HashSet::new();
         for dependent in &old_package.dependents {
             let (repository_id, _) = self.repository_manager.read_package(&dependent.name)?;
             let package_version_meta = self.repository_manager.read_repo_package_version(&repository_id, dependent)?;
@@ -731,19 +731,22 @@ impl<'a> Installer<'a> {
                 },
             };
 
-            if !skip_update && !dependency.satisfied(&new_package_id.name, new_version) {
-                let question = "Could not update, because the current version has dependents. Do you wish to install the newer version as active version, but keep the older version as well?";
-                if ask_user(question, QuestionResponse::Yes)?.is_no() {
-                    return Err(InstallerError::SatisfyError {
-                        new_version: new_version.clone(),
-                    });
-                }
-
-                skip_update = true;
+            if dependency.satisfied(&new_package_id.name, new_version) {
+                dependents.insert(dependent.clone());
                 continue;
             }
 
-            dependents.insert(dependent.clone());
+            unsatisfied_dependents.insert(dependent.clone());
+            if unsatisfied_dependents.len() > 1 {
+                continue;
+            }
+
+            let question = "Could not update, because the current version has dependents. Do you wish to install the newer version as active version, but keep the older version as well?";
+            if ask_user(question, QuestionResponse::Yes)?.is_no() {
+                return Err(InstallerError::SatisfyError {
+                    new_version: new_version.clone(),
+                });
+            }
         }
 
         // Use the old package reference before another borrow from self.install
@@ -793,10 +796,10 @@ impl<'a> Installer<'a> {
         // Remove the old package dependents, because the old package is no longer a dependency
         // Note that this is necessary before doing an uninstall.
         let old_package = self.register.get_package_version_mut(&old_package_id).expect("Expected old package to still exist.");
-        old_package.dependents.clear();
+        old_package.dependents = unsatisfied_dependents;
 
         // Only uninstall the package if an update has been done
-        if !skip_update {
+        if old_package.dependents.is_empty() {
             self.uninstall(&old_package_id.into())?;
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -715,6 +715,8 @@ impl<'a> Installer<'a> {
         }
 
         // Check if the new version still satisfies all dependents
+        let mut skip_update = false;
+        let mut dependents = HashSet::new();
         for dependent in &old_package.dependents {
             let (repository_id, _) = self.repository_manager.read_package(&dependent.name)?;
             let package_version_meta = self.repository_manager.read_repo_package_version(&repository_id, dependent)?;
@@ -729,22 +731,23 @@ impl<'a> Installer<'a> {
                 },
             };
 
-            if !dependency.satisfied(&new_package_id.name, new_version) {
-                let question = "Could not update, because the current version has dependents. Do you wish to install the newer version and set it as the active version?";
+            if !skip_update && !dependency.satisfied(&new_package_id.name, new_version) {
+                let question = "Could not update, because the current version has dependents. Do you wish to install the newer version as active version, but keep the older version as well?";
                 if ask_user(question, QuestionResponse::Yes)?.is_no() {
                     return Err(InstallerError::SatisfyError {
                         new_version: new_version.clone(),
                     });
                 }
 
-                // Install the new beside the old package
-                return self.install(&OptionalPackageId::from(new_package_id));
+                skip_update = true;
+                continue;
             }
+
+            dependents.insert(dependent.clone());
         }
 
         // Use the old package reference before another borrow from self.install
         // Clone to avoid borrowing issues
-        let dependents = old_package.dependents.clone();
         let old_package_id = old_package.package_id.clone();
 
         // Install the newer packager first
@@ -792,8 +795,10 @@ impl<'a> Installer<'a> {
         let old_package = self.register.get_package_version_mut(&old_package_id).expect("Expected old package to still exist.");
         old_package.dependents.clear();
 
-        // Uninstall the package
-        self.uninstall(&old_package_id.into())?;
+        // Only uninstall the package if an update has been done
+        if !skip_update {
+            self.uninstall(&old_package_id.into())?;
+        }
 
         Ok(new_package_id)
     }


### PR DESCRIPTION
When an update cannot be done, because not all dependents of a package support the newer version. Ask the user if they want to install the newer version as active instead (keeping the older version).