### PR TITLE
Column order grid print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
+- The list command now uses column order grid printing instead of row order.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.

--- a/src/cli/display/grid.rs
+++ b/src/cli/display/grid.rs
@@ -32,10 +32,12 @@ where
     // Print the items in the grid
     for i in 0..row_count {
         for j in 0..column_count {
-            if let Some(item) = items.get(i * column_count + j) {
+            if let Some(item) = items.get(j * row_count + i) {
                 let current_length = item.to_string().len();
                 let padding = " ".repeat(column_width - current_length);
                 print!("{item}{padding}");
+            } else {
+                print!("{}", " ".repeat(column_width))
             }
         }
 


### PR DESCRIPTION
This fixes the print order in the grid print, using a column order instead of a row order.