### PR TITLE
Add init command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Add checks and fixes for: stray directories, empty directories, package existence, correct permissions, missing Config.toml and missing Installed.toml.
 - Skip uninstall option when update is not possible because of dependents which need the older version.
 - Add portable repositories, a generated repository containing only specific packages for use on airgapped systems.
+- Add the init command which initializes the Packit environment and files.
 
 ### Changes
 - The build system now includes a new `build-install` xtask to create a full Packit build in a `bin` directory structure.

--- a/README.md
+++ b/README.md
@@ -108,6 +108,9 @@ Sets the repositories rank in the config. Multiple `<REPOSITORY-ID>` can be give
 #### `pit config repositories add <ID> <URL> [PROVIDER]`
 Adds a new repository to the config. Also adds the new repository to the back of the repositories rank.
 
+#### `pit init [--prefix <PREFIX>]`
+Initializes the Packit environment by setting up all required files and directories. If the `--prefix` option is given, the given path is used as prefix, instead of the [default prefix](#prefix).
+
 
 ## Config
 All available fields in the config are listed below. The [`pit config`](#pit-config-show) command can also be used to change the config.

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -3,6 +3,7 @@ mod check;
 mod config;
 mod fix;
 mod info;
+mod init;
 mod install;
 mod link;
 mod list;
@@ -22,9 +23,9 @@ use clap::{Parser, Subcommand, builder::Styles};
 use crate::cli::display::logging::debug;
 use crate::cli::{
     commands::{
-        check::CheckArgs, config::ConfigArgs, fix::FixArgs, info::InfoArgs, install::InstallArgs, link::LinkArgs, list::ListArgs,
-        package::PackageArgs, search::SearchArgs, switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs, update::UpdateArgs,
-        util::UtilArgs,
+        check::CheckArgs, config::ConfigArgs, fix::FixArgs, info::InfoArgs, init::InitArgs, install::InstallArgs, link::LinkArgs,
+        list::ListArgs, package::PackageArgs, search::SearchArgs, switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs,
+        update::UpdateArgs, util::UtilArgs,
     },
     display::logging::error,
 };
@@ -75,6 +76,9 @@ enum Commands {
 
     /// Update an installed package
     Update(UpdateArgs),
+
+    /// Initializes the Packit installation
+    Init(InitArgs),
 
     /// Several utils for advanced users
     #[clap(subcommand)]
@@ -138,6 +142,7 @@ impl Cli {
             Commands::Package(args) => args,
             Commands::Info(args) => args,
             Commands::Update(args) => args,
+            Commands::Init(args) => args,
             Commands::Util(args) => args,
             Commands::Config(args) => args,
         };

--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -40,7 +40,7 @@ impl CheckArgs {
         }
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         while let Some(issue) = verifier.next_issue(&register, &config).unwrap_or_exit(1) {
@@ -59,7 +59,7 @@ impl CheckArgs {
     fn check_packages(&self) {
         let mut verifier = Verifier::new();
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         for package_id in &self.packages {

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -94,7 +94,7 @@ impl ConfigArgs {
             return;
         }
 
-        let register_dir = PackageRegister::get_default_path(&config.get_config());
+        let register_dir = PackageRegister::get_default_path(&config.get_config().prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit_msg("Cannot read package register", 1);
 
         // Check if there are installed packages
@@ -117,7 +117,7 @@ impl ConfigArgs {
             return;
         }
 
-        let register_dir = PackageRegister::get_default_path(&config.get_config());
+        let register_dir = PackageRegister::get_default_path(&config.get_config().prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit_msg("Cannot read package register", 1);
 
         // Check if there are installed packages

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -64,7 +64,7 @@ impl FixArgs {
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Retrieve and fix the issues one by one
@@ -105,7 +105,7 @@ impl FixArgs {
     fn fix_packages(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         for package_id in &self.packages {

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -29,7 +29,7 @@ pub struct InfoArgs {
 impl HandleCommand for InfoArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Get package information

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -28,6 +28,7 @@ use crate::{
 #[derive(Args, Debug)]
 pub struct InitArgs {
     /// The prefix to use
+    #[arg(long)]
     prefix: Option<PathBuf>,
 }
 

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,13 +1,21 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashSet, path::PathBuf, process::exit, str::FromStr};
+use std::{
+    collections::HashSet,
+    path::{self, Path, PathBuf},
+    process::exit,
+    str::FromStr,
+};
 
 use clap::Args;
 
 use crate::{
     cli::{commands::HandleCommand, display::logging::error},
     config::{Config, EditableConfig},
-    installer::types::{PackageId, PackageName, Version},
-    platforms::DEFAULT_PREFIX,
+    installer::{
+        Symlinker,
+        types::{PackageId, PackageName, Version},
+    },
+    platforms::{DEFAULT_CONFIG_DIR, DEFAULT_PREFIX, permissions},
     repositories::types::Licenses,
     storage::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     utils::{
@@ -25,6 +33,19 @@ pub struct InitArgs {
 
 impl HandleCommand for InitArgs {
     fn handle(&self) {
+        // Check if config directory exists
+        let config_dir = Path::new(DEFAULT_CONFIG_DIR);
+        if !config_dir.exists() {
+            error!(msg: "Packit cannot be initialized: the config directory at {DEFAULT_CONFIG_DIR} does not exist yet, please create it first");
+            exit(1);
+        }
+
+        // Check if config directory is writable
+        if !permissions::is_writable(&config_dir.to_path_buf()).unwrap_or_exit_msg("Unable to check if config directory is writable", 1) {
+            error!(msg: "Packit cannot be initialized: the config directory at {DEFAULT_CONFIG_DIR} is not writable, please set the correct permissions");
+            exit(1);
+        }
+
         // Check if config already exists
         if Config::get_default_path().exists() {
             error!(msg: "Packit is already initialized: config already exists");
@@ -32,9 +53,21 @@ impl HandleCommand for InitArgs {
         }
 
         let prefix_directory = match &self.prefix {
-            Some(prefix) => prefix.clone(),
+            Some(prefix) => path::absolute(prefix).unwrap_or_exit_msg("Unable to convert given prefix to an absolute path", 1),
             None => DEFAULT_PREFIX.into(),
         };
+
+        // Check if prefix directory exists
+        if !prefix_directory.exists() {
+            error!(msg: "Packit cannot be initialized: the prefix directory at {} does not exist yet, please create it first", prefix_directory.display());
+            exit(1);
+        }
+
+        // Check if prefix directory is writable
+        if !permissions::is_writable(&prefix_directory).unwrap_or_exit_msg("Unable to check if prefix directory is writable", 1) {
+            error!(msg: "Packit cannot be initialized: the prefix directory at {} is not writable, please set the correct permissions", prefix_directory.display());
+            exit(1);
+        }
 
         // Check if register already exists
         if PackageRegister::get_default_path(&prefix_directory).exists() {
@@ -45,7 +78,8 @@ impl HandleCommand for InitArgs {
         let packit_version = env!("CARGO_PKG_VERSION");
 
         // Check if packit binary is at the correct location
-        let packit_binary = prefix_directory.join("packages").join("packit").join(packit_version).join("bin").join("packit");
+        let packit_package_path = prefix_directory.join("packages").join("packit").join(packit_version);
+        let packit_binary = packit_package_path.join("bin").join("packit");
         if !packit_binary.exists() {
             error!(msg: "Packit cannot be initialized: expected packit binary at {}", packit_binary.display());
             exit(1);
@@ -64,9 +98,10 @@ impl HandleCommand for InitArgs {
         let mut register = PackageRegister::new_empty();
         let package_name = PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name");
         let package_version = Version::from_str(packit_version).expect("Expected Packit version to be in the correct format");
+        let package_id = PackageId::new(package_name, package_version);
 
         let installed_package_version = InstalledPackageVersion {
-            package_id: PackageId::new(package_name, package_version),
+            package_id: package_id.clone(),
             license: Licenses::Single("GPL-3.0-only".into()),
             source_repository_provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.into(),
             source_repository_url: DEFAULT_METADATA_REPOSITORY_PATH.into(),
@@ -74,11 +109,11 @@ impl HandleCommand for InitArgs {
             source_prebuild_repository_provider: None,
             dependencies: HashSet::new(),
             dependents: HashSet::new(),
-            install_path: packit_binary,
+            install_path: packit_package_path,
             revisions: Vec::new(),
         };
-        let active = false; //TODO
-        let symlinked = false; //TODO
+        let active = false;
+        let symlinked = false;
         let package_description =
             "The universal package manager, designed to streamline the experience of installing packages on your system.".into();
         let package_homepage = Some("https://github.com/pack-it/packit".into());
@@ -92,5 +127,17 @@ impl HandleCommand for InitArgs {
         register
             .save_to(&PackageRegister::get_default_path(&prefix_directory))
             .unwrap_or_exit_msg("Packit cannot be initialized: error while saving register", 1);
+
+        // Create symlinks in prefix directory
+        let symlinker = Symlinker::new(default_config.get_config());
+        symlinker
+            .set_active(&mut register, &package_id, true)
+            .unwrap_or_exit_msg("Packit cannot be initialized: error while creating symlinks", 1);
+
+        // Set correct permissions to all files in the prefix
+        permissions::set_packit_permissions(&prefix_directory, default_config.get_config().multiuser, true).unwrap_or_exit_msg(
+            "Packit cannot be initialized: error while setting permissions of files in the prefix",
+            1,
+        );
     }
 }

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use std::{collections::HashSet, path::PathBuf, process::exit, str::FromStr};
+
+use clap::Args;
+
+use crate::{
+    cli::{commands::HandleCommand, display::logging::error},
+    config::{Config, EditableConfig},
+    installer::types::{PackageId, PackageName, Version},
+    platforms::DEFAULT_PREFIX,
+    repositories::types::Licenses,
+    storage::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
+    utils::{
+        constants::{DEFAULT_METADATA_REPOSITORY_PATH, DEFAULT_METADATA_REPOSITORY_PROVIDER},
+        unwrap_or_exit::UnwrapOrExit,
+    },
+};
+
+/// Initializes the Packit installation.
+#[derive(Args, Debug)]
+pub struct InitArgs {
+    /// The prefix to use
+    prefix: Option<PathBuf>,
+}
+
+impl HandleCommand for InitArgs {
+    fn handle(&self) {
+        // Check if config already exists
+        if Config::get_default_path().exists() {
+            error!(msg: "Packit is already initialized: config already exists");
+            exit(2);
+        }
+
+        let prefix_directory = match &self.prefix {
+            Some(prefix) => prefix.clone(),
+            None => DEFAULT_PREFIX.into(),
+        };
+
+        // Check if register already exists
+        if PackageRegister::get_default_path(&prefix_directory).exists() {
+            error!(msg: "Packit is already initialized: register already exists");
+            exit(2);
+        }
+
+        let packit_version = env!("CARGO_PKG_VERSION");
+
+        // Check if packit binary is at the correct location
+        let packit_binary = prefix_directory.join("packages").join("packit").join(packit_version).join("bin").join("packit");
+        if !packit_binary.exists() {
+            error!(msg: "Packit cannot be initialized: expected packit binary at {}", packit_binary.display());
+            exit(1);
+        }
+
+        // Create default config
+        let mut default_config = EditableConfig::default();
+        if let Some(prefix_directory) = &self.prefix {
+            default_config.set_prefix_directory(prefix_directory.clone());
+        }
+        default_config
+            .save_to(&Config::get_default_path())
+            .unwrap_or_exit_msg("Packit cannot be initialized: error while saving config", 1);
+
+        // Create register containing packit
+        let mut register = PackageRegister::new_empty();
+        let package_name = PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name");
+        let package_version = Version::from_str(packit_version).expect("Expected Packit version to be in the correct format");
+
+        let installed_package_version = InstalledPackageVersion {
+            package_id: PackageId::new(package_name, package_version),
+            license: Licenses::Single("GPL-3.0-only".into()),
+            source_repository_provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.into(),
+            source_repository_url: DEFAULT_METADATA_REPOSITORY_PATH.into(),
+            source_prebuild_repository_url: None,
+            source_prebuild_repository_provider: None,
+            dependencies: HashSet::new(),
+            dependents: HashSet::new(),
+            install_path: packit_binary,
+            revisions: Vec::new(),
+        };
+        let active = false; //TODO
+        let symlinked = false; //TODO
+        let package_description =
+            "The universal package manager, designed to streamline the experience of installing packages on your system.".into();
+        let package_homepage = Some("https://github.com/pack-it/packit".into());
+
+        // Add Packit to register
+        register
+            .add_package_raw(installed_package_version, active, symlinked, package_description, package_homepage)
+            .unwrap_or_exit_msg("Packit cannot be initialized: error while adding Packit to register", 1);
+
+        // Save register
+        register
+            .save_to(&PackageRegister::get_default_path(&prefix_directory))
+            .unwrap_or_exit_msg("Packit cannot be initialized: error while saving register", 1);
+    }
+}

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -64,7 +64,7 @@ impl HandleCommand for InstallArgs {
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Check if all packages exist before starting installation

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -30,7 +30,7 @@ pub struct LinkArgs {
 impl HandleCommand for LinkArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_path = PackageRegister::get_default_path(&config);
+        let register_path = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -21,7 +21,7 @@ pub struct ListArgs {
 impl HandleCommand for ListArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -28,7 +28,7 @@ pub struct PackageArgs {
 impl HandleCommand for PackageArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         let package_version = match register.get_package_version(&self.package_id) {

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -34,7 +34,7 @@ pub struct SwitchArgs {
 impl HandleCommand for SwitchArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_path = PackageRegister::get_default_path(&config);
+        let register_path = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -39,7 +39,7 @@ impl HandleCommand for UninstallArgs {
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         // Check if all packages are installed before starting uninstall

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -21,7 +21,7 @@ pub struct UnlinkArgs {
 impl HandleCommand for UnlinkArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let register_path = PackageRegister::get_default_path(&config);
+        let register_path = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
 
         // Get installed package

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -31,7 +31,7 @@ impl HandleCommand for UpdateArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let register_dir = PackageRegister::get_default_path(&config);
+        let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         if let Some(package_id) = self.optional_id.versioned() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -274,7 +274,7 @@ impl<'a> Installer<'a> {
             false,
             use_prebuild,
         )?;
-        self.register.save_to(&PackageRegister::get_default_path(self.config))?;
+        self.register.save_to(&PackageRegister::get_default_path(&self.config.prefix_directory))?;
 
         // Download and run post install script if it exists
         let script_path = version_meta.get_postinstall_script_path(&install_meta.target_bounds)?;

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -91,7 +91,7 @@ impl<'a> Symlinker<'a> {
         }
 
         // Save package storage
-        register.save_to(&PackageRegister::get_default_path(self.config))?;
+        register.save_to(&PackageRegister::get_default_path(&self.config.prefix_directory))?;
 
         Ok(())
     }
@@ -139,7 +139,7 @@ impl<'a> Symlinker<'a> {
         };
 
         // Save package register
-        register.save_to(&PackageRegister::get_default_path(self.config))?;
+        register.save_to(&PackageRegister::get_default_path(&self.config.prefix_directory))?;
 
         Ok(())
     }

--- a/src/storage/installed_package.rs
+++ b/src/storage/installed_package.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::{installer::types::Version, repositories::types::PackageMeta, storage::installed_package_version::InstalledPackageVersion};
+use crate::{installer::types::Version, storage::installed_package_version::InstalledPackageVersion};
 
 /// Represents a package that is installed on the system, holding package specific info
 /// and a mapping from the installed versions to package versions.
@@ -22,14 +22,19 @@ pub struct InstalledPackage {
 
 impl InstalledPackage {
     /// Creates a new installed package with its first entry and package specific data.
-    pub fn new(package_version: InstalledPackageVersion, symlinked: bool, package: &PackageMeta) -> Self {
+    pub fn new(
+        package_version: InstalledPackageVersion,
+        symlinked: bool,
+        package_description: String,
+        package_homepage: Option<String>,
+    ) -> Self {
         let version = package_version.package_id.version.clone();
         Self {
             versions: HashMap::from([(version.clone(), package_version)]),
             symlinked,
             active_version: version,
-            description: package.description.clone(),
-            homepage: package.homepage.clone(),
+            description: package_description,
+            homepage: package_homepage,
         }
     }
 

--- a/src/storage/package_register.rs
+++ b/src/storage/package_register.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::{
     cli::display::logging::warning,
-    config::{Config, Repository},
+    config::Repository,
     installer::types::{Dependency, OptionalPackageId, PackageId, PackageName},
     repositories::types::{PackageMeta, PackageVersionMeta},
     storage::{error::Result, installed_package::InstalledPackage, installed_package_version::InstalledPackageVersion},
@@ -28,7 +28,7 @@ pub struct PackageRegister {
 
 impl PackageRegister {
     /// Creates a new empty `PackageRegister`. Should normally never be used.
-    /// This is mainly used in the `Verifier`. Under normal circumstances use `PackageRegister::from`.
+    /// This is mainly used in the `Verifier` and init command. Under normal circumstances use `PackageRegister::from`.
     pub fn new_empty() -> Self {
         Self { packages: HashMap::new() }
     }
@@ -82,8 +82,8 @@ impl PackageRegister {
     }
 
     /// Gets the default path of the Packit installed packages file.
-    pub fn get_default_path(config: &Config) -> PathBuf {
-        Path::new(&config.prefix_directory).join(REGISTER_FILENAME)
+    pub fn get_default_path(prefix_directory: &PathBuf) -> PathBuf {
+        Path::new(prefix_directory).join(REGISTER_FILENAME)
     }
 
     /// Adds a package to the register storage.
@@ -120,6 +120,25 @@ impl PackageRegister {
             revisions: package_version.revisions.clone(),
         };
 
+        self.add_package_raw(
+            installed_package_version,
+            active,
+            symlinked,
+            package.description.clone(),
+            package.homepage.clone(),
+        )
+    }
+
+    /// Adds a raw InstalledPackageVersion to the register storage.
+    /// Please note that this does not save the storage and does not read the currently installed packages from the toml.
+    pub fn add_package_raw(
+        &mut self,
+        installed_package_version: InstalledPackageVersion,
+        active: bool,
+        symlinked: bool,
+        package_description: String,
+        package_homepage: Option<String>,
+    ) -> Result<()> {
         // Add the package as a dependent in its dependencies
         for dependency in &installed_package_version.dependencies {
             if let Some(package) = self.get_package_version_mut(dependency) {
@@ -130,13 +149,15 @@ impl PackageRegister {
             }
         }
 
+        let package_name = &installed_package_version.package_id.name;
+
         // Add the new installed package version and if there are no entries for the current package yet, also create a new entry
-        match self.packages.get_mut(&package.name) {
+        match self.packages.get_mut(package_name) {
             Some(package) => package.add_package_version(installed_package_version, active),
             None => {
                 self.packages.insert(
-                    package.name.clone(),
-                    InstalledPackage::new(installed_package_version, symlinked, package),
+                    package_name.clone(),
+                    InstalledPackage::new(installed_package_version, symlinked, package_description, package_homepage),
                 );
             },
         };

--- a/src/verifier/repairer.rs
+++ b/src/verifier/repairer.rs
@@ -237,7 +237,7 @@ impl Repairer {
         let missing_packages = get_storage_packages(&config)?;
         let manager = RepositoryManager::new(&config);
         self.fix_inconsistent_register(missing_packages, &mut register, &config, &manager)?;
-        register.save_to(&PackageRegister::get_default_path(&config))?;
+        register.save_to(&PackageRegister::get_default_path(&config.prefix_directory))?;
         Ok(())
     }
 

--- a/src/verifier/verifier.rs
+++ b/src/verifier/verifier.rs
@@ -281,7 +281,7 @@ impl Verifier {
     /// Returns `None` if the register exists or an `Issue::MissingRegister` otherwise.
     fn check_register_existence(&self) -> Result<Option<Issue>> {
         let config = Config::from(&Config::get_default_path())?;
-        let register_directory = &PackageRegister::get_default_path(&config);
+        let register_directory = &PackageRegister::get_default_path(&config.prefix_directory);
         if fs::exists(register_directory)? {
             return Ok(None);
         }
@@ -293,7 +293,7 @@ impl Verifier {
     /// Returns `None` if the register syntax is valid or an `Issue::MissingRegister` otherwise.
     fn check_register_syntax(&self) -> Result<Option<Issue>> {
         let config = Config::from(&Config::get_default_path())?;
-        match PackageRegister::from(&PackageRegister::get_default_path(&config)) {
+        match PackageRegister::from(&PackageRegister::get_default_path(&config.prefix_directory)) {
             Ok(_) => Ok(None),
             Err(_) => Ok(Some(Issue::MissingRegister)),
         }


### PR DESCRIPTION
This PR adds the init command, which can be used to initialize Packit. It sets up the config, register and prefix structure.

It currently requires the user to create the config dir and prefix dir before running the commands, and setting the correct permissions. In the future we probably want to look into this and change this behaviour.