### PR TITLE
Refactor tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
 - The list command now uses column order grid printing instead of row order.
 - The patch apply process now uses a more advanced file path resolver, which ensures better patch compatibility.
+- The install tree is now fully expanded before installation, making it clearer what will be installed.
+- Trees now perform a check for cycles, throwing an error if they detect one.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,13 +19,13 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.8.4"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
- "cfg-if",
  "cipher",
- "cpufeatures 0.2.17",
+ "cpubits",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -88,26 +88,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.102"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
-
-[[package]]
-name = "aquamarine"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f50776554130342de4836ba542aa85a4ddb361690d7e8df13774d7284c3d5c2"
-dependencies = [
- "include_dir",
- "itertools",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,55 +95,15 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
-
-[[package]]
-name = "autocxx"
-version = "0.26.0"
-source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
-dependencies = [
- "aquamarine",
- "autocxx-macro",
- "cxx",
- "moveit",
-]
-
-[[package]]
-name = "autocxx-macro"
-version = "0.26.0"
-source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
-dependencies = [
- "autocxx-parser",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "autocxx-parser"
-version = "0.26.0"
-source = "git+https://github.com/romainthomas/autocxx.git?branch=0.26.0#056f40c6c8cc345cd5537d4a2c9f7e10c1d178d7"
-dependencies = [
- "indexmap 1.9.3",
- "itertools",
- "log",
- "once_cell",
- "proc-macro2",
- "quote",
- "serde",
- "serde_json",
- "syn 2.0.117",
- "thiserror 1.0.69",
-]
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -171,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -207,63 +147,37 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
-
-[[package]]
-name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
-version = "0.10.4"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+ "zeroize",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "bzip2"
@@ -276,21 +190,15 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
  "libc",
  "shlex",
 ]
-
-[[package]]
-name = "cesu8"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -315,19 +223,19 @@ dependencies = [
 
 [[package]]
 name = "cipher"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+checksum = "e8cf2a2c93cd704877c0858356ed03480ff301ee950b43f1cbe4573b088bfa6c"
 dependencies = [
- "crypto-common 0.1.7",
+ "crypto-common",
  "inout",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -347,14 +255,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -370,6 +278,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
+name = "codespan-reporting"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af491d569909a7e4dee0ad7db7f5341fef5c614d5b8ec8cf765732aba3cff681"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -427,7 +352,7 @@ version = "0.0.1"
 source = "git+https://github.com/pack-it/contextdiff-parser.git#106ca54e79651e8709e87435bc0a9e41a45ba4d8"
 dependencies = [
  "chrono",
- "thiserror 2.0.18",
+ "thiserror",
 ]
 
 [[package]]
@@ -457,13 +382,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "cpufeatures"
-version = "0.2.17"
+name = "cpubits"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
-dependencies = [
- "libc",
-]
+checksum = "15b85f9c39137c3a891689859392b1bd49812121d0d61c9caf00d46ed5ce06ae"
 
 [[package]]
 name = "cpufeatures"
@@ -484,57 +406,83 @@ dependencies = [
 ]
 
 [[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
-dependencies = [
- "generic-array",
- "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
 ]
 
 [[package]]
-name = "cxx"
-version = "1.0.117"
+name = "ctutils"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c15f3b597018782655a05d417f28bac009f6eb60f4b6703eb818998c1aaa16a"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d8437319e3a2f43d93b341c137927ca70c0f5dabeea7a005a73665e247c7e"
 dependencies = [
  "cc",
+ "cxx-build",
+ "cxxbridge-cmd",
  "cxxbridge-flags",
  "cxxbridge-macro",
+ "foldhash",
  "link-cplusplus",
 ]
 
 [[package]]
-name = "cxxbridge-flags"
-version = "1.0.117"
+name = "cxx-build"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7eb4c4fd18505f5a935f9c2ee77780350dcdb56da7cd037634e806141c5c43"
+checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-cmd"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
+dependencies = [
+ "clap",
+ "codespan-reporting",
+ "indexmap",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.194"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23384a836ab4f0ad98ace7e3955ad2de39de42378ab487dc28d3990392cb283a"
 
 [[package]]
 name = "cxxbridge-macro"
-version = "1.0.117"
+version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d914fcc6452d133236ee067a9538be25ba6a644a450e1a6c617da84bf029854"
+checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
+ "indexmap",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -548,9 +496,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "diffy"
@@ -558,41 +503,32 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05264ab2aab4fb952fc4b0f3f6eff1ddfb4563064053a4ea174d91537584a769"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown",
  "zlib-rs",
 ]
 
 [[package]]
 name = "digest"
-version = "0.10.7"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer 0.10.4",
- "crypto-common 0.1.7",
- "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4850db49bf08e663084f7fb5c87d202ef91a3907271aff24a94eb97ff039153c"
-dependencies = [
- "block-buffer 0.12.0",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.2.1",
+ "crypto-common",
+ "ctutils",
+ "zeroize",
 ]
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -600,12 +536,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "either"
-version = "1.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "enable-ansi-support"
@@ -655,13 +585,12 @@ checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "filetime"
-version = "0.2.27"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
 dependencies = [
  "cfg-if",
  "libc",
- "libredox",
 ]
 
 [[package]]
@@ -686,12 +615,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -764,16 +687,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generic-array"
-version = "0.14.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
-dependencies = [
- "typenum",
- "version_check",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,16 +715,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
  "r-efi 6.0.0",
- "wasip2",
- "wasip3",
  "wasm-bindgen",
 ]
 
@@ -838,41 +749,22 @@ checksum = "53010ccb100b96a67bc32c0175f0ed1426b31b655d562898e57325f81c023ac0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "h2"
-version = "0.3.27"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.14.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
- "indexmap 2.14.0",
+ "http",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -881,26 +773,11 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.12.3"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
-
-[[package]]
-name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
-dependencies = [
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
@@ -910,12 +787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -923,43 +794,21 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
 name = "http"
-version = "0.2.12"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
-]
-
-[[package]]
-name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -969,7 +818,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http",
 ]
 
 [[package]]
@@ -980,8 +829,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -992,57 +841,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
-name = "httpdate"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
-
-[[package]]
 name = "hybrid-array"
-version = "0.4.10"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3944cf8cf766b40e2a1a333ee5e9b563f854d5fa49d6a8ca2764e97c6eddb214"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
 dependencies = [
  "typenum",
 ]
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
@@ -1053,30 +872,16 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
-dependencies = [
- "futures-util",
- "http 0.2.12",
- "hyper 0.14.32",
- "rustls 0.21.12",
- "tokio",
- "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-rustls"
 version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http",
+ "hyper",
  "hyper-util",
- "rustls 0.23.38",
+ "rustls",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower-service",
 ]
 
@@ -1086,19 +891,19 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "hyper 1.9.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
- "system-configuration 0.7.0",
+ "socket2",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -1187,12 +992,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1214,45 +1013,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "include_dir"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
-dependencies = [
- "include_dir_macros",
-]
-
-[[package]]
-name = "include_dir_macros"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1270,11 +1037,11 @@ dependencies = [
 
 [[package]]
 name = "inout"
-version = "0.1.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+checksum = "4250ce6452e92010fdf7268ccc5d14faa80bb12fc741938534c58f16804e03c7"
 dependencies = [
- "generic-array",
+ "hybrid-array",
 ]
 
 [[package]]
@@ -1282,27 +1049,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "is_ci"
@@ -1317,15 +1063,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1333,27 +1070,32 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
-version = "0.21.1"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
 dependencies = [
- "cesu8",
  "cfg-if",
  "combine",
- "jni-sys 0.3.1",
+ "jni-macros",
+ "jni-sys",
  "log",
- "thiserror 1.0.69",
+ "simd_cesu8",
+ "thiserror",
  "walkdir",
- "windows-sys 0.45.0",
+ "windows-link",
 ]
 
 [[package]]
-name = "jni-sys"
-version = "0.3.1"
+name = "jni-macros"
+version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
 dependencies = [
- "jni-sys 0.4.1",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn",
 ]
 
 [[package]]
@@ -1372,7 +1114,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1387,78 +1129,57 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "03d04c30968dffe80775bd4d7fb676131cd04a1fb46d2686dbffbaec2d9dfd31"
 dependencies = [
  "cfg-if",
  "futures-util",
- "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libbz2-rs-sys"
-version = "0.2.2"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c4a545a15244c7d945065b5d392b2d2d7f21526fba56ce51467b06ed445e8f7"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags 2.11.1",
- "libc",
- "plain",
- "redox_syscall",
-]
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "lief"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=1915b921dee222912880cfb8b1ddce0a00ca88cd#1915b921dee222912880cfb8b1ddce0a00ca88cd"
+source = "git+https://github.com/lief-project/LIEF.git#00341b040edda834dd5c001b0d2e4e019bae288f"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "cxx",
  "lief-ffi",
  "num-bigint",
  "num-derive",
  "num-traits",
- "tempfile",
 ]
 
 [[package]]
 name = "lief-build"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=1915b921dee222912880cfb8b1ddce0a00ca88cd#1915b921dee222912880cfb8b1ddce0a00ca88cd"
+source = "git+https://github.com/lief-project/LIEF.git#00341b040edda834dd5c001b0d2e4e019bae288f"
 dependencies = [
  "git-version",
  "miette",
- "reqwest 0.11.24",
+ "reqwest",
  "semver",
- "zip 0.6.6",
+ "zip 7.2.0",
 ]
 
 [[package]]
 name = "lief-ffi"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=1915b921dee222912880cfb8b1ddce0a00ca88cd#1915b921dee222912880cfb8b1ddce0a00ca88cd"
+source = "git+https://github.com/lief-project/LIEF.git#00341b040edda834dd5c001b0d2e4e019bae288f"
 dependencies = [
- "autocxx",
  "cxx",
  "lief-build",
  "miette",
@@ -1487,9 +1208,9 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru-slab"
@@ -1499,11 +1220,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lzma-rust2"
-version = "0.16.2"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47bb1e988e6fb779cf720ad431242d3f03167c1b3f2b1aae7f1a94b2495b36ae"
+checksum = "ce716bf1a316f47a280fc76295f6495b5bea4752bca01c3b3885e101b1c23c02"
 dependencies = [
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1519,40 +1240,38 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "miette"
-version = "5.10.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59bb584eaeeab6bd0226ccf3509a69d7936d148cf3d036ad350abe35e8c6856e"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
 dependencies = [
  "backtrace",
  "backtrace-ext",
- "is-terminal",
+ "cfg-if",
  "miette-derive",
- "once_cell",
  "owo-colors",
  "supports-color",
  "supports-hyperlinks",
  "supports-unicode",
- "terminal_size 0.1.17",
+ "terminal_size",
  "textwrap",
- "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
 
 [[package]]
 name = "miette-derive"
-version = "5.10.0"
+version = "7.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49e7bc1560b95a3c4a25d03de42fe76ca718ab92d1a22a55b9b4cf67b3ae635c"
+checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1573,22 +1292,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "moveit"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87d7335204cb6ef7bd647fa6db0be3e4d7aa25b5823a7aa030027ddf512cefba"
-dependencies = [
- "cxx",
 ]
 
 [[package]]
@@ -1603,9 +1313,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -1615,7 +1325,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1665,9 +1375,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "owo-colors"
-version = "3.5.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
 name = "packit"
@@ -1676,6 +1386,7 @@ dependencies = [
  "bytes",
  "clap",
  "colored",
+ "console",
  "contextdiff-parser",
  "diffy",
  "enable-ansi-support",
@@ -1685,29 +1396,29 @@ dependencies = [
  "libc",
  "lief",
  "regex",
- "reqwest 0.13.2",
+ "reqwest",
  "serde",
- "sha2 0.11.0",
+ "sha2",
  "tar",
  "tempfile",
- "terminal_size 0.4.4",
- "thiserror 2.0.18",
+ "terminal_size",
+ "thiserror",
  "toml",
  "toml_edit",
  "url",
  "windows",
  "windows-version",
  "xz2",
- "zip 8.5.1",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "pbkdf2"
-version = "0.12.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+checksum = "112d82ceb8c5bf524d9af484d4e4970c9fd5a0cc15ba14ad93dccd28873b0629"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "hmac",
 ]
 
@@ -1728,12 +1439,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -1772,61 +1477,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "proc-macro-error"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
-dependencies = [
- "proc-macro-error-attr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
-dependencies = [
- "proc-macro2",
- "quote",
- "version_check",
-]
-
-[[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1847,9 +1497,9 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.38",
- "socket2 0.6.3",
- "thiserror 2.0.18",
+ "rustls",
+ "socket2",
+ "thiserror",
  "tokio",
  "tracing",
  "web-time",
@@ -1868,10 +1518,10 @@ dependencies = [
  "rand",
  "ring",
  "rustc-hash",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1886,7 +1536,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1942,19 +1592,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-dependencies = [
- "bitflags 2.11.1",
-]
-
-[[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1975,69 +1616,28 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "reqwest"
-version = "0.11.24"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6920094eb85afde5e4a138be3f2de8bbdf28000f0029e72c45025a56b042251"
+checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
-dependencies = [
- "base64 0.22.1",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.9.0",
- "hyper-rustls 0.27.9",
+ "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
@@ -2045,12 +1645,12 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.38",
+ "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
- "tokio-rustls 0.26.4",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2087,12 +1687,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -2101,35 +1710,23 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.12"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
-dependencies = [
- "log",
- "ring",
- "rustls-webpki 0.101.7",
- "sct",
-]
-
-[[package]]
-name = "rustls"
-version = "0.23.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "once_cell",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -2138,19 +1735,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -2158,19 +1746,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-platform-verifier"
-version = "0.6.2"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
  "once_cell",
- "rustls 0.23.38",
+ "rustls",
  "rustls-native-certs",
  "rustls-platform-verifier-android",
- "rustls-webpki 0.103.12",
+ "rustls-webpki",
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
@@ -2185,19 +1773,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.7"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.103.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2210,12 +1788,6 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
-
-[[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2236,14 +1808,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.1"
+name = "scratch"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
-dependencies = [
- "ring",
- "untrusted",
-]
+checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
 
 [[package]]
 name = "security-framework"
@@ -2251,7 +1819,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2270,9 +1838,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -2301,20 +1869,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.149"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+ "syn",
 ]
 
 [[package]]
@@ -2327,37 +1882,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_urlencoded"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
-dependencies = [
- "form_urlencoded",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -2367,21 +1899,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.2",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "slab"
@@ -2391,31 +1939,15 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smawk"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -2441,58 +1973,35 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "supports-color"
-version = "2.1.0"
+version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6398cde53adc3c4557306a96ce67b302968513830a77a95b2b17305d9719a89"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
 dependencies = [
- "is-terminal",
  "is_ci",
 ]
 
 [[package]]
 name = "supports-hyperlinks"
-version = "2.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f84231692eb0d4d41e4cdd0cabfdd2e6cd9e255e65f80c9aa7c98dd502b4233d"
-dependencies = [
- "is-terminal",
-]
+checksum = "e396b6523b11ccb83120b115a0b7366de372751aa6edf19844dfb13a6af97e91"
 
 [[package]]
 name = "supports-unicode"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f850c19edd184a205e883199a261ed44471c81e39bd95b1357f5febbef00e77a"
-dependencies = [
- "is-terminal",
-]
+checksum = "b7401a30af6cb5818bb64852270bb722533397edcfc7344954a38f420819ece2"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
-version = "2.0.117"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
 ]
-
-[[package]]
-name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sync_wrapper"
@@ -2511,18 +2020,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
+ "syn",
 ]
 
 [[package]]
@@ -2531,19 +2029,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -2558,9 +2046,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.45"
+version = "0.4.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
 dependencies = [
  "filetime",
  "libc",
@@ -2574,20 +2062,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
-name = "terminal_size"
-version = "0.1.17"
+name = "termcolor"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
- "libc",
- "winapi",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2602,22 +2089,12 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.2"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
 dependencies = [
- "smawk",
  "unicode-linebreak",
- "unicode-width 0.1.14",
-]
-
-[[package]]
-name = "thiserror"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
-dependencies = [
- "thiserror-impl 1.0.69",
+ "unicode-width 0.2.2",
 ]
 
 [[package]]
@@ -2626,18 +2103,7 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.18",
-]
-
-[[package]]
-name = "thiserror-impl"
-version = "1.0.69"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
+ "thiserror-impl",
 ]
 
 [[package]]
@@ -2648,14 +2114,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
  "js-sys",
@@ -2667,9 +2133,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -2698,26 +2164,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "tokio-rustls"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
-dependencies = [
- "rustls 0.21.12",
- "tokio",
 ]
 
 [[package]]
@@ -2726,7 +2182,7 @@ version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
- "rustls 0.23.38",
+ "rustls",
  "tokio",
 ]
 
@@ -2749,7 +2205,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "serde_core",
  "serde_spanned",
  "toml_datetime",
@@ -2769,11 +2225,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
- "indexmap 2.14.0",
+ "indexmap",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
@@ -2804,7 +2260,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -2812,20 +2268,20 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "iri-string",
+ "http",
+ "http-body",
  "pin-project-lite",
  "tower",
  "tower-layer",
  "tower-service",
+ "url",
 ]
 
 [[package]]
@@ -2873,9 +2329,9 @@ checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "unicode-ident"
@@ -2900,12 +2356,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unit-prefix"
@@ -2944,12 +2394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
-
-[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2980,23 +2424,14 @@ version = "1.0.1+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
- "wit-bindgen 0.46.0",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "8ddb3f79143bced6de84270411622a2699cee572fc0875aeaf1e7867cf9fca1a"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3007,9 +2442,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "503b14d284f2c8dac03b819967e155ea753f573586193b2b2c95990cb5d69280"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3017,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3027,65 +2462,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap 2.14.0",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.11.1",
- "hashbrown 0.15.5",
- "indexmap 2.14.0",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "a6430a72df5eb332242960fe84b3002a241163998241eb596d4f739b9757061d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3103,34 +2504,12 @@ dependencies = [
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "0d46a5a140e6f7afeccd8eae97eff335163939eac8b929834875168b29b3d267"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
@@ -3140,12 +2519,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
@@ -3200,7 +2573,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3211,7 +2584,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3261,24 +2634,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.45.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
-dependencies = [
- "windows-targets 0.42.2",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -3302,36 +2657,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
-dependencies = [
- "windows_aarch64_gnullvm 0.42.2",
- "windows_aarch64_msvc 0.42.2",
- "windows_i686_gnu 0.42.2",
- "windows_i686_msvc 0.42.2",
- "windows_x86_64_gnu 0.42.2",
- "windows_x86_64_gnullvm 0.42.2",
- "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -3387,18 +2712,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -3411,18 +2724,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -3432,18 +2733,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3471,18 +2760,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -3492,18 +2769,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3519,18 +2784,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -3540,18 +2793,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3567,21 +2808,11 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3589,94 +2820,6 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap 2.14.0",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.11.1",
- "indexmap 2.14.0",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap 2.14.0",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -3721,9 +2864,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -3738,35 +2881,35 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
@@ -3779,15 +2922,15 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
@@ -3819,27 +2962,29 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "zip"
-version = "0.6.6"
+version = "7.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "760394e246e4c28189f19d488c058bf16f564016aefac5d32bb1f3b51d5e9261"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
 dependencies = [
- "byteorder",
  "crc32fast",
- "crossbeam-utils",
  "flate2",
+ "indexmap",
+ "memchr",
  "time",
+ "typed-path",
+ "zopfli",
 ]
 
 [[package]]
 name = "zip"
-version = "8.5.1"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcab981e19633ebcf0b001ddd37dd802996098bc1864f90b7c5d970ce76c1d59"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "aes",
  "bzip2",
@@ -3847,9 +2992,9 @@ dependencies = [
  "crc32fast",
  "deflate64",
  "flate2",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "hmac",
- "indexmap 2.14.0",
+ "indexmap",
  "lzma-rust2",
  "memchr",
  "pbkdf2",
@@ -3864,15 +3009,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
-
-[[package]]
-name = "zmij"
-version = "1.0.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"
 
 [[package]]
 name = "zopfli"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ toml_edit = "0.25.11"
 terminal_size = "0.4.4"
 diffy = { version = "0.5.0", features = ["binary"] }
 contextdiff-parser = { git = "https://github.com/pack-it/contextdiff-parser.git" }
+console = "0.16.3"
 
 # macOS and Linux dependencies
 [target.'cfg(any(target_os = "macos", target_os = "linux"))'.dependencies]

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -51,7 +51,7 @@ impl HandleCommand for InfoArgs {
                 exit(1);
             };
 
-            let tree = match EmptyTree::new_emtpy(package_id.clone(), &register) {
+            let tree = match EmptyTree::new_empty(package_id.clone(), &register) {
                 Ok(tree) => tree,
                 Err(TreeError::NotFound(..)) => not_found::register_package_version(&package_id, &register),
                 Err(e) => Err(e).unwrap_or_exit(1),

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -12,7 +12,7 @@ use crate::{
     installer::types::{OptionalPackageId, PackageId},
     register::{installed_package::InstalledPackage, package_register::PackageRegister},
     utils::{
-        tree::{EmptyNode, TreeError},
+        tree::{EmptyTree, TreeError},
         unwrap_or_exit::UnwrapOrExit,
     },
 };
@@ -51,7 +51,7 @@ impl HandleCommand for InfoArgs {
                 exit(1);
             };
 
-            let tree = match EmptyNode::build_simple_tree(package_id.clone(), &register) {
+            let tree = match EmptyTree::new_emtpy(package_id.clone(), &register) {
                 Ok(tree) => tree,
                 Err(TreeError::NotFound(..)) => not_found::register_package_version(&package_id, &register),
                 Err(e) => Err(e).unwrap_or_exit(1),

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -45,8 +45,8 @@ impl InstallLabel {
         &self.install_type
     }
 
-    /// Returns true if it is a build dependency
-    /// TODO: Change naming to is_build_dependency
+    /// Returns true if it is a normal dependency (not a build dependency).
+    /// If it is a dependency of a build dependency this also returns true.
     pub fn is_dependency(&self) -> bool {
         self.is_dependency
     }
@@ -78,14 +78,13 @@ impl InstallMeta {
 pub type InstallTree = Tree<Option<InstallMeta>, InstallLabel>;
 pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 
-// TODO: Maybe InstallTreeBuilder
-pub struct DependencyResolver<'a> {
+pub struct InstallTreeBuilder<'a> {
     register: &'a PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     asked_packages: HashSet<PackageId>,
 }
 
-impl<'a> DependencyResolver<'a> {
+impl<'a> InstallTreeBuilder<'a> {
     pub fn new(register: &'a PackageRegister, manager: &'a RepositoryManager) -> Self {
         Self {
             register,
@@ -115,19 +114,23 @@ impl<'a> DependencyResolver<'a> {
                         &self.register.get_package_version(node.get_package_id()).expect("Expected package version to exist").dependencies;
                     for dependency in dependencies {
                         let new_node = Node::new(dependency.clone(), None, InstallLabel::new(InstallType::Installed, false));
-                        let new_index = tree.add_node(node_index, new_node);
+                        let new_index = tree.add_node(node_index, new_node)?;
                         package_queue.push_back(new_index);
                     }
 
                     continue;
                 },
-                None => continue, // TODO: Error
+                None => {
+                    return Err(InstallerError::UnreachableError {
+                        msg: "Node value is None without InstallType::Installed".to_string(),
+                    });
+                },
             };
 
-            for (dependency, label) in DependencyResolver::expander(node, install_meta)? {
+            for (dependency, label) in InstallTreeBuilder::expander(node, install_meta)? {
                 let (dependency_id, meta, dependency_label) = self.populator(&dependency, label)?;
                 let new_node = Node::new(dependency_id, meta, dependency_label);
-                let new_index = tree.add_node(node_index, new_node);
+                let new_index = tree.add_node(node_index, new_node)?;
                 package_queue.push_back(new_index);
             }
         }
@@ -144,7 +147,11 @@ impl<'a> DependencyResolver<'a> {
             InstallType::Prebuild => InstallType::Prebuild,
             InstallType::Build => InstallType::Prebuild,
             InstallType::BuildAll => InstallType::BuildAll,
-            _ => unreachable!("Installed type should be unreachable"), // TODO: Error
+            _ => {
+                return Err(InstallerError::UnreachableError {
+                    msg: "InstallType::Installed should be unreachable".to_string(),
+                });
+            },
         };
 
         // TODO: Remove clone
@@ -210,7 +217,7 @@ impl<'a> DependencyResolver<'a> {
         let revision = install_meta.version_metadata.get_revision_count();
         match self.repository_manager.get_prebuild_url(&install_meta.repository_id, &package_id, revision, &Target::current()) {
             Ok(Some(_)) => return Ok(None),
-            Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
+            Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
             Err(e) => error!(e),
         }
 

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -89,10 +89,10 @@ pub struct InstallTreeBuilder<'a> {
 }
 
 impl<'a> InstallTreeBuilder<'a> {
-    pub fn new(register: &'a PackageRegister, manager: &'a RepositoryManager) -> Self {
+    pub fn new(register: &'a PackageRegister, repository_manager: &'a RepositoryManager) -> Self {
         Self {
             register,
-            repository_manager: manager,
+            repository_manager,
             checked_packages: HashSet::new(),
             asked_packages: HashSet::new(),
             terminal: Term::stdout(),
@@ -118,6 +118,7 @@ impl<'a> InstallTreeBuilder<'a> {
             let install_meta = match node.get_value() {
                 Some(install_meta) => install_meta,
                 None if node.get_label().install_type == InstallType::Installed => {
+                    // Note that we expect the package to exist because the node has the `InstallType::Installed` label type
                     let dependencies =
                         &self.register.get_package_version(node.get_package_id()).expect("Expected package version to exist").dependencies;
                     for dependency in dependencies {
@@ -136,7 +137,7 @@ impl<'a> InstallTreeBuilder<'a> {
                 },
             };
 
-            for (dependency, label) in InstallTreeBuilder::expander(node, install_meta)? {
+            for (dependency, label) in self.expander(node, install_meta)? {
                 let (dependency_id, meta, dependency_label) = self.populator(&dependency, label)?;
                 let new_node = Node::new(dependency_id, meta, dependency_label);
                 let new_index = tree.add_node(node_index, new_node)?;
@@ -164,7 +165,6 @@ impl<'a> InstallTreeBuilder<'a> {
             },
         };
 
-        // TODO: Remove clone
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
         let dependencies = install_meta
             .version_metadata
@@ -216,7 +216,7 @@ impl<'a> InstallTreeBuilder<'a> {
     }
 
     fn check_prebuild(&mut self, install_meta: &InstallMeta, package_id: &PackageId, label: &InstallLabel) -> Result<Option<InstallLabel>> {
-        // Don't check for prebuild if the package should not use a prebuild or if it was already asked
+        // Don't check for prebuild if the package should not use a prebuild
         if !matches!(label.get_type(), InstallType::Prebuild) {
             return Ok(None);
         }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -1,6 +1,8 @@
+// SPDX-License-Identifier: GPL-3.0-only
 use std::collections::{HashSet, VecDeque};
 
-// SPDX-License-Identifier: GPL-3.0-only
+use console::Term;
+
 use crate::{
     cli::display::{QuestionResponse, ask_user, logging::error},
     installer::{
@@ -82,6 +84,7 @@ pub struct InstallTreeBuilder<'a> {
     register: &'a PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     asked_packages: HashSet<PackageId>,
+    terminal: Term,
 }
 
 impl<'a> InstallTreeBuilder<'a> {
@@ -90,10 +93,12 @@ impl<'a> InstallTreeBuilder<'a> {
             register,
             repository_manager: manager,
             asked_packages: HashSet::new(),
+            terminal: Term::stdout(),
         }
     }
 
     pub fn create_tree(&mut self, package_id: PackageId, root_meta: InstallMeta, root_label: InstallLabel) -> Result<InstallTree> {
+        let mut tree_display_string = "".to_string();
         let root_label = match self.check_prebuild(&root_meta, &package_id, &root_label)? {
             Some(adjusted_label) => adjusted_label,
             None => root_label,
@@ -101,6 +106,7 @@ impl<'a> InstallTreeBuilder<'a> {
 
         let root = Node::new(package_id, Some(root_meta), root_label);
         let mut tree = Tree::new(root);
+        tree_display_string = self.update_tree_display(&tree_display_string, &tree)?;
 
         let mut package_queue = VecDeque::from([0 as usize]);
         while let Some(node_index) = package_queue.pop_front() {
@@ -115,6 +121,7 @@ impl<'a> InstallTreeBuilder<'a> {
                     for dependency in dependencies {
                         let new_node = Node::new(dependency.clone(), None, InstallLabel::new(InstallType::Installed, false));
                         let new_index = tree.add_node(node_index, new_node)?;
+                        tree_display_string = self.update_tree_display(&tree_display_string, &tree)?;
                         package_queue.push_back(new_index);
                     }
 
@@ -131,6 +138,7 @@ impl<'a> InstallTreeBuilder<'a> {
                 let (dependency_id, meta, dependency_label) = self.populator(&dependency, label)?;
                 let new_node = Node::new(dependency_id, meta, dependency_label);
                 let new_index = tree.add_node(node_index, new_node)?;
+                tree_display_string = self.update_tree_display(&tree_display_string, &tree)?;
                 package_queue.push_back(new_index);
             }
         }
@@ -229,7 +237,22 @@ impl<'a> InstallTreeBuilder<'a> {
             });
         }
 
+        // Remove the question
+        // TODO: Temporary, doesn't work with parallel tree build
+        self.terminal.clear_last_lines(1)?;
+
         // Return an adjusted label
         Ok(Some(InstallLabel::new(InstallType::Build, label.is_dependency())))
+    }
+
+    /// Updates the tree structure shown in the terminal.
+    fn update_tree_display(&self, tree_string: &str, tree: &InstallTree) -> Result<String> {
+        // Remove previous display content
+        let number_of_lines = tree_string.lines().count();
+        self.terminal.clear_last_lines(number_of_lines)?;
+
+        print!("{tree}");
+
+        Ok(tree.to_string())
     }
 }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -83,6 +83,7 @@ pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 pub struct InstallTreeBuilder<'a> {
     register: &'a PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
+    checked_packages: HashSet<PackageId>,
     asked_packages: HashSet<PackageId>,
     terminal: Term,
 }
@@ -92,6 +93,7 @@ impl<'a> InstallTreeBuilder<'a> {
         Self {
             register,
             repository_manager: manager,
+            checked_packages: HashSet::new(),
             asked_packages: HashSet::new(),
             terminal: Term::stdout(),
         }
@@ -215,11 +217,20 @@ impl<'a> InstallTreeBuilder<'a> {
 
     fn check_prebuild(&mut self, install_meta: &InstallMeta, package_id: &PackageId, label: &InstallLabel) -> Result<Option<InstallLabel>> {
         // Don't check for prebuild if the package should not use a prebuild or if it was already asked
-        if !matches!(label.get_type(), InstallType::Prebuild) || self.asked_packages.contains(&package_id) {
+        if !matches!(label.get_type(), InstallType::Prebuild) {
             return Ok(None);
         }
 
-        self.asked_packages.insert(package_id.clone());
+        // Note that if we have asked before and the program is still running we can assume the user agreed to do a build
+        if self.asked_packages.contains(package_id) {
+            return Ok(Some(InstallLabel::new(InstallType::Build, label.is_dependency())));
+        }
+
+        if self.checked_packages.contains(package_id) {
+            return Ok(None);
+        }
+
+        self.checked_packages.insert(package_id.clone());
 
         // Check if a prebuild for the package is available
         let revision = install_meta.version_metadata.get_revision_count();
@@ -237,8 +248,9 @@ impl<'a> InstallTreeBuilder<'a> {
             });
         }
 
+        self.asked_packages.insert(package_id.clone());
+
         // Remove the question
-        // TODO: Temporary, doesn't work with parallel tree build
         self.terminal.clear_last_lines(1)?;
 
         // Return an adjusted label

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -1,6 +1,12 @@
+use std::collections::VecDeque;
+
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::{
-    installer::types::{Dependency, PackageId},
+    cli::display::{QuestionResponse, ask_user, logging::error},
+    installer::{
+        error::{InstallerError, Result},
+        types::{Dependency, PackageId},
+    },
     platforms::Target,
     register::package_register::PackageRegister,
     repositories::{
@@ -8,7 +14,7 @@ use crate::{
         manager::RepositoryManager,
         types::{PackageMeta, PackageVersionMeta, TargetBounds},
     },
-    utils::tree::{self, Node},
+    utils::tree::{Node, Tree},
 };
 
 /// Represents the different types of installing a package.
@@ -54,7 +60,7 @@ pub struct InstallMeta {
 
 impl InstallMeta {
     /// Creates a new `InstallMeta` struct.
-    fn new(package_metadata: PackageMeta, version_metadata: PackageVersionMeta, repository_id: String) -> Result<Self, RepositoryError> {
+    fn new(package_metadata: PackageMeta, version_metadata: PackageVersionMeta, repository_id: String) -> Result<Self> {
         let target_bounds = version_metadata.get_best_target(&Target::current())?;
 
         Ok(Self {
@@ -66,14 +72,43 @@ impl InstallMeta {
     }
 }
 
+pub type InstallTree = Tree<Option<InstallMeta>, InstallLabel>;
 pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 
-impl InstallNode {
+// TODO: Rename to resolver?
+impl InstallTree {
+    pub fn create_tree(
+        package_id: PackageId,
+        install_meta: InstallMeta,
+        install_label: InstallLabel,
+        register: &PackageRegister,
+        manager: &RepositoryManager,
+    ) -> Result<Self> {
+        let root_label = InstallTree::check_prebuild(manager, &install_meta, &package_id, install_label)?;
+        let root = Node::new(package_id, Some(install_meta), root_label);
+        let mut tree = Tree::new(root);
+
+        let mut package_queue = VecDeque::from([0 as usize]);
+        while let Some(node_index) = package_queue.pop_front() {
+            let node = tree.get_node_by_index_mut(node_index).expect("Expected node to exist");
+            let dependencies = InstallTree::expander(node)?;
+            for (dependency, label) in dependencies {
+                let (dependency_id, meta, dependency_label) = InstallTree::populator(register, manager, &dependency, label)?;
+                let new_node = Node::new(dependency_id, meta, dependency_label);
+                let new_index = tree.add_node(node_index, new_node);
+                package_queue.push_back(new_index);
+            }
+        }
+
+        Ok(tree)
+    }
+
     /// Expands a tree based on metadata and also takes into account already installed packages.
     /// The children install types are based on the parent install type and determine how the tree
     /// is further expanded (with or without build dependencies).
-    pub fn expander(parent: &InstallNode) -> tree::Result<Vec<(Dependency, InstallLabel)>> {
+    fn expander(parent: &InstallNode) -> Result<Vec<(Dependency, InstallLabel)>> {
         // Return early if the node value is None (meaning that the package is already installed)
+        // TODO: Introduce an extra type (Installed) for already installed packages, this section of the tree should be expanded with help of the regsiter (because requests are more expansive)
         let install_meta = match parent.get_value() {
             Some(install_meta) => install_meta,
             None => return Ok(Vec::new()),
@@ -114,13 +149,14 @@ impl InstallNode {
 
     /// Populates the tree with metadata info. If a package is already installed it is added
     /// to the tree without a value and children.
-    pub fn populator(
+    fn populator(
         register: &PackageRegister,
         manager: &RepositoryManager,
         dependency: &Dependency,
         label: InstallLabel,
-    ) -> tree::Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
+    ) -> Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
         // If the package is already satisfied don't expand the dependency tree further
+        // TODO Expand with register and installed label type
         if let Some(package) = register.get_latest_satisfying_package(dependency) {
             return Ok((package.package_id.clone(), None, label));
         }
@@ -131,18 +167,44 @@ impl InstallNode {
         let dependency_id = PackageId::new(dependency.get_name().clone(), version.clone());
         let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
         let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;
+
+        // Don't check for prebuild if the package should be build
+        if matches!(label.get_type(), InstallType::Build | InstallType::BuildAll) {
+            return Ok((dependency_id, Some(install_meta), label));
+        }
+
+        let label = InstallTree::check_prebuild(manager, &install_meta, &dependency_id, label)?;
         Ok((dependency_id, Some(install_meta), label))
     }
 
-    /// Expands an install tree after it has been build. The current node will be changed to a build node
-    /// and its children will be updated accordingly.
-    pub fn expand_with_build(&mut self, register: &PackageRegister, manager: &RepositoryManager) -> tree::Result<()> {
-        self.set_label(InstallLabel {
-            install_type: InstallType::Build,
-            is_dependency: self.get_label().is_dependency(),
-        });
+    fn check_prebuild(
+        manager: &RepositoryManager,
+        install_meta: &InstallMeta,
+        package_id: &PackageId,
+        label: InstallLabel,
+    ) -> Result<InstallLabel> {
+        // Check if a prebuild for the package is available
+        let revision = install_meta.version_metadata.get_revision_count();
+        match manager.get_prebuild_url(&install_meta.repository_id, &package_id, revision, &Target::current()) {
+            Ok(Some(_)) => return Ok(label),
+            Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
+            Err(e) => error!(e),
+        }
 
-        // Expand the node again, but now for build. Duplicate nodes will be handled by the tree implementation
-        self.expand(&Self::expander, &|(d, l)| Self::populator(register, manager, &d, l))
+        // Return an error if the user doesn't want to build from source as alternative install method
+        let question = format!("Prebuild package for {package_id} cannot be found, would you like to build from source instead?");
+        if ask_user(&question, QuestionResponse::Yes)?.is_no_or_invalid() {
+            return Err(InstallerError::InstallationCanceled {
+                reason: format!("package '{package_id}' cannot be installed without building from source"),
+            });
+        }
+
+        // Create an adjusted label
+        let adjusted_label = InstallLabel {
+            install_type: InstallType::Build,
+            is_dependency: label.is_dependency(),
+        };
+
+        Ok(adjusted_label)
     }
 }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -23,6 +23,7 @@ pub enum InstallType {
     Prebuild,
     Build,
     BuildAll,
+    Installed,
 }
 
 /// Represents the label for the install tree.
@@ -44,6 +45,8 @@ impl InstallLabel {
         &self.install_type
     }
 
+    /// Returns true if it is a build dependency
+    /// TODO: Change naming to is_build_dependency
     pub fn is_dependency(&self) -> bool {
         self.is_dependency
     }
@@ -79,19 +82,38 @@ pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 impl InstallTree {
     pub fn create_tree(
         package_id: PackageId,
-        install_meta: InstallMeta,
-        install_label: InstallLabel,
+        root_meta: InstallMeta,
+        root_label: InstallLabel,
         register: &PackageRegister,
         manager: &RepositoryManager,
     ) -> Result<Self> {
-        let root_label = InstallTree::check_prebuild(manager, &install_meta, &package_id, install_label)?;
-        let root = Node::new(package_id, Some(install_meta), root_label);
+        let root_label = InstallTree::check_prebuild(manager, &root_meta, &package_id, root_label)?;
+        let root = Node::new(package_id, Some(root_meta), root_label);
         let mut tree = Tree::new(root);
 
         let mut package_queue = VecDeque::from([0 as usize]);
         while let Some(node_index) = package_queue.pop_front() {
             let node = tree.get_node_by_index_mut(node_index).expect("Expected node to exist");
-            let dependencies = InstallTree::expander(node)?;
+
+            // Expand with register if the node value is None and has the Installed label type (meaning that the package is already installed)
+            let install_meta = match node.get_value() {
+                Some(install_meta) => install_meta,
+                None if node.get_label().install_type == InstallType::Installed => {
+                    let dependencies =
+                        &register.get_package_version(node.get_package_id()).expect("Expected package version to exist").dependencies;
+                    for dependency in dependencies {
+                        let new_node = Node::new(dependency.clone(), None, InstallLabel::new(InstallType::Installed, false));
+                        let new_index = tree.add_node(node_index, new_node);
+                        package_queue.push_back(new_index);
+                    }
+
+                    continue;
+                },
+                None => continue, // TODO: Error
+            };
+
+            let dependencies = InstallTree::expander(node, install_meta)?;
+
             for (dependency, label) in dependencies {
                 let (dependency_id, meta, dependency_label) = InstallTree::populator(register, manager, &dependency, label)?;
                 let new_node = Node::new(dependency_id, meta, dependency_label);
@@ -106,19 +128,13 @@ impl InstallTree {
     /// Expands a tree based on metadata and also takes into account already installed packages.
     /// The children install types are based on the parent install type and determine how the tree
     /// is further expanded (with or without build dependencies).
-    fn expander(parent: &InstallNode) -> Result<Vec<(Dependency, InstallLabel)>> {
-        // Return early if the node value is None (meaning that the package is already installed)
-        // TODO: Introduce an extra type (Installed) for already installed packages, this section of the tree should be expanded with help of the regsiter (because requests are more expansive)
-        let install_meta = match parent.get_value() {
-            Some(install_meta) => install_meta,
-            None => return Ok(Vec::new()),
-        };
-
+    fn expander(parent: &InstallNode, install_meta: &InstallMeta) -> Result<Vec<(Dependency, InstallLabel)>> {
         // Determine the (build) dependency types of the children based on the parent
         let install_type = match *parent.get_label().get_type() {
             InstallType::Prebuild => InstallType::Prebuild,
             InstallType::Build => InstallType::Prebuild,
             InstallType::BuildAll => InstallType::BuildAll,
+            _ => unreachable!("Installed type should be unreachable"), // TODO: Error
         };
 
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
@@ -155,10 +171,10 @@ impl InstallTree {
         dependency: &Dependency,
         label: InstallLabel,
     ) -> Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
-        // If the package is already satisfied don't expand the dependency tree further
-        // TODO Expand with register and installed label type
+        // Return early with empty value if the package is already satisfied
         if let Some(package) = register.get_latest_satisfying_package(dependency) {
-            return Ok((package.package_id.clone(), None, label));
+            let adjusted_label = InstallLabel::new(InstallType::Installed, label.is_dependency());
+            return Ok((package.package_id.clone(), None, adjusted_label));
         }
 
         // Use the latest version if the dependency is not yet satisfied
@@ -199,12 +215,7 @@ impl InstallTree {
             });
         }
 
-        // Create an adjusted label
-        let adjusted_label = InstallLabel {
-            install_type: InstallType::Build,
-            is_dependency: label.is_dependency(),
-        };
-
-        Ok(adjusted_label)
+        // Return an adjusted label
+        Ok(InstallLabel::new(InstallType::Build, label.is_dependency()))
     }
 }

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -1,4 +1,4 @@
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 
 // SPDX-License-Identifier: GPL-3.0-only
 use crate::{
@@ -78,16 +78,28 @@ impl InstallMeta {
 pub type InstallTree = Tree<Option<InstallMeta>, InstallLabel>;
 pub type InstallNode = Node<Option<InstallMeta>, InstallLabel>;
 
-// TODO: Rename to resolver?
-impl InstallTree {
-    pub fn create_tree(
-        package_id: PackageId,
-        root_meta: InstallMeta,
-        root_label: InstallLabel,
-        register: &PackageRegister,
-        manager: &RepositoryManager,
-    ) -> Result<Self> {
-        let root_label = InstallTree::check_prebuild(manager, &root_meta, &package_id, root_label)?;
+// TODO: Maybe InstallTreeBuilder
+pub struct DependencyResolver<'a> {
+    register: &'a PackageRegister,
+    repository_manager: &'a RepositoryManager<'a>,
+    asked_packages: HashSet<PackageId>,
+}
+
+impl<'a> DependencyResolver<'a> {
+    pub fn new(register: &'a PackageRegister, manager: &'a RepositoryManager) -> Self {
+        Self {
+            register,
+            repository_manager: manager,
+            asked_packages: HashSet::new(),
+        }
+    }
+
+    pub fn create_tree(&mut self, package_id: PackageId, root_meta: InstallMeta, root_label: InstallLabel) -> Result<InstallTree> {
+        let root_label = match self.check_prebuild(&root_meta, &package_id, &root_label)? {
+            Some(adjusted_label) => adjusted_label,
+            None => root_label,
+        };
+
         let root = Node::new(package_id, Some(root_meta), root_label);
         let mut tree = Tree::new(root);
 
@@ -100,7 +112,7 @@ impl InstallTree {
                 Some(install_meta) => install_meta,
                 None if node.get_label().install_type == InstallType::Installed => {
                     let dependencies =
-                        &register.get_package_version(node.get_package_id()).expect("Expected package version to exist").dependencies;
+                        &self.register.get_package_version(node.get_package_id()).expect("Expected package version to exist").dependencies;
                     for dependency in dependencies {
                         let new_node = Node::new(dependency.clone(), None, InstallLabel::new(InstallType::Installed, false));
                         let new_index = tree.add_node(node_index, new_node);
@@ -112,10 +124,8 @@ impl InstallTree {
                 None => continue, // TODO: Error
             };
 
-            let dependencies = InstallTree::expander(node, install_meta)?;
-
-            for (dependency, label) in dependencies {
-                let (dependency_id, meta, dependency_label) = InstallTree::populator(register, manager, &dependency, label)?;
+            for (dependency, label) in DependencyResolver::expander(node, install_meta)? {
+                let (dependency_id, meta, dependency_label) = self.populator(&dependency, label)?;
                 let new_node = Node::new(dependency_id, meta, dependency_label);
                 let new_index = tree.add_node(node_index, new_node);
                 package_queue.push_back(new_index);
@@ -137,6 +147,7 @@ impl InstallTree {
             _ => unreachable!("Installed type should be unreachable"), // TODO: Error
         };
 
+        // TODO: Remove clone
         let target = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
         let dependencies = install_meta
             .version_metadata
@@ -164,45 +175,41 @@ impl InstallTree {
     }
 
     /// Populates the tree with metadata info. If a package is already installed it is added
-    /// to the tree without a value and children.
-    fn populator(
-        register: &PackageRegister,
-        manager: &RepositoryManager,
-        dependency: &Dependency,
-        label: InstallLabel,
-    ) -> Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
+    /// to the tree without a value and with LabelType::Installed.
+    fn populator(&mut self, dependency: &Dependency, label: InstallLabel) -> Result<(PackageId, Option<InstallMeta>, InstallLabel)> {
         // Return early with empty value if the package is already satisfied
-        if let Some(package) = register.get_latest_satisfying_package(dependency) {
+        if let Some(package) = self.register.get_latest_satisfying_package(dependency) {
             let adjusted_label = InstallLabel::new(InstallType::Installed, label.is_dependency());
             return Ok((package.package_id.clone(), None, adjusted_label));
         }
 
         // Use the latest version if the dependency is not yet satisfied
-        let (repository_id, package_metadata) = manager.read_package(dependency.get_name())?;
+        let (repository_id, package_metadata) = self.repository_manager.read_package(dependency.get_name())?;
         let version = package_metadata.get_latest_dependency_version(dependency, &Target::current())?;
         let dependency_id = PackageId::new(dependency.get_name().clone(), version.clone());
-        let version_metadata = manager.read_repo_package_version(&repository_id, &dependency_id)?;
+        let version_metadata = self.repository_manager.read_repo_package_version(&repository_id, &dependency_id)?;
         let install_meta = InstallMeta::new(package_metadata, version_metadata, repository_id)?;
 
-        // Don't check for prebuild if the package should be build
-        if matches!(label.get_type(), InstallType::Build | InstallType::BuildAll) {
-            return Ok((dependency_id, Some(install_meta), label));
-        }
+        let label = match self.check_prebuild(&install_meta, &dependency_id, &label)? {
+            Some(adjusted_label) => adjusted_label,
+            None => label,
+        };
 
-        let label = InstallTree::check_prebuild(manager, &install_meta, &dependency_id, label)?;
         Ok((dependency_id, Some(install_meta), label))
     }
 
-    fn check_prebuild(
-        manager: &RepositoryManager,
-        install_meta: &InstallMeta,
-        package_id: &PackageId,
-        label: InstallLabel,
-    ) -> Result<InstallLabel> {
+    fn check_prebuild(&mut self, install_meta: &InstallMeta, package_id: &PackageId, label: &InstallLabel) -> Result<Option<InstallLabel>> {
+        // Don't check for prebuild if the package should not use a prebuild or if it was already asked
+        if !matches!(label.get_type(), InstallType::Prebuild) || self.asked_packages.contains(&package_id) {
+            return Ok(None);
+        }
+
+        self.asked_packages.insert(package_id.clone());
+
         // Check if a prebuild for the package is available
         let revision = install_meta.version_metadata.get_revision_count();
-        match manager.get_prebuild_url(&install_meta.repository_id, &package_id, revision, &Target::current()) {
-            Ok(Some(_)) => return Ok(label),
+        match self.repository_manager.get_prebuild_url(&install_meta.repository_id, &package_id, revision, &Target::current()) {
+            Ok(Some(_)) => return Ok(None),
             Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
             Err(e) => error!(e),
         }
@@ -216,6 +223,6 @@ impl InstallTree {
         }
 
         // Return an adjusted label
-        Ok(InstallLabel::new(InstallType::Build, label.is_dependency()))
+        Ok(Some(InstallLabel::new(InstallType::Build, label.is_dependency())))
     }
 }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -156,7 +156,8 @@ impl<'a> Installer<'a> {
         // Get the value or return early if there is no value (package is already satisfied)
         let node_value = match node.get_value() {
             Some(value) => value,
-            None => return Ok(()),
+            None if *node.get_label().get_type() == InstallType::Installed => return Ok(()),
+            None => return Ok(()), // TODO: Error
         };
 
         let dependencies = tree.get_children_ids_filtered(node, InstallLabel::is_dependency);

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -9,7 +9,7 @@ use crate::{
     installer::{
         InstallLabel,
         error::{InstallerError, Result},
-        install_tree::{InstallMeta, InstallTree, InstallType},
+        install_tree::{DependencyResolver, InstallMeta, InstallTree, InstallType},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -117,12 +117,12 @@ impl<'a> Installer<'a> {
 
         // Create the install tree based on the install type
         println!("Building dependency tree for {package_id}");
-        let mut dependency_tree =
-            InstallTree::create_tree(package_id.clone(), root_meta, install_label, self.register, self.repository_manager)?;
+        let mut resolver = DependencyResolver::new(self.register, self.repository_manager);
+        let dependency_tree = resolver.create_tree(package_id.clone(), root_meta, install_label)?;
 
         println!("Installing the following packages:");
         println!("{dependency_tree}");
-        self.install_nodes(&0, &mut dependency_tree)?;
+        self.install_nodes(&0, &dependency_tree)?;
 
         // TODO: This check doesn't work when the tree is expanded after the users intial command
         if !self.options.keep_build && self.options.install_type != InstallType::Prebuild {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -9,7 +9,7 @@ use crate::{
     installer::{
         InstallLabel,
         error::{InstallerError, Result},
-        install_tree::{DependencyResolver, InstallMeta, InstallTree, InstallType},
+        install_tree::{InstallMeta, InstallTree, InstallTreeBuilder, InstallType},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -117,19 +117,15 @@ impl<'a> Installer<'a> {
 
         // Create the install tree based on the install type
         println!("Building dependency tree for {package_id}");
-        let mut resolver = DependencyResolver::new(self.register, self.repository_manager);
-        let dependency_tree = resolver.create_tree(package_id.clone(), root_meta, install_label)?;
+        let mut tree_builder = InstallTreeBuilder::new(self.register, self.repository_manager);
+        let dependency_tree = tree_builder.create_tree(package_id.clone(), root_meta, install_label)?;
 
         println!("Installing the following packages:");
         println!("{dependency_tree}");
         self.install_nodes(&0, &dependency_tree)?;
 
-        // TODO: This check doesn't work when the tree is expanded after the users intial command
-        if !self.options.keep_build && self.options.install_type != InstallType::Prebuild {
-            if !dependency_tree.get_children_ids_filtered(dependency_tree.get_root(), |c| !c.is_dependency()).is_empty() {
-                println!("Removing build dependencies");
-            }
-
+        if !self.options.keep_build {
+            println!("Removing build dependencies (if there are any");
             self.remove_build_dependencies(&0, &dependency_tree)?;
         }
 
@@ -157,7 +153,11 @@ impl<'a> Installer<'a> {
         let node_value = match node.get_value() {
             Some(value) => value,
             None if *node.get_label().get_type() == InstallType::Installed => return Ok(()),
-            None => return Ok(()), // TODO: Error
+            None => {
+                return Err(InstallerError::UnreachableError {
+                    msg: "Node value is None without InstallType::Installed".to_string(),
+                });
+            },
         };
 
         let dependencies = tree.get_children_ids_filtered(node, InstallLabel::is_dependency);

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -120,7 +120,7 @@ impl<'a> Installer<'a> {
         let mut tree_builder = InstallTreeBuilder::new(self.register, self.repository_manager);
         let dependency_tree = tree_builder.create_tree(package_id.clone(), root_meta, install_label)?;
 
-        self.install_nodes(&0, &dependency_tree)?;
+        self.install_nodes(&dependency_tree)?;
 
         if !self.options.keep_build {
             println!("Removing build dependencies (if there are any");
@@ -130,43 +130,36 @@ impl<'a> Installer<'a> {
         Ok(package_id)
     }
 
-    /// Installs all packages recursively. For each package the install type is considered.
+    // TODO: Implement parallelization
+    /// Installs all packages based on the given install tree. For each package the install type is considered.
     /// Returns an `InstallerError::InstallationCanceled` if the installation has been canceled (by the user).
-    /// TODO: For parallelization this will become non recursive, so tree would be passed anyway
-    fn install_nodes(&mut self, node_index: &usize, tree: &InstallTree) -> Result<()> {
-        let node = tree.get_node_by_index(*node_index).expect("Expected node to exist");
+    fn install_nodes(&mut self, tree: &InstallTree) -> Result<()> {
+        // Note that by way of construction of the tree iterating in reverse will always install bottom up
+        for node in tree.get_nodes().iter().rev() {
+            // Continue if the package has already been installed (maybe by another earlier node from another branch)
+            if self.register.get_package_version(node.get_package_id()).is_some() {
+                continue;
+            }
 
-        // Install childs first
-        // TODO: Implement parallelization here
-        for child in node.get_children() {
-            self.install_nodes(child, tree)?;
+            // Get the value or continue if there is no value (package is already satisfied)
+            let node_value = match node.get_value() {
+                Some(value) => value,
+                None if *node.get_label().get_type() == InstallType::Installed => continue,
+                None => {
+                    return Err(InstallerError::UnreachableError {
+                        msg: "Node value is None without InstallType::Installed".to_string(),
+                    });
+                },
+            };
+
+            let dependencies = tree.get_children_ids_filtered(node, InstallLabel::is_dependency);
+            match node.get_label().get_type() {
+                InstallType::Build | InstallType::BuildAll => self.install_package(node_value, dependencies, false)?,
+                _ => self.install_package(node_value, dependencies, true)?,
+            }
         }
 
-        // Return early if the package has already been installed (maybe by another earlier node from another branch)
-        if self.register.get_package_version(node.get_package_id()).is_some() {
-            return Ok(());
-        }
-
-        // Get the value or return early if there is no value (package is already satisfied)
-        let node_value = match node.get_value() {
-            Some(value) => value,
-            None if *node.get_label().get_type() == InstallType::Installed => return Ok(()),
-            None => {
-                return Err(InstallerError::UnreachableError {
-                    msg: "Node value is None without InstallType::Installed".to_string(),
-                });
-            },
-        };
-
-        let dependencies = tree.get_children_ids_filtered(node, InstallLabel::is_dependency);
-
-        // Check if the current package should be build from source
-        if matches!(node.get_label().get_type(), InstallType::Build | InstallType::BuildAll) {
-            // Install the current node without prebuild
-            return self.install_package(node_value, dependencies, false);
-        }
-
-        Ok(self.install_package(node_value, dependencies, true)?)
+        Ok(())
     }
 
     /// Downloads and installs a package. This is done with a build from the source code or with pre-builds.

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -3,13 +3,13 @@ use crate::{
     builder::Builder,
     cli::display::{
         QuestionResponse, Spinner, ask_user,
-        logging::{debug, error, warning},
+        logging::{debug, warning},
     },
     config::{Config, Repository},
     installer::{
         InstallLabel,
         error::{InstallerError, Result},
-        install_tree::{InstallMeta, InstallNode, InstallType},
+        install_tree::{InstallMeta, InstallTree, InstallType},
         options::InstallerOptions,
         scripts::{self, ScriptData},
         symlinker::Symlinker,
@@ -19,12 +19,11 @@ use crate::{
     platforms::{DEFAULT_PREFIX, Target, permissions, symlink},
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::{
-        error::RepositoryError,
         manager::RepositoryManager,
         provider,
         types::{Checksum, PackageTarget},
     },
-    utils::{io, tree::TreeBuilder},
+    utils::io,
 };
 
 use std::{
@@ -118,22 +117,20 @@ impl<'a> Installer<'a> {
 
         // Create the install tree based on the install type
         println!("Building dependency tree for {package_id}");
-        let mut dependency_tree = TreeBuilder::new()
-            .root(package_id.clone(), Some(root_meta), install_label)
-            .expander(InstallNode::expander)
-            .populator(|(d, l)| InstallNode::populator(self.register, self.repository_manager, &d, l))
-            .build()?;
+        let mut dependency_tree =
+            InstallTree::create_tree(package_id.clone(), root_meta, install_label, self.register, self.repository_manager)?;
 
         println!("Installing the following packages:");
         println!("{dependency_tree}");
-        self.install_nodes(&mut dependency_tree)?;
+        self.install_nodes(&0, &mut dependency_tree)?;
 
+        // TODO: This check doesn't work when the tree is expanded after the users intial command
         if !self.options.keep_build && self.options.install_type != InstallType::Prebuild {
-            if !dependency_tree.get_children_ids_filtered(|c| !c.is_dependency()).is_empty() {
+            if !dependency_tree.get_children_ids_filtered(dependency_tree.get_root(), |c| !c.is_dependency()).is_empty() {
                 println!("Removing build dependencies");
             }
 
-            self.remove_build_dependencies(&dependency_tree, true)?;
+            self.remove_build_dependencies(&0, &dependency_tree)?;
         }
 
         Ok(package_id)
@@ -141,15 +138,18 @@ impl<'a> Installer<'a> {
 
     /// Installs all packages recursively. For each package the install type is considered.
     /// Returns an `InstallerError::InstallationCanceled` if the installation has been canceled (by the user).
-    fn install_nodes(&mut self, node: &mut InstallNode) -> Result<()> {
+    /// TODO: For parallelization this will become non recursive, so tree would be passed anyway
+    fn install_nodes(&mut self, node_index: &usize, tree: &InstallTree) -> Result<()> {
+        let node = tree.get_node_by_index(*node_index).expect("Expected node to exist");
+
         // Install childs first
         // TODO: Implement parallelization here
-        for child in node.get_children_mut() {
-            self.install_nodes(child)?;
+        for child in node.get_children() {
+            self.install_nodes(child, tree)?;
         }
 
-        // Return early if the package has already been installed (maybe by another earlier node)
-        if self.register.get_package_version(node.get_id()).is_some() {
+        // Return early if the package has already been installed (maybe by another earlier node from another branch)
+        if self.register.get_package_version(node.get_package_id()).is_some() {
             return Ok(());
         }
 
@@ -159,7 +159,7 @@ impl<'a> Installer<'a> {
             None => return Ok(()),
         };
 
-        let dependencies = node.get_children_ids_filtered(InstallLabel::is_dependency);
+        let dependencies = tree.get_children_ids_filtered(node, InstallLabel::is_dependency);
 
         // Check if the current package should be build from source
         if matches!(node.get_label().get_type(), InstallType::Build | InstallType::BuildAll) {
@@ -167,32 +167,7 @@ impl<'a> Installer<'a> {
             return self.install_package(node_value, dependencies, false);
         }
 
-        // Install the package with a prebuild if possible
-        let revision = node_value.version_metadata.get_revision_count();
-        match self.repository_manager.get_prebuild_url(&node_value.repository_id, node.get_id(), revision, &Target::current()) {
-            Ok(Some(_)) => {
-                self.install_package(node_value, dependencies, true)?;
-                return Ok(());
-            },
-            Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => (),
-            Err(e) => error!(e),
-        }
-
-        // Return early if the user doesn't want to build from source as alternative install method
-        let question = format!(
-            "Prebuild package for {} cannot be found, would you like to build from source instead?",
-            node.get_id()
-        );
-        if ask_user(&question, QuestionResponse::Yes)?.is_no_or_invalid() {
-            return Err(InstallerError::InstallationCanceled {
-                reason: format!("package '{}' cannot be installed without building from source", node.get_id()),
-            });
-        }
-
-        node.expand_with_build(self.register, self.repository_manager)?;
-        self.install_nodes(node)?;
-
-        Ok(())
+        Ok(self.install_package(node_value, dependencies, true)?)
     }
 
     /// Downloads and installs a package. This is done with a build from the source code or with pre-builds.
@@ -399,26 +374,28 @@ impl<'a> Installer<'a> {
 
     /// Removes the build dependencies recursively. There are early returns to make sure that the
     /// package is not removed if it was already installed, is not installed anymore or is a dependency.
-    fn remove_build_dependencies(&mut self, parent: &InstallNode, is_root: bool) -> Result<()> {
+    fn remove_build_dependencies(&mut self, node_index: &usize, tree: &InstallTree) -> Result<()> {
+        let node = tree.get_node_by_index(*node_index).expect("Expected node to exist");
+
         // Return early if the node value is None (meaning that the package was already installed)
-        if parent.get_value().is_none() {
+        if node.get_value().is_none() {
             return Ok(());
         }
 
         // Return early if the package doesn't exist (removed in earlier iteration) or if it's a dependency
-        let optional_id = &OptionalPackageId::from(parent.get_id().clone());
-        if self.register.get_package_version(parent.get_id()).is_none() || self.register.is_dependency(optional_id) {
+        let optional_id = &OptionalPackageId::from(node.get_package_id().clone());
+        if self.register.get_package_version(node.get_package_id()).is_none() || self.register.is_dependency(optional_id) {
             return Ok(());
         }
 
         // Don't remove the package if it's the root
-        if !is_root {
-            println!("Remove build dependency {}", parent.get_id());
+        if *node_index != 0 {
+            println!("Remove build dependency {}", node.get_package_id());
             self.uninstall(optional_id)?;
         }
 
-        for child in parent.get_children() {
-            self.remove_build_dependencies(child, false)?;
+        for child in node.get_children() {
+            self.remove_build_dependencies(child, tree)?;
         }
 
         Ok(())

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -367,7 +367,7 @@ impl<'a> Installer<'a> {
     /// Removes the build dependencies recursively. There are early returns to make sure that the
     /// package is not removed if it was already installed, is not installed anymore or is a dependency.
     fn remove_build_dependencies(&mut self, node_index: &usize, tree: &InstallTree) -> Result<()> {
-        let node = tree.get_node_by_index(*node_index).expect("Expected node to exist");
+        let node = tree.get_node_by_index(node_index).expect("Expected node to exist");
 
         // Return early if the node value is None (meaning that the package was already installed)
         if node.get_value().is_none() {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -120,8 +120,6 @@ impl<'a> Installer<'a> {
         let mut tree_builder = InstallTreeBuilder::new(self.register, self.repository_manager);
         let dependency_tree = tree_builder.create_tree(package_id.clone(), root_meta, install_label)?;
 
-        println!("Installing the following packages:");
-        println!("{dependency_tree}");
         self.install_nodes(&0, &dependency_tree)?;
 
         if !self.options.keep_build {

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{
-    collections::HashSet,
+    collections::{HashSet, VecDeque},
     fmt::{Debug, Display},
 };
 
@@ -8,14 +8,17 @@ use thiserror::Error;
 
 use crate::{installer::types::PackageId, register::package_register::PackageRegister, repositories::error::RepositoryError};
 
+// Static string prefixes for the tree display
+const BRANCH: &str = "\u{251C}\u{2500}\u{2500}\u{2500} ";
+const LAST_BRANCH: &str = "\u{2514}\u{2500}\u{2500}\u{2500} ";
+const VERTICAL_LINE: &str = "\u{2502}    ";
+const EMPTY_SPACE: &str = "     ";
+
 /// The errors that occur while doing tree operations.
 #[derive(Error, Debug)]
 pub enum TreeError {
     #[error("Package id '{0}' cannot be found")]
     NotFound(PackageId),
-
-    #[error("Cannot create tree, because necessary build attribute '{0}' was missing from the tree builder.")]
-    MissingBuildAttributes(String),
 
     #[error("Cannot create tree, because of an error reading the repository.")]
     RepositoryError(#[from] RepositoryError),
@@ -23,132 +26,71 @@ pub enum TreeError {
 
 pub type Result<T> = std::result::Result<T, TreeError>;
 
+pub struct Tree<V, L: Eq> {
+    // A list of all nodes in the tree. Note that this list will always have parents before children by
+    // way of construction (you can only add a node as child of another node).
+    nodes: Vec<Node<V, L>>,
+}
+
 /// Represents a node in a dependency tree with generic values and labels.
 #[derive(Debug)]
 pub struct Node<V, L: Eq> {
-    id: PackageId,
+    package_id: PackageId,
     value: V,
-    children: Vec<Node<V, L>>,
+    children: Vec<usize>,
     label: L,
 }
 
-/// A tree builder to build trees from a root, an expander and a populator.
-#[derive(Debug)]
-pub struct TreeBuilder<E, P, T, V, L: Eq>
-where
-    E: Fn(&Node<V, L>) -> Result<Vec<T>>,
-    P: Fn(T) -> Result<(PackageId, V, L)>,
-{
-    /// The root of the tree.
-    root: Option<Node<V, L>>,
-
-    /// Closure specifying how to get children of a certain package id.
-    expander: Option<E>,
-
-    /// Closure specifying how to populate the tree with the expander return values.
-    populator: Option<P>,
-}
-
-// Static string prefixes for the tree display
-const BRANCH: &str = "\u{251C}\u{2500}\u{2500}\u{2500} ";
-const LAST_BRANCH: &str = "\u{2514}\u{2500}\u{2500}\u{2500} ";
-const VERTICAL_LINE: &str = "\u{2502}    ";
-const EMPTY_SPACE: &str = "     ";
-
-impl<E, P, T, V, L: Eq> TreeBuilder<E, P, T, V, L>
-where
-    E: Fn(&Node<V, L>) -> Result<Vec<T>>,
-    P: Fn(T) -> Result<(PackageId, V, L)>,
-{
-    pub fn new() -> Self {
-        Self {
-            root: None,
-            expander: None,
-            populator: None,
-        }
+impl<V, L: Eq> Tree<V, L> {
+    pub fn new(root: Node<V, L>) -> Self {
+        Self { nodes: vec![root] }
     }
 
-    pub fn expander(mut self, expander: E) -> Self {
-        self.expander = Some(expander);
-        self
+    pub fn add_node(&mut self, parent_index: usize, node: Node<V, L>) -> usize {
+        self.nodes.push(node);
+        let index = self.nodes.len() - 1;
+        let parent = self.nodes.get_mut(parent_index).expect("TODO");
+        parent.children.push(index);
+        index
     }
 
-    pub fn populator(mut self, populator: P) -> Self {
-        self.populator = Some(populator);
-        self
+    pub fn get_root(&self) -> &Node<V, L> {
+        self.nodes.get(0).expect("Expected root to exist")
     }
 
-    /// Sets the root of the tree. Its children are initialized to an empty vec.
-    pub fn root(mut self, package_id: PackageId, value: V, label: L) -> Self {
-        self.root = Some(Node {
-            id: package_id,
-            value,
-            children: Vec::new(),
-            label,
-        });
-
-        self
+    /// Returns a reference to a list which contains the nodes of the tree.
+    pub fn get_nodes(&self) -> &Vec<Node<V, L>> {
+        &self.nodes
     }
 
-    /// Builds the tree. Returns a result containing the root if successful. If any of
-    /// the tree builder attributes are None a MissingBuildAttributes error is returned instead.
-    pub fn build(self) -> Result<Node<V, L>> {
-        let mut root = match self.root {
-            Some(root) => root,
-            None => return Err(TreeError::MissingBuildAttributes("root".to_string())),
-        };
-
-        let expander = match &self.expander {
-            Some(expander) => expander,
-            None => return Err(TreeError::MissingBuildAttributes("expander".to_string())),
-        };
-
-        let populator = match &self.populator {
-            Some(populator) => populator,
-            None => return Err(TreeError::MissingBuildAttributes("populator".to_string())),
-        };
-
-        root.expand(&expander, &populator)?;
-        Ok(root)
+    /// Gets a node based on its index.
+    pub fn get_node_by_index(&self, index: usize) -> Option<&Node<V, L>> {
+        self.nodes.get(index)
     }
-}
 
-// Generic node implementation.
-impl<V, L: Eq> Node<V, L> {
-    /// Expands a node. The expander is used in combination with the populator to get its child nodes.
-    /// If a child already exists it's not added again.
-    pub fn expand<E, P, T>(&mut self, expander: &E, populator: &P) -> Result<()>
+    /// Gets a node mutably based on its index.
+    pub fn get_node_by_index_mut(&mut self, index: usize) -> Option<&mut Node<V, L>> {
+        self.nodes.get_mut(index)
+    }
+
+    /// Gets the ids of the children of the node in a hashset.
+    /// Checks for a filter on the label and will only return the children that satisfy the filter.
+    pub fn get_children_ids_filtered<F>(&self, node: &Node<V, L>, filter: F) -> HashSet<PackageId>
     where
-        E: Fn(&Node<V, L>) -> Result<Vec<T>>,
-        P: Fn(T) -> Result<(PackageId, V, L)>,
+        F: Fn(&L) -> bool,
     {
-        let existing_childs = self.get_children_ids();
-
-        for child in expander(self)? {
-            let (id, value, label) = populator(child)?;
-
-            // Node already exists, skip adding
-            if existing_childs.contains(&id) {
-                continue;
-            }
-
-            let mut child_node = Node {
-                id,
-                value,
-                children: Vec::new(),
-                label,
-            };
-
-            child_node.expand(expander, populator)?;
-            self.children.push(child_node);
-        }
-
-        Ok(())
+        node.get_children()
+            .iter()
+            .map(|c| self.get_node_by_index(*c).expect("TODO"))
+            .filter(|c| filter(&c.label))
+            .map(|c| c.package_id.clone())
+            .collect()
     }
 
     /// The implementation of the tree display.
-    fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, node: &Node<V, L>, prefix: &str) -> std::fmt::Result {
-        writeln!(f, "{prefix}{}", node.id)?;
+    fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, node_index: &usize, prefix: &str) -> std::fmt::Result {
+        let node = self.get_node_by_index(*node_index).expect("Expected node to exist");
+        writeln!(f, "{prefix}{}", node.package_id)?;
 
         // Note that when the input prefix is "" then this prefix will also be ""
         let prefix = match prefix.ends_with(BRANCH) {
@@ -167,10 +109,22 @@ impl<V, L: Eq> Node<V, L> {
 
         Ok(())
     }
+}
+
+// Generic node implementation.
+impl<V, L: Eq> Node<V, L> {
+    pub fn new(package_id: PackageId, value: V, label: L) -> Self {
+        Self {
+            package_id,
+            value,
+            children: Vec::new(),
+            label,
+        }
+    }
 
     /// Gets the package id.
-    pub fn get_id(&self) -> &PackageId {
-        &self.id
+    pub fn get_package_id(&self) -> &PackageId {
+        &self.package_id
     }
 
     /// Gets the value of the node.
@@ -178,71 +132,50 @@ impl<V, L: Eq> Node<V, L> {
         &self.value
     }
 
-    /// Gets the ids of the children of the node in a hashset.
-    /// Checks for a filter on the label and will only return the children that satisfy the filter.
-    pub fn get_children_ids_filtered<F>(&self, filter: F) -> HashSet<PackageId>
-    where
-        F: Fn(&L) -> bool,
-    {
-        self.children.iter().filter(|c| filter(&c.label)).map(|c| c.id.clone()).collect()
-    }
-
-    /// Gets the ids of the children of the node in a hashset.
-    pub fn get_children_ids(&self) -> HashSet<PackageId> {
-        self.children.iter().map(|c| c.id.clone()).collect()
-    }
-
     /// Gets the child nodes as reference.
-    pub fn get_children(&self) -> &Vec<Node<V, L>> {
+    pub fn get_children(&self) -> &Vec<usize> {
         &self.children
-    }
-
-    /// Gets the child nodes as mutable reference.
-    pub fn get_children_mut(&mut self) -> &mut Vec<Node<V, L>> {
-        &mut self.children
     }
 
     /// Gets the label.
     pub fn get_label(&self) -> &L {
         &self.label
     }
-
-    /// Sets a new label.
-    pub fn set_label(&mut self, new_label: L) {
-        self.label = new_label;
-    }
 }
 
-/// Represents an empty node, without any value or label.
-pub type EmptyNode = Node<(), ()>;
+/// Represents a tree, without any value or label at its nodes.
+pub type EmptyTree = Tree<(), ()>;
 
 // An empty node implementation, without any values or labels.
-impl EmptyNode {
+impl EmptyTree {
     /// Builds a simple tree based on the installed packages.
-    pub fn build_simple_tree(package_id: PackageId, register: &PackageRegister) -> Result<EmptyNode> {
-        TreeBuilder::new()
-            .root(package_id, (), ())
-            .expander(|p| EmptyNode::expander(p, register))
-            .populator(EmptyNode::populator)
-            .build()
-    }
+    pub fn new_emtpy(package_id: PackageId, register: &PackageRegister) -> Result<EmptyTree> {
+        let root = Node::new(package_id, (), ());
+        let mut tree = Tree::new(root);
 
-    /// Gets the children based on the installed packages.
-    fn expander(parent: &EmptyNode, register: &PackageRegister) -> Result<Vec<PackageId>> {
-        let package = register.get_package_version(parent.get_id()).ok_or(TreeError::NotFound(parent.get_id().clone()))?;
-        Ok(package.dependencies.iter().cloned().collect())
-    }
+        let mut package_queue = VecDeque::from([0 as usize]);
+        while let Some(node_index) = package_queue.pop_front() {
+            let node = tree.get_node_by_index_mut(node_index).expect("Expected node to exist");
+            let dependencies = &register
+                .get_package_version(node.get_package_id())
+                .ok_or(TreeError::NotFound(node.get_package_id().clone()))?
+                .dependencies;
 
-    /// Populates nodes with empty values and labels.
-    fn populator(package_id: PackageId) -> Result<(PackageId, (), ())> {
-        Ok((package_id, (), ()))
+            for dependency in dependencies {
+                let new_node = Node::new(dependency.clone(), (), ());
+                let new_index = tree.add_node(node_index, new_node);
+                package_queue.push_back(new_index);
+            }
+        }
+
+        Ok(tree)
     }
 }
 
 // Display trait for nice display of a tree.
-impl<V, L: Eq> Display for Node<V, L> {
+impl<V, L: Eq> Display for Tree<V, L> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        self.display_impl(f, self, "")?;
+        self.display_impl(f, &0, "")?;
         Ok(())
     }
 }

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -63,13 +63,15 @@ impl<V, L: Eq> Tree<V, L> {
             return Err(TreeError::CycleError(node.get_package_id().clone()));
         }
 
-        node.parent_index = parent_index;
-        self.nodes.push(node);
-        let index = self.nodes.len() - 1;
+        // Get the parent and check if it exists
         let parent = match self.nodes.get_mut(parent_index) {
             Some(parent) => parent,
             None => return Err(TreeError::NonExistentParent(parent_index)),
         };
+
+        node.parent_index = parent_index;
+        self.nodes.push(node);
+        let index = self.nodes.len() - 1;
 
         parent.children.push(index);
         Ok(index)
@@ -87,8 +89,8 @@ impl<V, L: Eq> Tree<V, L> {
     }
 
     /// Gets a node based on its index.
-    pub fn get_node_by_index(&self, index: &usize) -> Option<&Node<V, L>> {
-        self.nodes.get(*index)
+    pub fn get_node_by_index(&self, index: usize) -> Option<&Node<V, L>> {
+        self.nodes.get(index)
     }
 
     /// Gets a node mutably based on its index.
@@ -111,7 +113,7 @@ impl<V, L: Eq> Tree<V, L> {
     }
 
     /// Checks if a given package id will create a cycle in the tree.
-    /// Returns true is a cycle will be formed, false if not.
+    /// Returns true if a cycle will be formed, false if not.
     /// Returns `TreeError::NonExistentParent` if the given parent_index doesn't exist.
     fn is_cyclic(&self, parent_index: &usize, package_id: &PackageId) -> Result<bool> {
         let mut current_parent = parent_index;
@@ -131,7 +133,7 @@ impl<V, L: Eq> Tree<V, L> {
     }
 
     /// The implementation of the tree display.
-    fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, node_index: &usize, prefix: &str) -> std::fmt::Result {
+    fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, node_index: usize, prefix: &str) -> std::fmt::Result {
         let node = self.get_node_by_index(node_index).expect("Expected node to exist");
         writeln!(f, "{prefix}{}", node.package_id)?;
 

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -23,6 +23,9 @@ pub enum TreeError {
     #[error("Parent with node id '{0}' cannot be found")]
     NonExistentParent(usize),
 
+    #[error("'{0}' has itself as a dependency, creating a cycle in the tree")]
+    CycleError(PackageId),
+
     #[error("Cannot create tree, because of an error reading the repository.")]
     RepositoryError(#[from] RepositoryError),
 }
@@ -41,6 +44,7 @@ pub struct Node<V, L: Eq> {
     package_id: PackageId,
     value: V,
     children: Vec<usize>,
+    parent_index: usize,
     label: L,
 }
 
@@ -49,7 +53,17 @@ impl<V, L: Eq> Tree<V, L> {
         Self { nodes: vec![root] }
     }
 
-    pub fn add_node(&mut self, parent_index: usize, node: Node<V, L>) -> Result<usize> {
+    /// Adds a node to the tree under the given parent index.
+    /// Returns the index of the node added to the nodes list.
+    /// Returns a `TreeError::CycleError` if the new node creates a cycle in the tree.
+    /// Returns a `TreeError::NonExistentParent` if the given parent index doesn't exist.
+    pub fn add_node(&mut self, parent_index: usize, mut node: Node<V, L>) -> Result<usize> {
+        // Check for cycles before adding the node to the tree
+        if self.is_cyclic(&parent_index, node.get_package_id())? {
+            return Err(TreeError::CycleError(node.get_package_id().clone()));
+        }
+
+        node.parent_index = parent_index;
         self.nodes.push(node);
         let index = self.nodes.len() - 1;
         let parent = match self.nodes.get_mut(parent_index) {
@@ -61,6 +75,8 @@ impl<V, L: Eq> Tree<V, L> {
         Ok(index)
     }
 
+    /// Gets the root of the tree.
+    #[expect(unused)]
     pub fn get_root(&self) -> &Node<V, L> {
         self.nodes.get(0).expect("Expected root to exist")
     }
@@ -71,8 +87,8 @@ impl<V, L: Eq> Tree<V, L> {
     }
 
     /// Gets a node based on its index.
-    pub fn get_node_by_index(&self, index: usize) -> Option<&Node<V, L>> {
-        self.nodes.get(index)
+    pub fn get_node_by_index(&self, index: &usize) -> Option<&Node<V, L>> {
+        self.nodes.get(*index)
     }
 
     /// Gets a node mutably based on its index.
@@ -88,15 +104,35 @@ impl<V, L: Eq> Tree<V, L> {
     {
         node.get_children()
             .iter()
-            .map(|c| self.get_node_by_index(*c).expect("Expected node to exist"))
+            .map(|c| self.get_node_by_index(c).expect("Expected node to exist"))
             .filter(|c| filter(&c.label))
             .map(|c| c.package_id.clone())
             .collect()
     }
 
+    /// Checks if a given package id will create a cycle in the tree.
+    /// Returns true is a cycle will be formed, false if not.
+    /// Returns `TreeError::NonExistentParent` if the given parent_index doesn't exist.
+    fn is_cyclic(&self, parent_index: &usize, package_id: &PackageId) -> Result<bool> {
+        let mut current_parent = parent_index;
+        while *current_parent != 0 {
+            let Some(parent_node) = self.get_node_by_index(current_parent) else {
+                return Err(TreeError::NonExistentParent(*current_parent));
+            };
+
+            if parent_node.get_package_id() == package_id {
+                return Ok(true);
+            }
+
+            current_parent = parent_node.get_parent();
+        }
+
+        Ok(false)
+    }
+
     /// The implementation of the tree display.
     fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, node_index: &usize, prefix: &str) -> std::fmt::Result {
-        let node = self.get_node_by_index(*node_index).expect("Expected node to exist");
+        let node = self.get_node_by_index(node_index).expect("Expected node to exist");
         writeln!(f, "{prefix}{}", node.package_id)?;
 
         // Note that when the input prefix is "" then this prefix will also be ""
@@ -120,11 +156,14 @@ impl<V, L: Eq> Tree<V, L> {
 
 // Generic node implementation.
 impl<V, L: Eq> Node<V, L> {
+    /// Creates a new `Node`. Note that the parent_index is 0 by default. The root will have itself as parent
+    /// and when adding a node to a `Tree` the parent index will need to be adjusted.
     pub fn new(package_id: PackageId, value: V, label: L) -> Self {
         Self {
             package_id,
             value,
             children: Vec::new(),
+            parent_index: 0,
             label,
         }
     }
@@ -137,6 +176,11 @@ impl<V, L: Eq> Node<V, L> {
     /// Gets the value of the node.
     pub fn get_value(&self) -> &V {
         &self.value
+    }
+
+    /// Gets the parent index of the node.
+    pub fn get_parent(&self) -> &usize {
+        &self.parent_index
     }
 
     /// Gets the child nodes as reference.

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -20,6 +20,9 @@ pub enum TreeError {
     #[error("Package id '{0}' cannot be found")]
     NotFound(PackageId),
 
+    #[error("Parent with node id '{0}' cannot be found")]
+    NonExistentParent(usize),
+
     #[error("Cannot create tree, because of an error reading the repository.")]
     RepositoryError(#[from] RepositoryError),
 }
@@ -46,12 +49,16 @@ impl<V, L: Eq> Tree<V, L> {
         Self { nodes: vec![root] }
     }
 
-    pub fn add_node(&mut self, parent_index: usize, node: Node<V, L>) -> usize {
+    pub fn add_node(&mut self, parent_index: usize, node: Node<V, L>) -> Result<usize> {
         self.nodes.push(node);
         let index = self.nodes.len() - 1;
-        let parent = self.nodes.get_mut(parent_index).expect("TODO");
+        let parent = match self.nodes.get_mut(parent_index) {
+            Some(parent) => parent,
+            None => return Err(TreeError::NonExistentParent(parent_index)),
+        };
+
         parent.children.push(index);
-        index
+        Ok(index)
     }
 
     pub fn get_root(&self) -> &Node<V, L> {
@@ -81,7 +88,7 @@ impl<V, L: Eq> Tree<V, L> {
     {
         node.get_children()
             .iter()
-            .map(|c| self.get_node_by_index(*c).expect("TODO"))
+            .map(|c| self.get_node_by_index(*c).expect("Expected node to exist"))
             .filter(|c| filter(&c.label))
             .map(|c| c.package_id.clone())
             .collect()
@@ -149,7 +156,7 @@ pub type EmptyTree = Tree<(), ()>;
 // An empty node implementation, without any values or labels.
 impl EmptyTree {
     /// Builds a simple tree based on the installed packages.
-    pub fn new_emtpy(package_id: PackageId, register: &PackageRegister) -> Result<EmptyTree> {
+    pub fn new_empty(package_id: PackageId, register: &PackageRegister) -> Result<EmptyTree> {
         let root = Node::new(package_id, (), ());
         let mut tree = Tree::new(root);
 
@@ -163,7 +170,7 @@ impl EmptyTree {
 
             for dependency in dependencies {
                 let new_node = Node::new(dependency.clone(), (), ());
-                let new_index = tree.add_node(node_index, new_node);
+                let new_index = tree.add_node(node_index, new_node)?;
                 package_queue.push_back(new_index);
             }
         }


### PR DESCRIPTION
This refactors the tree util, making it easier to use (less generic types). It also makes the install iterative instead of recursive in preparation for parallelization of the install.

The install tree is also fully expanded and shown to the user, making it clearer what will be installed.

The UI functionality still needs some works (also deciding which crates to finally use), but this should be done on a separate UI branch I think.