### PR TITLE
Extend patch implementation to support context and unified diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - Support for loading non-text external test files.
 - The `--active` flag for the list command, to list all active packages.
+- Support for context (using our [`contextdiff-parser`](https://github.com/pack-it/contextdiff-parser)) and unified diff formats for patches.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
 - The list command now uses column order grid printing instead of row order.
+- The patch apply process now uses a more advanced file path resolver, which ensures better patch compatibility.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.
 - Fix `--updatables` flag listing older installed package versions when a newer up-to-date version is installed.
+- Fix checksum check for patch files that are downloaded from the metadata repository.
 
 
 ## [v0.0.2](https://github.com/pack-it/packit/compare/0.0.1...0.0.2) - 2026-05-14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -305,6 +305,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +420,14 @@ name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "contextdiff-parser"
+version = "0.0.1"
+dependencies = [
+ "chrono",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1658,6 +1675,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "contextdiff-parser",
  "diffy",
  "enable-ansi-support",
  "flate2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,6 +424,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 [[package]]
 name = "contextdiff-parser"
 version = "0.0.1"
+source = "git+https://github.com/pack-it/contextdiff-parser.git#106ca54e79651e8709e87435bc0a9e41a45ba4d8"
 dependencies = [
  "chrono",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ url = "2.5.8"
 toml_edit = "0.25.11"
 terminal_size = "0.4.4"
 diffy = { version = "0.5.0", features = ["binary"] }
+contextdiff-parser = { path = "../contextdiff-parser" }
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ url = "2.5.8"
 toml_edit = "0.25.11"
 terminal_size = "0.4.4"
 diffy = { version = "0.5.0", features = ["binary"] }
-contextdiff-parser = { path = "../contextdiff-parser" }
+contextdiff-parser = { git = "https://github.com/pack-it/contextdiff-parser.git" }
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -130,7 +130,7 @@ impl<'a> Builder<'a> {
             };
 
             // Apply patch
-            patches::apply_patch(&patch_bytes, &apply_directory)?;
+            patches::apply_patch(patch_bytes, &apply_directory)?;
 
             println!("Applied patch '{id}' to '{package_id}'");
         }
@@ -195,6 +195,14 @@ impl<'a> Builder<'a> {
             .repository_manager
             .read_file_bytes(repository_id, &package_id.name, &patch.url)?
             .ok_or(BuilderError::RepositoryPatchNotFound)?;
+
+        // Calculate the checksum
+        let calculated_checksum = Checksum::from_bytes(&file);
+
+        // Check equality of checksum
+        if patch.checksum != calculated_checksum {
+            return Err(BuilderError::ChecksumError);
+        }
 
         // Finish download spinner
         spinner.finish(format!(

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::Path, str::Utf8Error};
+use std::{
+    fs,
+    path::{self, Path, PathBuf},
+    str::Utf8Error,
+};
 
 #[cfg(unix)]
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
@@ -99,4 +103,33 @@ pub fn directory_is_empty(directory: &Path) -> Result<bool, std::io::Error> {
     }
 
     Ok(true)
+}
+
+/// Normalizes a path by resolving current and parent dir operators.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+
+    for component in path.components() {
+        match &component {
+            std::path::Component::ParentDir => {
+                if let Some(path::Component::Normal(_)) = components.last() {
+                    components.pop();
+                    continue;
+                }
+
+                components.push(component);
+            },
+            std::path::Component::CurDir => (),
+            std::path::Component::Prefix(_) | std::path::Component::RootDir | std::path::Component::Normal(_) => {
+                components.push(component);
+            },
+        }
+    }
+
+    let mut path = PathBuf::new();
+    for component in components {
+        path.push(component.as_os_str());
+    }
+
+    path
 }

--- a/src/utils/patches.rs
+++ b/src/utils/patches.rs
@@ -54,7 +54,7 @@ pub enum PatchFormat {
     Unknown,
 }
 
-// Applies the given patch to the given directory directory.
+/// Applies the given patch to the given directory directory.
 pub fn apply_patch(patch: Bytes, directory: &Path) -> Result<()> {
     // Detect the format of the patch
     let patch_format = detect_patch_format(&patch)?;
@@ -94,7 +94,7 @@ pub fn apply_patch(patch: Bytes, directory: &Path) -> Result<()> {
     Ok(())
 }
 
-// Handles the file operation to apply the different patch operations.
+/// Handles the file operation to apply the different patch operations.
 fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]>, directory: &Path) -> Result<()> {
     match operation {
         FileOperation::Create(path) => {
@@ -112,7 +112,12 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
         FileOperation::Modify { original, modified } => {
             let source = create_path(directory, original)?;
             let destination = create_path(directory, modified)?;
-            debug!("Modifying file '{}' to '{}'", source.display(), destination.display());
+            let (source, destination) = resolve_paths(&source, &destination);
+            if source == destination {
+                debug!("Modifying file '{}'", source.display());
+            } else {
+                debug!("Modifying file '{}' to '{}'", source.display(), destination.display());
+            }
 
             apply_path(patch.patch(), Some(&source), &destination)?;
 
@@ -124,6 +129,7 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
         FileOperation::Rename { from, to } => {
             let source = create_path(directory, from)?;
             let destination = create_path(directory, to)?;
+            let (source, destination) = resolve_paths(&source, &destination);
             debug!("Renaming file '{}' to '{}'", source.display(), destination.display());
 
             if let Some(parent) = destination.parent() {
@@ -135,6 +141,7 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
         FileOperation::Copy { from, to } => {
             let source = create_path(directory, from)?;
             let destination = create_path(directory, to)?;
+            let (source, destination) = resolve_paths(&source, &destination);
             debug!("Copying file '{}' to '{}'", source.display(), destination.display());
 
             if let Some(parent) = destination.parent() {
@@ -148,14 +155,34 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
     Ok(())
 }
 
-// Creates a path for the patch by parsing the path from bytes and appending it to the given directory.
+/// Creates a path for the patch by parsing the path from bytes and appending it to the given directory.
 fn create_path(directory: &Path, patch_path: &[u8]) -> Result<PathBuf> {
     let path = directory.join(io::parse_path_from_bytes(patch_path)?);
     Ok(io::normalize_path(&path))
 }
 
-// Applies a text or binary patch to a file. The source argument can be none, to use no original file
-fn apply_path(patch: &PatchKind<[u8]>, source: Option<&PathBuf>, destination: &PathBuf) -> Result<()> {
+/// Resolves the source and destination paths to a full pair with an existing source.
+fn resolve_paths<'a>(source: &'a Path, destination: &'a Path) -> (&'a Path, &'a Path) {
+    // If the source does not exist and the destination does exist, check if we can assume same file
+    if !source.exists() && destination.exists() {
+        if let Some(source_file) = source.file_name()
+            && let Some(destination_file) = destination.file_name()
+            && source_file == destination_file
+        {
+            debug!("Detected non-existing source file, but destination with same filename exists, using destination as source");
+            debug!("Non-existant source file: {}", source.display());
+
+            // If the source does not exist, but the destination does and the file names are the same,
+            // assume the source and destination are the same file.
+            return (destination, destination);
+        }
+    }
+
+    (source, destination)
+}
+
+/// Applies a text or binary patch to a file. The source argument can be none, to use no original file
+fn apply_path(patch: &PatchKind<[u8]>, source: Option<&Path>, destination: &Path) -> Result<()> {
     if matches!(patch, PatchKind::Binary(BinaryPatch::Marker)) {
         warning!("Patch has a binary patch marker, but does not contain any data");
         return Ok(());

--- a/src/utils/patches.rs
+++ b/src/utils/patches.rs
@@ -12,12 +12,15 @@ use diffy::{
 };
 use thiserror::Error;
 
-use crate::cli::display::logging::warning;
+use crate::cli::display::logging::{debug, warning};
 use crate::utils::io;
 
 /// The errors that occur while applying patches.
 #[derive(Error, Debug)]
 pub enum PatchError {
+    #[error("Unknown patch format")]
+    UnknownPatchFormat,
+
     #[error("Error while interacting with filesystem")]
     IoError(#[from] std::io::Error),
 
@@ -32,22 +35,57 @@ pub enum PatchError {
 
     #[error("Cannot apply patch")]
     PatchApplyError(#[from] diffy::ApplyError),
+
+    #[error("Patch is not a UTF-8 string")]
+    PatchNotUtf8(std::string::FromUtf8Error),
+
+    #[error("Cannot parse context diff")]
+    ContextDiffParseError(#[from] contextdiff_parser::parser::ParserError),
 }
 
 pub type Result<T> = std::result::Result<T, PatchError>;
 
-// Applies the given patch to the given directory directory.
-pub fn apply_patch(patch: &Bytes, directory: &Path) -> Result<()> {
-    let patches = PatchSet::parse_bytes(patch, ParseOptions::gitdiff());
+/// Represents the format of a patch.
+#[derive(Debug)]
+pub enum PatchFormat {
+    Context,
+    Git,
+    Unified,
+    Unknown,
+}
 
+// Applies the given patch to the given directory directory.
+pub fn apply_patch(patch: Bytes, directory: &Path) -> Result<()> {
+    // Detect the format of the patch
+    let patch_format = detect_patch_format(&patch)?;
+    debug!("Detected patch format: {patch_format:?}");
+
+    // Use correct parse options for patch format
+    let (patch, options) = match patch_format {
+        PatchFormat::Context => {
+            let patch_str = String::from_utf8(patch.to_vec()).map_err(PatchError::PatchNotUtf8)?;
+            let context_diff = contextdiff_parser::parser::parse_from_str(&patch_str)?;
+
+            debug!("Translating context diff to unified diff");
+            let unified_diff = contextdiff_parser::translator::translate_to_unified_diff(context_diff);
+
+            (unified_diff.into_bytes().into(), ParseOptions::unidiff())
+        },
+        PatchFormat::Git => (patch, ParseOptions::gitdiff()),
+        PatchFormat::Unified => (patch, ParseOptions::unidiff()),
+        PatchFormat::Unknown => return Err(PatchError::UnknownPatchFormat),
+    };
+
+    // Parse patch from bytes
+    let patches = PatchSet::parse_bytes(&patch, options);
     for file_patch in patches {
         let file_patch = file_patch?;
 
-        // Remove a and b prefixes from paths that do not come from the `Rename` or `Copy` operation
+        // Remove a and b prefixes from paths
         let operation = file_patch.operation();
-        let operation = match operation {
-            FileOperation::Rename { .. } | FileOperation::Copy { .. } => operation,
-            _ => &operation.strip_prefix(1),
+        let operation = match contains_git_prefix(operation) {
+            true => &operation.strip_prefix(1),
+            _ => operation,
         };
 
         handle_file_operation(operation, &file_patch, directory)?;
@@ -61,16 +99,20 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
     match operation {
         FileOperation::Create(path) => {
             let path = create_path(directory, path)?;
+            debug!("Creating file '{}'", path.display());
 
             apply_path(patch.patch(), None, &path)?;
         },
         FileOperation::Delete(path) => {
             let path = create_path(directory, path)?;
+            debug!("Deleting file '{}'", path.display());
+
             fs::remove_file(&path)?;
         },
         FileOperation::Modify { original, modified } => {
             let source = create_path(directory, original)?;
             let destination = create_path(directory, modified)?;
+            debug!("Modifying file '{}' to '{}'", source.display(), destination.display());
 
             apply_path(patch.patch(), Some(&source), &destination)?;
 
@@ -82,6 +124,7 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
         FileOperation::Rename { from, to } => {
             let source = create_path(directory, from)?;
             let destination = create_path(directory, to)?;
+            debug!("Renaming file '{}' to '{}'", source.display(), destination.display());
 
             if let Some(parent) = destination.parent() {
                 fs::create_dir_all(parent)?;
@@ -92,6 +135,7 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
         FileOperation::Copy { from, to } => {
             let source = create_path(directory, from)?;
             let destination = create_path(directory, to)?;
+            debug!("Copying file '{}' to '{}'", source.display(), destination.display());
 
             if let Some(parent) = destination.parent() {
                 fs::create_dir_all(parent)?;
@@ -106,7 +150,8 @@ fn handle_file_operation(operation: &FileOperation<[u8]>, patch: &FilePatch<[u8]
 
 // Creates a path for the patch by parsing the path from bytes and appending it to the given directory.
 fn create_path(directory: &Path, patch_path: &[u8]) -> Result<PathBuf> {
-    Ok(directory.join(io::parse_path_from_bytes(patch_path)?))
+    let path = directory.join(io::parse_path_from_bytes(patch_path)?);
+    Ok(io::normalize_path(&path))
 }
 
 // Applies a text or binary patch to a file. The source argument can be none, to use no original file
@@ -133,4 +178,74 @@ fn apply_path(patch: &PatchKind<[u8]>, source: Option<&PathBuf>, destination: &P
     fs::write(destination, patched)?;
 
     Ok(())
+}
+
+/// Detect the format of the given patch.
+fn detect_patch_format(patch: &Bytes) -> Result<PatchFormat> {
+    let mut found_git_header = false;
+
+    let mut found_unified_from = false;
+    let mut found_unified_to = false;
+    let mut found_unified_hunk = false;
+
+    let mut found_context_from_hunk = false;
+    let mut found_context_to_hunk = false;
+    let mut found_context_hunk_separator = false;
+
+    for line in patch.split(|&b| b == b'\n') {
+        let line = match line.ends_with(b"\r") {
+            true => &line[..line.len() - 1],
+            false => line,
+        };
+
+        if line.starts_with(b"diff --git ") {
+            found_git_header = true;
+        }
+
+        if line.starts_with(b"--- ") && !line.ends_with(b" ----") {
+            found_unified_from = true;
+        }
+        if line.starts_with(b"+++ ") {
+            found_unified_to = true;
+        }
+        if line.starts_with(b"@@ ") {
+            found_unified_hunk = true;
+        }
+
+        if line.starts_with(b"*** ") && line.ends_with(b" ****") {
+            found_context_from_hunk = true;
+        }
+        if line.starts_with(b"--- ") && line.ends_with(b" ----") {
+            found_context_to_hunk = true;
+        }
+        if line == b"***************" {
+            found_context_hunk_separator = true;
+        }
+    }
+
+    if found_git_header {
+        return Ok(PatchFormat::Git);
+    }
+
+    if found_unified_from && found_unified_to && found_unified_hunk {
+        return Ok(PatchFormat::Unified);
+    }
+
+    if found_context_from_hunk && found_context_to_hunk && found_context_hunk_separator {
+        return Ok(PatchFormat::Context);
+    }
+
+    Ok(PatchFormat::Unknown)
+}
+
+/// Checks if a file operation contains git `a/` and `b/` prefixes.
+fn contains_git_prefix(operation: &FileOperation<[u8]>) -> bool {
+    match operation {
+        FileOperation::Delete(path) if path.starts_with(b"a/") => true,
+        FileOperation::Create(path) if path.starts_with(b"b/") => true,
+        FileOperation::Modify { original, modified } if original.starts_with(b"a/") && modified.starts_with(b"b/") => true,
+        FileOperation::Rename { from, to } if from.starts_with(b"a/") && to.starts_with(b"b/") => true,
+        FileOperation::Copy { from, to } if from.starts_with(b"a/") && to.starts_with(b"b/") => true,
+        _ => false,
+    }
 }


### PR DESCRIPTION
This PR extends the patch implementation to support applying context diffs and unified diffs.
It also fixes the bug that patch files stored in the metadata repository were not verified with the checksum.
A better file path resolution algorithm is implemented to support a wider range of patches.