### PR TITLE
Fix multiple repositories issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
 
+### Fixed
+- Fix package not found issue when multiple repositories have the same package but different versions.
+
 
 ## [v0.0.2](https://github.com/pack-it/packit/compare/0.0.1...0.0.2) - 2026-05-14
 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -98,7 +98,7 @@ impl SearchArgs {
         };
 
         // Create a package id
-        let package_id = optional_id.versioned_or(package_version.version.clone());
+        let package_id = optional_id.versioned_or_cloned(&package_version.version);
 
         let target_bounds = package_version
             .get_best_target(&Target::current())

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -75,7 +75,7 @@ impl SearchArgs {
 
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let (repository_id, package) = match manager.read_package(&optional_id.name) {
+        let (repository_id, package, package_version) = match manager.read_package_and_version(&optional_id, &Target::current()) {
             Ok(package) => package,
             Err(RepositoryError::PackageNotFoundError { .. }) => not_found::repository_package(&optional_id.name, &manager, &config),
             Err(e) => {
@@ -99,15 +99,6 @@ impl SearchArgs {
 
         // Create a package id
         let package_id = optional_id.versioned_or_cloned(latest_version);
-
-        // Get package version info for its target
-        let package_version = match manager.read_repo_package_version(&repository_id, &package_id) {
-            Ok(package_version) => package_version,
-            Err(e) => {
-                error!(e, "Cannot read '{package_id}' from repository {repository_id}");
-                return;
-            },
-        };
 
         let target_bounds = package_version
             .get_best_target(&Target::current())

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -98,7 +98,7 @@ impl SearchArgs {
         };
 
         // Create a package id
-        let package_id = optional_id.versioned_or_cloned(latest_version);
+        let package_id = optional_id.versioned_or(package_version.version.clone());
 
         let target_bounds = package_version
             .get_best_target(&Target::current())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -68,21 +68,24 @@ impl<'a> Installer<'a> {
             return Err(InstallerError::PermissionsError);
         }
 
-        let (repository_id, package_metadata) = self.repository_manager.read_package(&optional_id.name)?;
-        let latest_version = package_metadata.get_latest_version(&Target::current())?;
+        // Read package and version metadata
+        let (repository_id, package_metadata, version_metadata) =
+            self.repository_manager.read_package_and_version(&optional_id, &Target::current())?;
 
         // Create a package id of the current package
-        let package_id = optional_id.versioned_or_cloned(latest_version);
+        let version = &version_metadata.version;
+        let package_id = optional_id.versioned_or(version.clone());
+
+        // Check if this package version is already installed
+        if self.register.get_package_version(&package_id).is_some() {
+            return Err(InstallerError::AlreadyInstalledError { package_id });
+        }
 
         // If the version isn't specified check if a package with this package name is already installed (otherwise a user can get two different version installed without knowing)
         if optional_id.version.is_none() {
-            if let Some(package) = self.register.get_package(&optional_id.name) {
-                if package.get_package_version(latest_version).is_some() {
-                    return Err(InstallerError::AlreadyInstalledError { package_id });
-                }
-
+            if self.register.get_package(&optional_id.name).is_some() {
                 let question = format!(
-                    "The package '{optional_id}' is already installed, but a newer version '{latest_version}' is available. Do you wish to install the latest version as well?"
+                    "The package '{optional_id}' is already installed, but a newer version '{version}' is available. Do you wish to install the latest version as well?"
                 );
                 if ask_user(&question, QuestionResponse::No)?.is_no_or_invalid() {
                     return Err(InstallerError::InstallationCanceled {
@@ -104,16 +107,8 @@ impl<'a> Installer<'a> {
             self.options.install_type = InstallType::BuildAll;
         }
 
-        // Check if this package version is already installed
-        if self.register.get_package_version(&package_id).is_some() {
-            return Err(InstallerError::AlreadyInstalledError { package_id });
-        }
-
-        // Get package version info
-        let version_metadata = self.repository_manager.read_repo_package_version(&repository_id, &package_id)?;
+        // Create flattened dependency sequence
         let target_bounds = version_metadata.get_best_target(&Target::current())?;
-
-        // Create flattend dependency sequence
         let root_meta = InstallMeta {
             package_metadata,
             version_metadata,

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -74,7 +74,7 @@ impl<'a> Installer<'a> {
 
         // Create a package id of the current package
         let version = &version_metadata.version;
-        let package_id = optional_id.versioned_or(version.clone());
+        let package_id = optional_id.versioned_or_cloned(version);
 
         // Check if this package version is already installed
         if self.register.get_package_version(&package_id).is_some() {
@@ -82,16 +82,14 @@ impl<'a> Installer<'a> {
         }
 
         // If the version isn't specified check if a package with this package name is already installed (otherwise a user can get two different version installed without knowing)
-        if optional_id.version.is_none() {
-            if self.register.get_package(&optional_id.name).is_some() {
-                let question = format!(
-                    "The package '{optional_id}' is already installed, but a newer version '{version}' is available. Do you wish to install the latest version as well?"
-                );
-                if ask_user(&question, QuestionResponse::No)?.is_no_or_invalid() {
-                    return Err(InstallerError::InstallationCanceled {
-                        reason: "A version of this package was already installed".to_string(),
-                    });
-                }
+        if optional_id.version.is_none() && self.register.get_package(&optional_id.name).is_some() {
+            let question = format!(
+                "The package '{optional_id}' is already installed, but a newer version '{version}' is available. Do you wish to install the latest version as well?"
+            );
+            if ask_user(&question, QuestionResponse::No)?.is_no_or_invalid() {
+                return Err(InstallerError::InstallationCanceled {
+                    reason: "A version of this package was already installed".to_string(),
+                });
             }
         }
 

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -7,7 +7,7 @@ use crate::{
     cli::display::logging::{debug, error, warning},
     config::Config,
     installer::{
-        types::{PackageId, PackageName},
+        types::{OptionalPackageId, PackageId, PackageName},
         unpack::ArchiveExtension,
     },
     platforms::Target,
@@ -63,6 +63,36 @@ impl<'a> RepositoryManager<'a> {
             config,
             metadata_providers,
             prebuild_providers,
+        }
+    }
+
+    /// Reads package and package version metadata of the given package. When the package is only a name, the latest version is read.
+    /// Returns the repository id, package metadata and package version metadata.
+    /// Returns a `PackageNotFoundError` if the package canot be found.
+    pub fn read_package_and_version(
+        &self,
+        package: &OptionalPackageId,
+        target: &Target,
+    ) -> Result<(String, PackageMeta, PackageVersionMeta)> {
+        match package.versioned() {
+            Some(package_id) => {
+                // Read package version metadata first, then the according package
+                let (repository_id, version_metadata) = self.read_package_version(&package_id, target)?;
+                let package_metadata = self.read_repo_package(&repository_id, &package_id.name)?;
+
+                Ok((repository_id, package_metadata, version_metadata))
+            },
+            None => {
+                // Read package metadata first
+                let (repository_id, package_metadata) = self.read_package(&package.name)?;
+
+                // Read latest version package version metadata
+                let latest_version = package_metadata.get_latest_version(target)?;
+                let package_id = PackageId::new(package.name.clone(), latest_version.clone());
+                let version_metadata = self.read_repo_package_version(&repository_id, &package_id)?;
+
+                Ok((repository_id, package_metadata, version_metadata))
+            },
         }
     }
 


### PR DESCRIPTION
This PR fixes issues regarding the use of multiple repositories. When searching or installing a version which is not in the repository that is first in the rank, the next repository is checked now. This ensures the package is recognized succesfully.