### PR TITLE
Add package all and sorted flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Skip uninstall option when update is not possible because of dependents which need the older version.
 - Add portable repositories, a generated repository containing only specific packages for use on airgapped systems.
 - Add the init command which initializes the Packit environment and files.
+- Add `--sorted` flag to the package command to sort packages into a prebuild directory structure.
+- Add `--all` flag to the package command to package all installed packages.
 
 ### Changes
 - The build system now includes a new `build-install` xtask to create a full Packit build in a `bin` directory structure.

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Links the specified package into the /bin, /lib, /share, etc. directories. If th
 #### `pit unlink <PACKAGE-NAME>`
 Unlinks the specified package, causing the package to be unavailable from the `PATH` environment variable.
 
-#### `pit package <PACKAGE-NAME>@<VERSION> ... <DESTINATION> [--sorted] [--all]`
+#### `pit package <DESTINATION> <PACKAGE-NAME>@<VERSION> ... [--sorted] [--all]`
 Packages the specified package(s) into a prebuild and stores it in the destination directory, together with a checksum of the prebuild. When `--sorted` is used the packages will be sorted into a prebuild directory structure. `--all` will package all installed packages.
 
 #### `pit util checksum <URL>`

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Links the specified package into the /bin, /lib, /share, etc. directories. If th
 #### `pit unlink <PACKAGE-NAME>`
 Unlinks the specified package, causing the package to be unavailable from the `PATH` environment variable.
 
-#### `pit package <PACKAGE-NAME>@<VERSION> <DESTINATION>`
-Packages the specified package into a prebuild and stores it in the destination directory, together with a checksum of the prebuild.
+#### `pit package <PACKAGE-NAME>@<VERSION> ... <DESTINATION> [--sorted] [--all]`
+Packages the specified package(s) into a prebuild and stores it in the destination directory, together with a checksum of the prebuild. When `--sorted` is used the packages will be sorted into a prebuild directory structure. `--all` will package all installed packages.
 
 #### `pit util checksum <URL>`
 Calculates the checksum of the file at the given url.

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::PathBuf};
+use std::{fs, path::PathBuf, process::exit};
 
 use clap::Args;
 
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{Spinner, not_found},
+        display::{Spinner, logging::error, not_found},
     },
     config::Config,
     installer::types::PackageId,
@@ -18,11 +18,11 @@ use crate::{
 /// Packages the specified package into a prebuild and store it in the destination directory, together with a checksum of the prebuild.
 #[derive(Args, Debug)]
 pub struct PackageArgs {
-    /// The package id of the package
-    pub package_id: PackageId,
-
     /// Destination of the compressed package
     pub destination: PathBuf,
+
+    /// The package id of the package
+    pub packages: Vec<PackageId>,
 
     /// True to sort the package into a prebuild directory
     #[arg(short, long, default_value = "false")]
@@ -35,30 +35,43 @@ impl HandleCommand for PackageArgs {
         let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        let package_version = match register.get_package_version(&self.package_id) {
-            Some(package_version) => package_version,
-            None => not_found::register_package_version(&self.package_id, &register),
-        };
+        if self.packages.is_empty() {
+            error!(msg: "Nothing packaged, no packages specified");
+            exit(1);
+        }
 
-        // Get the correct install directory
-        let destination = match self.sorted {
-            true => {
-                let prefix = self.package_id.name.get_prefix().to_string();
-                &self.destination.join("packages").join(prefix).join(&self.package_id.name).join(self.package_id.version.to_string())
-            },
-            false => &self.destination,
+        for package_id in &self.packages {
+            // Get the correct install directory
+            let destination = match self.sorted {
+                true => {
+                    let prefix = package_id.name.get_prefix().to_string();
+                    &self.destination.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string())
+                },
+                false => &self.destination,
+            };
+
+            self.package(package_id, destination, &config, &register);
+        }
+    }
+}
+
+impl PackageArgs {
+    fn package(&self, package_id: &PackageId, destination: &PathBuf, config: &Config, register: &PackageRegister) {
+        let package_version = match register.get_package_version(package_id) {
+            Some(package_version) => package_version,
+            None => not_found::register_package_version(package_id, &register),
         };
 
         // Automatically create the destination directory
         fs::create_dir_all(destination).unwrap_or_exit_msg("Failed to create prebuild directory", 1);
 
         let spinner = Spinner::new();
-        let spinner_message = format!("Packaging {}", self.package_id);
+        let spinner_message = format!("Packaging {package_id}");
         spinner.show(spinner_message.clone());
 
-        packager::package(&config, &self.package_id, destination, package_version.revisions.len() as u64).unwrap_or_exit(1);
+        packager::package(&config, package_id, destination, package_version.revisions.len() as u64).unwrap_or_exit(1);
 
         spinner.finish(format!("{spinner_message} successful"));
-        println!("Successfully packaged {} to {:?}", self.package_id, self.destination);
+        println!("Successfully packaged {package_id} to {:?}", destination);
     }
 }

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -27,6 +27,10 @@ pub struct PackageArgs {
     /// True to sort the package into a prebuild directory
     #[arg(short, long, default_value = "false")]
     pub sorted: bool,
+
+    /// True to build all installed packages
+    #[arg(short, long, default_value = "false")]
+    pub all: bool,
 }
 
 impl HandleCommand for PackageArgs {
@@ -35,12 +39,17 @@ impl HandleCommand for PackageArgs {
         let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        if self.packages.is_empty() {
+        let packages: Vec<&PackageId> = match self.all {
+            true => register.iterate_all().map(|p| &p.package_id).collect(),
+            false => self.packages.iter().collect(),
+        };
+
+        if packages.is_empty() {
             error!(msg: "Nothing packaged, no packages specified");
             exit(1);
         }
 
-        for package_id in &self.packages {
+        for package_id in &packages {
             // Get the correct install directory
             let destination = match self.sorted {
                 true => {

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -21,14 +21,14 @@ pub struct PackageArgs {
     /// Destination of the compressed package
     pub destination: PathBuf,
 
-    /// The package id of the package
+    /// The ids of the packages to package
     pub packages: Vec<PackageId>,
 
     /// True to sort the package into a prebuild directory
     #[arg(short, long, default_value = "false")]
     pub sorted: bool,
 
-    /// True to build all installed packages
+    /// True to package all installed packages
     #[arg(short, long, default_value = "false")]
     pub all: bool,
 }

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::path::PathBuf;
+use std::{fs, path::PathBuf};
 
 use clap::Args;
 
@@ -10,7 +10,7 @@ use crate::{
     },
     config::Config,
     installer::types::PackageId,
-    packager::{self},
+    packager,
     storage::package_register::PackageRegister,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -23,6 +23,10 @@ pub struct PackageArgs {
 
     /// Destination of the compressed package
     pub destination: PathBuf,
+
+    /// True to sort the package into a prebuild directory
+    #[arg(short, long, default_value = "false")]
+    pub sorted: bool,
 }
 
 impl HandleCommand for PackageArgs {
@@ -36,11 +40,23 @@ impl HandleCommand for PackageArgs {
             None => not_found::register_package_version(&self.package_id, &register),
         };
 
+        // Get the correct install directory
+        let destination = match self.sorted {
+            true => {
+                let prefix = self.package_id.name.get_prefix().to_string();
+                &self.destination.join("packages").join(prefix).join(&self.package_id.name).join(self.package_id.version.to_string())
+            },
+            false => &self.destination,
+        };
+
+        // Automatically create the destination directory
+        fs::create_dir_all(destination).unwrap_or_exit_msg("Failed to create prebuild directory", 1);
+
         let spinner = Spinner::new();
         let spinner_message = format!("Packaging {}", self.package_id);
         spinner.show(spinner_message.clone());
 
-        packager::package(&config, &self.package_id, &self.destination, package_version.revisions.len() as u64).unwrap_or_exit(1);
+        packager::package(&config, &self.package_id, destination, package_version.revisions.len() as u64).unwrap_or_exit(1);
 
         spinner.finish(format!("{spinner_message} successful"));
         println!("Successfully packaged {} to {:?}", self.package_id, self.destination);

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -17,6 +17,13 @@ pub enum PackageNameError {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PackageName(String);
 
+impl PackageName {
+    /// Get the prefix from the package name. The package name regex assures that one character is always present.
+    pub fn get_prefix(&self) -> char {
+        self.0.chars().next().expect("Expected first char, based on regex")
+    }
+}
+
 impl<'de> Deserialize<'de> for PackageName {
     /// Deserializes a string into a `PackageName`.
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -29,9 +29,6 @@ pub enum RepositoryError {
     #[error("Cannot find target for package.")]
     TargetError,
 
-    #[error("The given package name is empty")]
-    EmptyPackageName,
-
     #[error("Dependency '{0}' cannot be satisfied by the current package repository for the current target.")]
     DependencySupportError(String),
 

--- a/src/repositories/prebuilds/filesystem.rs
+++ b/src/repositories/prebuilds/filesystem.rs
@@ -60,7 +60,7 @@ impl FileSystemPrebuildProvider {
     }
 
     fn get_file_path(&self, package_id: &PackageId, revision: u64, target: &Target, extension: &str) -> Result<Option<PathBuf>> {
-        let prefix = package_id.name.chars().next().ok_or(RepositoryError::EmptyPackageName)?.to_string();
+        let prefix = package_id.name.get_prefix().to_string();
         let target = target.architecture.to_string();
         let prebuild_name = format!("{package_id}-{revision}-{target}.{extension}");
         let path = self.path.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string()).join(prebuild_name);

--- a/src/repositories/prebuilds/web.rs
+++ b/src/repositories/prebuilds/web.rs
@@ -71,7 +71,7 @@ impl WebPrebuildProvider {
     /// Returns None if the file cannot be found in the repository.
     /// Returns a `UrlParseError` if the created url cannot be parsed.
     fn read_file_path(&self, package_id: &PackageId, revision: u64, target: &Target, extension: &str) -> Result<Option<(Url, Response)>> {
-        let prefix = package_id.name.chars().next().ok_or(RepositoryError::EmptyPackageName)?.to_string();
+        let prefix = package_id.name.get_prefix().to_string();
         let target = target.architecture.to_string();
         let package_name = &package_id.name;
         let file_name = format!("{package_id}-{revision}-{target}.{extension}");


### PR DESCRIPTION
This PR adds a --sorted flag to sort packages into a prebuild directory and also a --all flag to package all install packages.