### PR TITLE
Small install fixes/changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,11 +20,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Update all dependencies, remove unnecessary dependency features and ensure all dependencies support MSRV 1.85.
 - When packages are specified for the `check` and `fix` commands, only those are checked when doing a package related check. Initial and general checks are now done as well in the case.
 - Improve IOError messages by including information about the operation that failed.
+- The `gnubin` directory of a package is now also symlinked into `<prefix>/gnubin`.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.
 - Fix `--updatables` flag listing older installed package versions when a newer up-to-date version is installed.
 - Fix checksum check for patch files that are downloaded from the metadata repository.
+- Fix empty directories (`lib`, `share`) in the prefix, by not creating them anymore.
 
 
 ## [v0.0.2](https://github.com/pack-it/packit/compare/0.0.1...0.0.2) - 2026-05-14

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -57,9 +57,8 @@ impl<'a> Into<Environment> for BuildEnv<'a> {
         }
 
         // Add M4 variable if m4 is a dependency
-        if self.build_dependencies.iter().any(|x| *x.package_id.name == "m4") {
-            let m4_path = self.prefix_directory.join("bin").join("m4");
-            match m4_path.to_str() {
+        if let Some(m4) = self.build_dependencies.iter().find(|x| *x.package_id.name == "m4") {
+            match m4.install_path.to_str() {
                 Some(path) => env.insert_var("M4", path),
                 None => warning!("Cannot add M4 var to build env: cannot convert PathBuf to string"),
             };

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -56,7 +56,7 @@ impl<'a> Into<Environment> for BuildEnv<'a> {
             env.strip_var(*var);
         }
 
-        // Add M4 variable if m4 is a dependency
+        // Add M4 variable if m4 is a build dependency
         if let Some(m4) = self.build_dependencies.iter().find(|x| *x.package_id.name == "m4") {
             match m4.install_path.to_str() {
                 Some(path) => env.insert_var("M4", path),

--- a/src/installer/mod.rs
+++ b/src/installer/mod.rs
@@ -15,4 +15,5 @@ pub use self::installer::Installer;
 
 pub use self::options::InstallerOptions;
 
+pub use self::symlinker::SYMLINK_DIRECTORIES;
 pub use self::symlinker::Symlinker;

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -62,7 +62,7 @@ impl<'a> Symlinker<'a> {
         let package_directory = self.config.prefix_directory.join("packages").join(&package_id.name);
 
         // Remove symlinks for all package symlinked directories
-        for dir_name in SYMLINK_DIRECTORIES.iter().chain(iter::once("active")) {
+        for dir_name in SYMLINK_DIRECTORIES.iter().chain(iter::once(&"active")) {
             let prefix_dir_path = self.config.prefix_directory.join(dir_name);
 
             io::remove_symlinks(&prefix_dir_path, &package_directory)?;

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::Path};
+use std::{fs, iter, path::Path};
 
 use crate::{
     cli::display::logging::warning,
@@ -13,6 +13,9 @@ use crate::{
     utils::{io, ioerror::IOResultExt},
 };
 
+/// All directories of a package that should be symlinked.
+pub const SYMLINK_DIRECTORIES: &[&str] = &["bin", "include", "lib", "share", "gnubin"];
+
 /// Manages symlink operations for installing, uninstalling and changing active and symlink states of packages.
 pub struct Symlinker<'a> {
     config: &'a Config,
@@ -24,14 +27,14 @@ impl<'a> Symlinker<'a> {
         Self { config }
     }
 
-    /// Creates symlinks from Packit's "bin", "include", "lib" and "share" folders to
-    /// the "bin", "include", "lib" and "share" folders in a given package directory.
+    /// Creates symlinks from Packit's "bin", "include", "lib", "share", etc. directories to
+    /// the "bin", "include", "lib", "share", etc. directories in a given package directory.
     /// Could return an IO error.
     pub fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
         let prefix_dir = Path::new(&self.config.prefix_directory);
 
-        // Symlink directories bin, include, lib and share
-        for dir_name in ["bin", "include", "lib", "share"] {
+        // Symlink package directories bin, include, lib, share, etc.
+        for dir_name in SYMLINK_DIRECTORIES {
             let package_dir_path = package_directory.join(dir_name);
             let prefix_dir_path = prefix_dir.join(dir_name);
 
@@ -58,8 +61,8 @@ impl<'a> Symlinker<'a> {
 
         let package_directory = self.config.prefix_directory.join("packages").join(&package_id.name);
 
-        // Symlink directories bin, include, lib and share
-        for dir_name in ["bin", "include", "lib", "share", "active"] {
+        // Remove symlinks for all package symlinked directories
+        for dir_name in SYMLINK_DIRECTORIES.iter().chain(iter::once("active")) {
             let prefix_dir_path = self.config.prefix_directory.join(dir_name);
 
             io::remove_symlinks(&prefix_dir_path, &package_directory)?;

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -8,7 +8,10 @@ use std::{
 use crate::{
     cli::display::logging::{debug, warning},
     config::{Config, Repository},
-    installer::types::{Dependency, PackageId, PackageName},
+    installer::{
+        self,
+        types::{Dependency, PackageId, PackageName},
+    },
     integrity::{Issue, error::Result, utils::get_storage_packages},
     packager,
     platforms::Target,
@@ -296,7 +299,7 @@ fn check_missing_package_link(package_id: &PackageId, register: &PackageRegister
     }
 
     let package_path = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
-    for directory_name in ["bin", "include", "lib", "share"] {
+    for directory_name in installer::SYMLINK_DIRECTORIES {
         let symlink_directory = config.prefix_directory.join(directory_name);
         let directory = package_path.join(directory_name);
 

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -17,14 +17,14 @@ use crate::{
 /// Recursively creates symlinks from a link directory to the original directory.
 /// Note that there is an early return when the original doesn't exist. Non-existant link directories are created.
 pub fn create_folder_symlinks(original_dir: &Path, link_dir: &Path) -> symlink::Result<()> {
-    // Create destination if it does not exist
-    if !link_dir.exists() {
-        fs::create_dir_all(link_dir).err_with_path("create dirs", link_dir)?;
-    }
-
     // Skip symlinking if source does not exist
     if !original_dir.exists() {
         return Ok(());
+    }
+
+    // Create destination if it does not exist
+    if !link_dir.exists() {
+        fs::create_dir_all(link_dir).err_with_path("create dirs", link_dir)?;
     }
 
     // Symlink files


### PR DESCRIPTION
The symlinker now doesn't create empty directories anymore, it first checks if the directory is needed.
The symlinker now symlinks the `gnubin` directory.
The build environment now uses an absolute path to the M4 installation in the `M4` environment variable when M4 is listed as a build dependency.