### PR TITLE
Add list --active command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.
+- Fix `--updatables` flag listing older installed package versions when a newer up-to-date version is installed.
 
 
 ## [v0.0.2](https://github.com/pack-it/packit/compare/0.0.1...0.0.2) - 2026-05-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - Support for loading non-text external test files.
+- The `--active` flag for the list command, to list all active packages.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -14,8 +14,12 @@ use crate::{
 #[derive(Args, Debug)]
 pub struct ListArgs {
     /// List updatables packages
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value = "false", conflicts_with = "active")]
     pub updatables: bool,
+
+    /// List active packages
+    #[arg(long, default_value = "false", conflicts_with = "updatables")]
+    pub active: bool,
 }
 
 impl HandleCommand for ListArgs {
@@ -27,13 +31,26 @@ impl HandleCommand for ListArgs {
         let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();
         packages.sort_by_key(|a| a.package_id.to_string());
 
-        if !self.updatables {
-            display::print_grid(packages.iter().map(|p| &p.package_id).collect());
+        if self.updatables {
+            self.updatables_list(packages, &config);
 
             return;
         }
 
-        let manager = RepositoryManager::new(&config);
+        if self.active {
+            display::print_grid(register.iterate_active_packages().collect());
+
+            return;
+        }
+
+        display::print_grid(packages.iter().map(|p| &p.package_id).collect());
+    }
+}
+
+impl ListArgs {
+    /// Lists all updatable packages.
+    fn updatables_list(&self, packages: Vec<&InstalledPackageVersion>, config: &Config) {
+        let manager = RepositoryManager::new(config);
         let mut updatables = Vec::new();
         for package in packages {
             let (_, package_meta) = manager.read_package(&package.package_id.name).unwrap_or_exit(1);

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -4,6 +4,7 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display},
     config::Config,
+    installer::types::PackageId,
     platforms::Target,
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::manager::RepositoryManager,
@@ -28,11 +29,8 @@ impl HandleCommand for ListArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();
-        packages.sort_by_key(|a| a.package_id.to_string());
-
         if self.updatables {
-            self.updatables_list(packages, &config);
+            self.updatables_list(&config, &register);
 
             return;
         }
@@ -43,24 +41,30 @@ impl HandleCommand for ListArgs {
             return;
         }
 
+        let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();
+        packages.sort_by_key(|a| a.package_id.to_string());
         display::print_grid(packages.iter().map(|p| &p.package_id).collect());
     }
 }
 
 impl ListArgs {
     /// Lists all updatable packages.
-    fn updatables_list(&self, packages: Vec<&InstalledPackageVersion>, config: &Config) {
+    fn updatables_list(&self, config: &Config, register: &PackageRegister) {
         let manager = RepositoryManager::new(config);
         let mut updatables = Vec::new();
-        for package in packages {
-            let (_, package_meta) = manager.read_package(&package.package_id.name).unwrap_or_exit(1);
-            let latest_version = package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1);
+        for (package_name, package) in register.iterate_packages() {
+            let (_, package_meta) = manager.read_package(&package_name).unwrap_or_exit(1);
+            let latest_available_version = package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1);
 
-            if *latest_version == package.package_id.version {
+            // Get the latest installed version
+            let latest_installed_version = package.versions.keys().max().expect("Expected a latest installed version");
+
+            // Check if the latest version exists
+            if latest_available_version == latest_installed_version {
                 continue;
             }
 
-            updatables.push(&package.package_id);
+            updatables.push(PackageId::new(package_name.clone(), latest_installed_version.clone()));
         }
 
         if updatables.is_empty() {

--- a/src/register/package_register.rs
+++ b/src/register/package_register.rs
@@ -312,6 +312,11 @@ impl PackageRegister {
         self.packages.keys()
     }
 
+    /// Returns an iterator, which iterates over all package names and values.
+    pub fn iterate_packages(&self) -> impl Iterator<Item = (&PackageName, &InstalledPackage)> {
+        self.packages.iter()
+    }
+
     /// Returns an iterator, which iterates over all active packages.
     pub fn iterate_active_packages(&self) -> impl Iterator<Item = PackageId> {
         self.packages.iter().map(|(name, p)| PackageId::new(name.clone(), p.active_version.clone()))

--- a/src/register/package_register.rs
+++ b/src/register/package_register.rs
@@ -307,9 +307,14 @@ impl PackageRegister {
         self.packages.values().flat_map(|p| p.versions.values())
     }
 
-    /// Returns an iterator, which iterates over all package names
+    /// Returns an iterator, which iterates over all package names.
     pub fn iterate_package_names(&self) -> impl Iterator<Item = &PackageName> {
         self.packages.keys()
+    }
+
+    /// Returns an iterator, which iterates over all active packages.
+    pub fn iterate_active_packages(&self) -> impl Iterator<Item = PackageId> {
+        self.packages.iter().map(|(name, p)| PackageId::new(name.clone(), p.active_version.clone()))
     }
 }
 


### PR DESCRIPTION
This PR adds the `--active` flag to the `pit list` command, it lists all the active packages.
It also fixes the `--updatables` flag listing older installed package versions when a newer up-to-date version is installed.