### PR TITLE
Add package-build xtask

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
 [alias]
 build-install = "run --package xtask-build-install --"
+package-build = "run --package xtask-package-build --"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased](https://github.com/pack-it/packit/compare/0.0.2...HEAD)
 
+### Changes
+- The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
+
 
 ## [v0.0.2](https://github.com/pack-it/packit/compare/0.0.1...0.0.2) - 2026-05-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3683,6 +3683,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "xtask-package-build"
+version = "0.0.0"
+dependencies = [
+ "clap",
+ "flate2",
+ "tar",
+]
+
+[[package]]
 name = "xz2"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/xtasks/xtask-build-install/src/main.rs
+++ b/xtasks/xtask-build-install/src/main.rs
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-only
 use std::{
     fs,
     path::{Path, PathBuf},
@@ -117,7 +118,7 @@ fn copy_binary_to_destination(destination: &PathBuf) {
     }
 }
 
-/// Gets the path to the proejct root directory.
+/// Gets the path to the project root directory.
 fn get_project_root_path() -> PathBuf {
     Path::new(std::env!("CARGO_MANIFEST_DIR"))
         .ancestors()

--- a/xtasks/xtask-package-build/Cargo.toml
+++ b/xtasks/xtask-package-build/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "xtask-package-build"
+description = "Utility to package the build of Packit."
+version = "0.0.0"
+publish = false
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+clap = { version = "4.6.0", features = ["derive"] }
+tar = "0.4.45"
+flate2 = "1.1.9"

--- a/xtasks/xtask-package-build/src/compress.rs
+++ b/xtasks/xtask-package-build/src/compress.rs
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: GPL-3.0-only
+/*
+ * Adapted from the Packit packager module, to use less dependencies and make it suitable for xtask execution.
+ */
+
+#[cfg(target_family = "unix")]
+use std::os::unix::fs::PermissionsExt;
+use std::{
+    fs::{self, File},
+    io,
+    path::PathBuf,
+};
+
+use flate2::{Compression, GzBuilder, write::GzEncoder};
+use tar::{Builder, EntryType, Header};
+
+/// Compresses a given directory using a normalized tar and returns the compressed bytes.
+pub fn compress(source_directory: &PathBuf, top_directory_name: &str) -> std::io::Result<Vec<u8>> {
+    let buffer = Vec::new();
+    let encoder = GzBuilder::new().mtime(0).write(buffer, Compression::default());
+
+    // Add the whole directory recursively
+    let mut tar_builder = Builder::new(encoder);
+    let tar_path = PathBuf::from(".").join(top_directory_name);
+    create_normalized_tar(&mut tar_builder, &tar_path, source_directory)?;
+    tar_builder.finish()?;
+
+    // Build tar into bytes vec
+    let encoder = tar_builder.into_inner()?;
+    let encoded = encoder.finish()?;
+
+    Ok(encoded)
+}
+
+/// Creates a normalized tar by recursively adding files to the tar from a given directory while maintaining the directory structure.
+fn create_normalized_tar(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> std::io::Result<()> {
+    add_directory(builder, tar_path, file_path)?;
+
+    // Get directory entries
+    let mut entries = Vec::new();
+    for entry in fs::read_dir(file_path)? {
+        let entry = entry?;
+        entries.push(entry.path());
+    }
+
+    // Sort the entries for deterministic behaviour
+    entries.sort();
+
+    // Add to tar file recursively
+    for entry in entries {
+        let filename = entry.file_name().expect("Expected a valid path termination");
+        let filename = filename.to_str().ok_or(io::Error::new(
+            io::ErrorKind::InvalidFilename,
+            "Filename contains invalid unicode character.",
+        ))?;
+
+        // Add symlink to tar
+        if entry.is_symlink() {
+            add_symlink(builder, &tar_path.join(filename), &entry)?;
+            continue;
+        }
+
+        // Add directory to tar
+        if entry.is_dir() {
+            create_normalized_tar(builder, &tar_path.join(filename), &entry)?;
+            continue;
+        }
+
+        // Add file to tar
+        if entry.is_file() {
+            add_file(builder, &tar_path.join(filename), &entry)?;
+            continue;
+        }
+    }
+
+    Ok(())
+}
+
+/// Adds a normalized directory to a tar file.
+fn add_directory(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> std::io::Result<()> {
+    // Create directory header
+    let mut header = Header::new_ustar();
+    header.set_entry_type(EntryType::Directory);
+    normalize_header(&mut header, 0, tar_path, file_path)?;
+
+    // Add directory to builder
+    builder.append_data(&mut header, tar_path, io::empty())?;
+
+    Ok(())
+}
+
+/// Adds a normalized file to a tar file.
+fn add_file(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> std::io::Result<()> {
+    let file = File::open(file_path)?;
+
+    // Create regular file header
+    let mut header = Header::new_ustar();
+    header.set_entry_type(EntryType::Regular);
+    normalize_header(&mut header, file.metadata()?.len(), tar_path, file_path)?;
+
+    // Add file to builder
+    builder.append_data(&mut header, tar_path, file)?;
+
+    Ok(())
+}
+
+/// Adds a normalized symlink to a tar file.
+fn add_symlink(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> std::io::Result<()> {
+    let target = fs::read_link(file_path)?;
+
+    // Create symlink header
+    let mut header = Header::new_ustar();
+    header.set_entry_type(EntryType::Symlink);
+    normalize_header(&mut header, 0, tar_path, file_path)?;
+
+    // Add symlink to builder
+    builder.append_link(&mut header, tar_path, target)?;
+
+    Ok(())
+}
+
+/// Normalizes a tar header. Most fields are set to zero. The data length and path fields are set based on
+/// the given parameters. The mode field is set based on the entry type of the existing/given header.
+#[cfg_attr(target_os = "windows", expect(unused_variables))] // Ignore unused file_path variable on windows
+fn normalize_header(header: &mut Header, data_length: u64, tar_path: &PathBuf, file_path: &PathBuf) -> std::io::Result<()> {
+    #[cfg(target_family = "unix")]
+    {
+        // For symlink do symlink_metadata() instead of metadata()
+        let mode = match header.entry_type() == EntryType::Symlink {
+            true => fs::symlink_metadata(file_path)?.permissions().mode(),
+            false => fs::metadata(file_path)?.permissions().mode(),
+        };
+        header.set_mode(mode);
+    }
+
+    header.set_size(data_length);
+    header.set_uid(0);
+    header.set_gid(0);
+    header.set_mtime(0);
+    header.set_path(tar_path)?;
+
+    // Reset header checksum
+    header.set_cksum();
+
+    Ok(())
+}

--- a/xtasks/xtask-package-build/src/main.rs
+++ b/xtasks/xtask-package-build/src/main.rs
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0-only
+mod compress;
+mod target_architecture;
+
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::exit,
+};
+
+use clap::Parser;
+
+use crate::target_architecture::TARGET_ARCHITECTURE;
+
+/// Represents the package-build command, holding the given options.
+#[derive(Parser, Debug)]
+#[command(name = "package-build", version, about)]
+pub struct TaskCommand {
+    /// The directory to save the package to
+    #[arg(long)]
+    destination: Option<PathBuf>,
+
+    /// True if the package should be overwritten if it already exists
+    #[arg(short, long, default_value = "false")]
+    overwrite: bool,
+}
+
+const PACKIT_VERSION: &str = "0.0.2";
+const PACKIT_REVISION: &str = "0";
+
+fn main() {
+    let command = TaskCommand::parse();
+
+    // Check if build exists
+    let source = get_target_path().join("build");
+    if !source.exists() {
+        eprintln!("Failed to find Packit build, please make sure to run cargo build-install before packaging");
+        exit(1);
+    }
+
+    // Retrieve destination
+    let destination = command.destination.unwrap_or(get_target_path());
+    let destination = match std::path::absolute(destination) {
+        Ok(path) => path,
+        Err(e) => {
+            eprintln!("Failed to convert destination directory to absolute path");
+            eprintln!("Error: {e}");
+            exit(1);
+        },
+    };
+
+    // Check if package already exists
+    let package_name = format!("packit@{PACKIT_VERSION}-{PACKIT_REVISION}-{TARGET_ARCHITECTURE}");
+    let package_file_name = format!("{package_name}.tar.gz");
+    let archive_destination = destination.join(&package_file_name);
+    if !command.overwrite && archive_destination.exists() {
+        eprintln!("The package already exists, please remove it first or specifiy the -o option");
+        exit(1);
+    }
+
+    // Compress build
+    let bytes = match compress::compress(&source, &package_name) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            eprintln!("Failed to compress build");
+            eprintln!("Error: {e}");
+            exit(1);
+        },
+    };
+
+    // Write archive to destination
+    if let Err(e) = fs::write(archive_destination, bytes) {
+        eprintln!("Failed to write compressed build to destination");
+        eprintln!("Error: {e}");
+        exit(1);
+    }
+
+    println!("Finished packaging Packit to {}", destination.display())
+}
+
+/// Gets the path to the project root directory.
+fn get_project_root_path() -> PathBuf {
+    Path::new(std::env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("Expected CARGO_MANIFEST_DIR to return the xtask-package-build directory path.")
+        .to_path_buf()
+}
+
+/// Gets the target directory path in the project root.
+fn get_target_path() -> PathBuf {
+    get_project_root_path().join("target")
+}

--- a/xtasks/xtask-package-build/src/main.rs
+++ b/xtasks/xtask-package-build/src/main.rs
@@ -54,7 +54,7 @@ fn main() {
     let package_file_name = format!("{package_name}.tar.gz");
     let archive_destination = destination.join(&package_file_name);
     if !command.overwrite && archive_destination.exists() {
-        eprintln!("The package already exists, please remove it first or specifiy the -o option");
+        eprintln!("The package already exists, please remove it first or specify the --overwrite option");
         exit(1);
     }
 

--- a/xtasks/xtask-package-build/src/target_architecture.rs
+++ b/xtasks/xtask-package-build/src/target_architecture.rs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0-only
+#[cfg(target_os = "macos")]
+#[cfg(target_arch = "x86_64")]
+pub const TARGET_ARCHITECTURE: &str = "x86_64-apple-darwin";
+
+#[cfg(target_os = "macos")]
+#[cfg(target_arch = "aarch64")]
+pub const TARGET_ARCHITECTURE: &str = "aarch64-apple-darwin";
+
+#[cfg(target_os = "linux")]
+#[cfg(target_arch = "aarch64")]
+#[cfg(target_env = "gnu")]
+pub const TARGET_ARCHITECTURE: &str = "aarch64-unknown-linux-gnu";
+
+#[cfg(target_os = "linux")]
+#[cfg(target_arch = "x86_64")]
+#[cfg(target_env = "gnu")]
+pub const TARGET_ARCHITECTURE: &str = "x86_64-unknown-linux-gnu";
+
+#[cfg(target_os = "linux")]
+#[cfg(target_arch = "x86_64")]
+#[cfg(target_env = "musl")]
+pub const TARGET_ARCHITECTURE: &str = "x86_64-unknown-linux-musl";
+
+#[cfg(target_os = "windows")]
+#[cfg(target_arch = "x86_64")]
+#[cfg(target_env = "msvc")]
+pub const TARGET_ARCHITECTURE: &str = "x86_64-pc-windows-msvc";
+
+#[cfg(target_os = "windows")]
+#[cfg(target_arch = "aarch64")]
+#[cfg(target_env = "msvc")]
+pub const TARGET_ARCHITECTURE: &str = "aarch64-pc-windows-msvc";


### PR DESCRIPTION
This PR adds the package-build xtask, packaging the most recent build into a prebuild. For compressing the existing packager module is copied and minified to use less dependencies and be compressed in the correct structure as expected by the install scripts.