### PR TITLE
Add config repositories remove command

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ Sets the repositories rank in the config. Multiple `<REPOSITORY-ID>` can be give
 #### `pit config repositories add <ID> <URL> [PROVIDER]`
 Adds a new repository to the config. Also adds the new repository to the back of the repositories rank.
 
+#### `pit config repositories remove <ID>`
+Removes a repository from the config. Also removes the repository from the repositories rank.
+
 #### `pit init [--prefix <PREFIX>]`
 Initializes the Packit environment by setting up all required files and directories. If the `--prefix` option is given, the given path is used as prefix, instead of the [default prefix](#prefix).
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -63,6 +63,12 @@ pub enum RepositoriesArgs {
         /// The optional provider of the new repository, `web` is used as default
         provider: Option<String>,
     },
+
+    /// Removes a repository from the config
+    Remove {
+        /// The id of the repository to remove
+        id: String,
+    },
 }
 
 impl HandleCommand for ConfigArgs {
@@ -77,6 +83,7 @@ impl HandleCommand for ConfigArgs {
             ConfigArgs::Repositories(RepositoriesArgs::List) => self.handle_list_repositories(config),
             ConfigArgs::Repositories(RepositoriesArgs::SetRank { new_rank }) => self.handle_set_repositories_rank(config, new_rank),
             ConfigArgs::Repositories(RepositoriesArgs::Add { id, url, provider }) => self.handle_add_repository(config, id, url, provider),
+            ConfigArgs::Repositories(RepositoriesArgs::Remove { id }) => self.handle_remove_repository(config, id),
         }
     }
 }
@@ -196,6 +203,12 @@ impl ConfigArgs {
 
     /// Handles the config repositories add command.
     fn handle_add_repository(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>) {
+        // Check if the config already contains a repository with this id
+        if config.get_config().repositories.contains_key(id) {
+            error!(msg: "A repository {id} with this id already exists.");
+            exit(1);
+        }
+
         let provider = match provider {
             Some(provider) => provider,
             None => DEFAULT_METADATA_PROVIDER_ID,
@@ -209,5 +222,26 @@ impl ConfigArgs {
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
         println!("Succesfully added repository {id} to the config!");
+    }
+
+    /// Handles the config repositories remove command.
+    fn handle_remove_repository(&self, mut config: EditableConfig, id: &str) {
+        // Check if the config even contains this repository
+        if !config.get_config().repositories.contains_key(id) {
+            error!(msg: "Repository {id} does not exist.");
+            exit(1);
+        }
+
+        // Check if the config only contains this repository
+        if config.get_config().repositories.len() == 1 {
+            error!(msg: "Repository {id} is the only repository in the config, please add another one before removing this one.");
+            exit(1);
+        }
+
+        config.remove_repository(id);
+
+        config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
+
+        println!("Succesfully removed repository {id} from the config!");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,15 +246,12 @@ impl EditableConfig {
     }
 
     // Removes a repository with the given id from the config.
-    // TODO: Implement this for the config command (making sure that we handle packages which currently use this repo)
     pub fn remove_repository(&mut self, id: &str) {
-        if let Some(repositories) = self.document.get_mut("repositories").and_then(|r| r.as_table_mut()) {
-            repositories.remove(id);
-        }
+        let repositories = self.document["repositories"].as_table_like_mut().expect("Expected repositories to be a table!");
+        repositories.remove(id);
 
-        if let Some(repositories) = self.document.get_mut("repositories_rank").and_then(|r| r.as_array_mut()) {
-            repositories.retain(|v| v.as_str() != Some(id));
-        }
+        let repositories_rank = self.document["repositories_rank"].as_array_mut().expect("Expected repositories_rank to be an array!");
+        repositories_rank.retain(|v| v.as_str() != Some(id));
 
         self.config.repositories.remove(id);
         self.config.repositories_rank.retain(|v| v != id);


### PR DESCRIPTION
This PR adds the `pit config repositories remove` command which removes a repository from the config