### PR TITLE
Refactor fuzzy alternatives

### DIFF
--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -41,7 +41,7 @@ impl HandleCommand for InfoArgs {
         // Get package information
         let package = match register.get_package(&self.package.name) {
             Some(package) => package,
-            None => not_found::package_not_found(&self.package.name, &register),
+            None => not_found::register_package(&self.package.name, &register),
         };
 
         // Display tree if tree flag is given
@@ -53,7 +53,7 @@ impl HandleCommand for InfoArgs {
 
             let tree = match EmptyNode::build_simple_tree(package_id.clone(), &register) {
                 Ok(tree) => tree,
-                Err(TreeError::NotFound(..)) => not_found::package_version_not_found(&package_id, &register),
+                Err(TreeError::NotFound(..)) => not_found::register_package_version(&package_id, &register),
                 Err(e) => Err(e).unwrap_or_exit(1),
             };
 
@@ -94,7 +94,7 @@ impl InfoArgs {
     fn display_package_version_info(&self, package_id: &PackageId, register: &PackageRegister, package: &InstalledPackage) {
         let package_version = match register.get_package_version(package_id) {
             Some(package) => package,
-            None => not_found::package_version_not_found(package_id, register),
+            None => not_found::register_package_version(package_id, register),
         };
 
         println!("{}", package_id);

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -4,11 +4,17 @@ use std::process::exit;
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{
+        commands::HandleCommand,
+        display::{logging::error, not_found},
+    },
     config::Config,
     installer::types::{OptionalPackageId, PackageId},
     storage::{installed_package::InstalledPackage, package_register::PackageRegister},
-    utils::{fuzzy, tree::EmptyNode, unwrap_or_exit::UnwrapOrExit},
+    utils::{
+        tree::{EmptyNode, TreeError},
+        unwrap_or_exit::UnwrapOrExit,
+    },
 };
 
 /// Shows info about the specified installed package.
@@ -35,28 +41,24 @@ impl HandleCommand for InfoArgs {
         // Get package information
         let package = match register.get_package(&self.package.name) {
             Some(package) => package,
-            None => {
-                error!(msg: "Package '{}' is not installed", self.package);
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.package.name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1)
-            },
+            None => not_found::package_not_found(&self.package.name, &register),
         };
 
         // Display tree if tree flag is given
         if self.tree {
-            if let Some(package_id) = self.package.versioned() {
-                let tree = EmptyNode::build_simple_tree(package_id, &register).unwrap_or_exit(1);
-                println!("{tree}");
-                return;
-            } else {
+            let Some(package_id) = self.package.versioned() else {
                 error!(msg: "Displaying a tree requires package version to be specified.");
-                exit(1)
-            }
+                exit(1);
+            };
+
+            let tree = match EmptyNode::build_simple_tree(package_id.clone(), &register) {
+                Ok(tree) => tree,
+                Err(TreeError::NotFound(..)) => not_found::package_version_not_found(&package_id, &register),
+                Err(e) => Err(e).unwrap_or_exit(1),
+            };
+
+            println!("{tree}");
+            return;
         }
 
         // Show package version specific information
@@ -92,10 +94,7 @@ impl InfoArgs {
     fn display_package_version_info(&self, package_id: &PackageId, register: &PackageRegister, package: &InstalledPackage) {
         let package_version = match register.get_package_version(package_id) {
             Some(package) => package,
-            None => {
-                error!(msg: "Package '{}' doesn't exist", package_id);
-                exit(1)
-            },
+            None => not_found::package_version_not_found(package_id, register),
         };
 
         println!("{}", package_id);

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -4,13 +4,16 @@ use std::process::exit;
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{
+        commands::HandleCommand,
+        display::{logging::error, not_found},
+    },
     config::Config,
     installer::{InstallType, Installer, InstallerOptions, types::OptionalPackageId},
     platforms::Target,
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::{duplicates, fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::{duplicates, unwrap_or_exit::UnwrapOrExit},
 };
 
 /// Installs the specified packages, if a version is given that version will be installed,
@@ -69,37 +72,12 @@ impl HandleCommand for InstallArgs {
 
         // Check if all packages exist before starting installation
         for optional_id in &self.packages {
-            if let Some(package_id) = optional_id.versioned() {
-                if manager.read_package_version(&package_id, &Target::current()).is_ok() {
-                    continue;
-                }
-
-                error!(msg: "Package '{}' cannot be found.", package_id);
-
-                // Show possible versions if a package with the given name exists
-                if let Ok((_, package_name)) = manager.read_package(&package_id.name) {
-                    let versions = package_name.versions;
-                    print!("Did you mean version(s): ");
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-                    println!();
-                    return;
-                }
+            match optional_id.versioned() {
+                Some(package_id) if manager.read_package_version(&package_id, &Target::current()).is_ok() => continue,
+                Some(package_id) => not_found::repository_package_version(&package_id, &manager, &config),
+                None if manager.read_package(&optional_id.name).is_ok() => continue,
+                None => not_found::repository_package(&optional_id.name, &manager, &config),
             }
-
-            if manager.read_package(&optional_id.name).is_ok() {
-                continue;
-            }
-
-            error!(msg: "Package '{}' cannot be found.", optional_id.name);
-
-            let fuzzy_match = fuzzy::repository_search(&config, &manager, &optional_id.name).unwrap_or_exit(1);
-            if let Some(fuzzy_match) = fuzzy_match {
-                println!("Did you mean: '{fuzzy_match}'?");
-            }
-
-            return;
         }
 
         // Determine the install type. Note that clap already check if build and build-all are both set (which should not be possible).

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -1,19 +1,17 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::process::exit;
-
 use clap::Args;
 
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::logging::{error, warning},
+        display::{logging::warning, not_found},
     },
     config::{Config, Repository},
     installer::{Symlinker, types::PackageName},
     platforms::Target,
     repositories::{provider, types::PackageVersionMeta},
     storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Links the specified package into the /bin, /lib, /share, etc. directories.
@@ -36,16 +34,7 @@ impl HandleCommand for LinkArgs {
         // Get installed package
         let package = match register.get_package(&self.package_name) {
             Some(package) => package,
-            None => {
-                error!(msg: "Package {} is not installed!", self.package_name);
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.package_name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1);
-            },
+            None => not_found::register_package(&self.package_name, &register),
         };
 
         // Check if the package is already symlinked

--- a/src/cli/commands/package.rs
+++ b/src/cli/commands/package.rs
@@ -1,18 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{path::PathBuf, process::exit};
+use std::path::PathBuf;
 
 use clap::Args;
 
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{Spinner, logging::error},
+        display::{Spinner, not_found},
     },
     config::Config,
     installer::types::PackageId,
     packager::{self},
     storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Packages the specified package into a prebuild and store it in the destination directory, together with a checksum of the prebuild.
@@ -33,27 +33,7 @@ impl HandleCommand for PackageArgs {
 
         let package_version = match register.get_package_version(&self.package_id) {
             Some(package_version) => package_version,
-            None => {
-                error!(msg: "Package '{}' cannot be found.", self.package_id);
-
-                // Show possible versions if a package with the given name exists
-                if let Some(package_name) = register.get_package(&self.package_id.name) {
-                    let versions = package_name.versions.keys();
-                    print!("Did you mean version(s): ");
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-                    println!();
-                    return;
-                }
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.package_id.name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1);
-            },
+            None => not_found::register_package_version(&self.package_id, &register),
         };
 
         let spinner = Spinner::new();

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -7,13 +7,13 @@ use std::{collections::HashSet, str::FromStr};
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{logging::error, print_grid},
+        display::{logging::error, not_found, print_grid},
     },
     config::Config,
     installer::types::OptionalPackageId,
     platforms::Target,
     repositories::{error::RepositoryError, manager::RepositoryManager},
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata.
@@ -76,16 +76,7 @@ impl SearchArgs {
         let manager = RepositoryManager::new(&config);
         let (repository_id, package) = match manager.read_package(&optional_id.name) {
             Ok(package) => package,
-            Err(RepositoryError::PackageNotFoundError { .. }) => {
-                println!("Cannot find package '{}'", optional_id.name);
-
-                let fuzzy_match = fuzzy::repository_search(&config, &manager, &optional_id.name).unwrap_or_exit(1);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                return;
-            },
+            Err(RepositoryError::PackageNotFoundError { .. }) => not_found::repository_package(&optional_id.name, &manager, &config),
             Err(e) => {
                 error!(e, "Cannot read package");
                 return;

--- a/src/cli/commands/switch.rs
+++ b/src/cli/commands/switch.rs
@@ -6,7 +6,10 @@ use clap::Args;
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::logging::{error, warning},
+        display::{
+            logging::{error, warning},
+            not_found,
+        },
     },
     config::Config,
     installer::{
@@ -14,7 +17,7 @@ use crate::{
         types::{PackageName, Version},
     },
     storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Switches the active version of the specified package to the specified version.
@@ -40,16 +43,7 @@ impl HandleCommand for SwitchArgs {
         // Get installed package
         let package = match register.get_package(&self.package_name) {
             Some(package) => package,
-            None => {
-                error!(msg: "Package {} is not installed!", self.package_name);
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.package_name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1);
-            },
+            None => not_found::register_package(&self.package_name, &register),
         };
 
         // Check if the package version is already active
@@ -63,18 +57,7 @@ impl HandleCommand for SwitchArgs {
             Some(package_version) => package_version,
             None => {
                 error!(msg: "Package '{}@{}' cannot be found.", self.package_name, self.package_version);
-
-                // Show possible versions if a package with the given name exists
-                if let Some(package_name) = register.get_package(&self.package_name) {
-                    let versions = package_name.versions.keys();
-                    print!("Did you mean version(s): ");
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-                    println!();
-                    return;
-                }
-
+                not_found::register_version(&self.package_name, &register);
                 exit(1);
             },
         };

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -4,12 +4,15 @@ use std::process::exit;
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{
+        commands::HandleCommand,
+        display::{logging::error, not_found},
+    },
     config::Config,
     installer::{Installer, InstallerOptions, types::OptionalPackageId},
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::{duplicates, fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::{duplicates, unwrap_or_exit::UnwrapOrExit},
 };
 
 /// Uninstalls the specified packages, if a version is given that version will be uninstalled, if not,
@@ -44,37 +47,12 @@ impl HandleCommand for UninstallArgs {
 
         // Check if all packages are installed before starting uninstall
         for optional_id in &self.packages {
-            if let Some(package_id) = optional_id.versioned() {
-                if register.get_package_version(&package_id).is_some() {
-                    continue;
-                }
-
-                error!(msg: "Package '{}' cannot be found.", package_id);
-
-                // Show possible versions if a package with the given name exists
-                if let Some(package) = register.get_package(&package_id.name) {
-                    let versions = package.versions.keys();
-                    print!("Did you mean version(s): ");
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-                    println!();
-                    return;
-                }
+            match optional_id.versioned() {
+                Some(package_id) if register.get_package_version(&package_id).is_some() => continue,
+                Some(package_id) => not_found::register_package_version(&package_id, &register),
+                None if register.get_package(&optional_id.name).is_some() => continue,
+                None => not_found::register_package(&optional_id.name, &register),
             }
-
-            if register.get_package(&optional_id.name).is_some() {
-                continue;
-            }
-
-            error!(msg: "Package '{}' cannot be found.", optional_id.name);
-
-            let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &optional_id.name);
-            if let Some(fuzzy_match) = fuzzy_match {
-                println!("Did you mean: '{fuzzy_match}'?");
-            }
-
-            return;
         }
 
         let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());

--- a/src/cli/commands/unlink.rs
+++ b/src/cli/commands/unlink.rs
@@ -1,14 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::process::exit;
-
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{commands::HandleCommand, display::not_found},
     config::Config,
     installer::{Symlinker, types::PackageName},
     storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Unlinks the specified package, causing the package to be unavailable from the PATH environment variable.
@@ -27,16 +25,7 @@ impl HandleCommand for UnlinkArgs {
         // Get installed package
         let package = match register.get_package(&self.package_name) {
             Some(package) => package,
-            None => {
-                error!(msg: "Package {} is not installed!", self.package_name);
-
-                let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.package_name);
-                if let Some(fuzzy_match) = fuzzy_match {
-                    println!("Did you mean: '{fuzzy_match}'?");
-                }
-
-                exit(1);
-            },
+            None => not_found::register_package(&self.package_name, &register),
         };
 
         // Check if the package is already symlinked

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -4,7 +4,10 @@ use std::process::exit;
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{
+        commands::HandleCommand,
+        display::{logging::error, not_found},
+    },
     config::Config,
     installer::{
         Installer, InstallerOptions,
@@ -13,7 +16,7 @@ use crate::{
     platforms::Target,
     repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
+    utils::unwrap_or_exit::UnwrapOrExit,
 };
 
 /// Updates the specified package to the new version, or the latest version if no new version is specified.
@@ -34,32 +37,11 @@ impl HandleCommand for UpdateArgs {
         let register_dir = PackageRegister::get_default_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        if let Some(package_id) = self.optional_id.versioned() {
-            if register.get_package_version(&package_id).is_none() {
-                error!(msg: "Package '{}' cannot be found.", package_id);
-
-                // Show possible versions if a package with the given name exists
-                if let Some(package) = register.get_package(&package_id.name) {
-                    let versions = package.versions.keys();
-                    print!("Did you mean version(s): ");
-                    for version in versions {
-                        print!("'{version}' ");
-                    }
-                    println!();
-                    return;
-                }
-            }
-        }
-
-        if register.get_package(&self.optional_id.name).is_none() {
-            error!(msg: "Package '{}' cannot be found.", self.optional_id.name);
-
-            let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &self.optional_id.name);
-            if let Some(fuzzy_match) = fuzzy_match {
-                println!("Did you mean: '{fuzzy_match}'?");
-            }
-
-            return;
+        match self.optional_id.versioned() {
+            Some(package_id) if register.get_package_version(&package_id).is_some() => {},
+            Some(package_id) => not_found::register_package_version(&package_id, &register),
+            None if register.get_package(&self.optional_id.name).is_some() => {},
+            None => not_found::register_package(&self.optional_id.name, &register),
         }
 
         let (_, package_meta) = manager.read_package(&self.optional_id.name).unwrap_or_exit(1);
@@ -69,21 +51,10 @@ impl HandleCommand for UpdateArgs {
             None => package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1),
         };
 
-        // Check if new version exists
+        // Check if the new version exists
         if !package_meta.versions.contains(new_version) {
             error!(msg: "New package version '{new_version}' does not exist.");
-
-            // Show possible versions if a package with the given name exists
-            if let Ok((_, package_name)) = manager.read_package(&self.optional_id.name) {
-                let versions = package_name.versions;
-                print!("Did you mean version(s): ");
-                for version in versions {
-                    print!("'{version}' ");
-                }
-                println!();
-                return;
-            }
-
+            not_found::repository_version(&self.optional_id.name, &manager);
             exit(1);
         }
 

--- a/src/cli/display/mod.rs
+++ b/src/cli/display/mod.rs
@@ -2,6 +2,7 @@
 pub mod error;
 pub mod grid;
 pub mod logging;
+pub mod not_found;
 mod progressbar;
 mod prompts;
 mod reader;

--- a/src/cli/display/not_found.rs
+++ b/src/cli/display/not_found.rs
@@ -1,0 +1,50 @@
+use std::process::exit;
+
+use crate::{
+    cli::display::logging::error,
+    installer::types::{PackageId, PackageName},
+    storage::package_register::PackageRegister,
+    utils::fuzzy,
+};
+
+/// Shows possible versions and exits with status 1 if the given package name exits.
+pub fn version_not_found(package_name: &PackageName, register: &PackageRegister) {
+    // Return early if the package name doesn't exist
+    let Some(package_name) = register.get_package(package_name) else {
+        return;
+    };
+
+    let versions = package_name.versions.keys();
+    print!("Did you mean version(s): ");
+    for version in versions {
+        print!("'{version}' ");
+    }
+    println!();
+
+    exit(1);
+}
+
+/// Shows a package cannot be found error and a fuzzy alternative for a package name. Then exits at the end.
+pub fn package_not_found(package_name: &PackageName, register: &PackageRegister) -> ! {
+    error!(msg: "Package '{}' cannot be found", package_name);
+
+    let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), package_name);
+    if let Some(fuzzy_match) = fuzzy_match {
+        println!("Did you mean: '{fuzzy_match}'?");
+    }
+
+    exit(1)
+}
+
+/// Shows a package cannot be found error and a fuzzy alternative for a package version. Then exits at the end.
+pub fn package_version_not_found(package_id: &PackageId, register: &PackageRegister) -> ! {
+    error!(msg: "Package '{package_id}' cannot be found.");
+    version_not_found(&package_id.name, register);
+
+    let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &package_id.name);
+    if let Some(fuzzy_match) = fuzzy_match {
+        println!("Did you mean: '{fuzzy_match}'?");
+    }
+
+    exit(1);
+}

--- a/src/cli/display/not_found.rs
+++ b/src/cli/display/not_found.rs
@@ -1,20 +1,37 @@
+// SPDX-License-Identifier: GPL-3.0-onl
 use std::process::exit;
 
 use crate::{
     cli::display::logging::error,
-    installer::types::{PackageId, PackageName},
+    config::Config,
+    installer::types::{PackageId, PackageName, Version},
+    repositories::manager::RepositoryManager,
     storage::package_register::PackageRegister,
-    utils::fuzzy,
+    utils::{fuzzy, unwrap_or_exit::UnwrapOrExit},
 };
 
-/// Shows possible versions and exits with status 1 if the given package name exits.
-pub fn version_not_found(package_name: &PackageName, register: &PackageRegister) {
-    // Return early if the package name doesn't exist
-    let Some(package_name) = register.get_package(package_name) else {
+/// Shows possible register versions and exits with status 1 if the given package name exits.
+pub fn register_version(package_name: &PackageName, register: &PackageRegister) {
+    // Return early if the package name doesn't exist in the register
+    let Some(package) = register.get_package(package_name) else {
         return;
     };
 
-    let versions = package_name.versions.keys();
+    display_versions(package.versions.keys())
+}
+
+/// Shows possible repository versions and exits with status 1 if the given package name exits.
+pub fn repository_version(package_name: &PackageName, manager: &RepositoryManager) {
+    // Return early if the package name doesn't exist in the repository
+    let Ok((_, package)) = manager.read_package(package_name) else {
+        return;
+    };
+
+    display_versions(package.versions.iter())
+}
+
+/// Displays alternative versions and exits.
+fn display_versions<'a>(versions: impl Iterator<Item = &'a Version>) -> ! {
     print!("Did you mean version(s): ");
     for version in versions {
         print!("'{version}' ");
@@ -24,8 +41,8 @@ pub fn version_not_found(package_name: &PackageName, register: &PackageRegister)
     exit(1);
 }
 
-/// Shows a package cannot be found error and a fuzzy alternative for a package name. Then exits at the end.
-pub fn package_not_found(package_name: &PackageName, register: &PackageRegister) -> ! {
+/// Shows an error that the package (name) cannot be found (in the register) and a fuzzy alternative. Then exits at the end.
+pub fn register_package(package_name: &PackageName, register: &PackageRegister) -> ! {
     error!(msg: "Package '{}' cannot be found", package_name);
 
     let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), package_name);
@@ -33,15 +50,40 @@ pub fn package_not_found(package_name: &PackageName, register: &PackageRegister)
         println!("Did you mean: '{fuzzy_match}'?");
     }
 
-    exit(1)
+    exit(1);
 }
 
-/// Shows a package cannot be found error and a fuzzy alternative for a package version. Then exits at the end.
-pub fn package_version_not_found(package_id: &PackageId, register: &PackageRegister) -> ! {
+/// Shows an error that the package (name) cannot be found (in the repository) and a fuzzy alternative. Then exits at the end.
+pub fn repository_package(package_name: &PackageName, manager: &RepositoryManager, config: &Config) -> ! {
+    error!(msg: "Package '{package_name}' cannot be found.");
+
+    let fuzzy_match = fuzzy::repository_search(config, &manager, package_name).unwrap_or_exit(1);
+    if let Some(fuzzy_match) = fuzzy_match {
+        println!("Did you mean: '{fuzzy_match}'?");
+    }
+
+    exit(1);
+}
+
+/// Shows an error that the package version cannot be found (in the register) and a fuzzy alternative. Then exits at the end.
+pub fn register_package_version(package_id: &PackageId, register: &PackageRegister) -> ! {
     error!(msg: "Package '{package_id}' cannot be found.");
-    version_not_found(&package_id.name, register);
+    register_version(&package_id.name, register);
 
     let fuzzy_match = fuzzy::min_search(register.iterate_package_names(), &package_id.name);
+    if let Some(fuzzy_match) = fuzzy_match {
+        println!("Did you mean: '{fuzzy_match}'?");
+    }
+
+    exit(1);
+}
+
+/// Shows an error that the package version cannot be found (in the repository) and a fuzzy alternative. Then exits at the end.
+pub fn repository_package_version(package_id: &PackageId, manager: &RepositoryManager, config: &Config) -> ! {
+    error!(msg: "Package '{}' cannot be found.", package_id);
+    repository_version(&package_id.name, manager);
+
+    let fuzzy_match = fuzzy::repository_search(config, &manager, &package_id.name).unwrap_or_exit(1);
     if let Some(fuzzy_match) = fuzzy_match {
         println!("Did you mean: '{fuzzy_match}'?");
     }


### PR DESCRIPTION
This PR is a refactor for all the fuzzy alternative display code. 
- It's now in a separate module, making the command code easier to read.
- The info command now also has version suggestions.