### PR TITLE
Add update all and exclude flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Support for loading non-text external test files.
 - The `--active` flag for the list command, to list all active packages.
 - Support for context (using our [`contextdiff-parser`](https://github.com/pack-it/contextdiff-parser)) and unified diff formats for patches.
+- The update command now accepts multiple packages as input instead of just one.
+- The `--all` flag for the update command flag to update all packages which are not up-to-date.
+- The `--exclude` flag for the update command to exclude certain packages when using the `--all` flag.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Improve IOError messages by including information about the operation that failed.
 - The `gnubin` directory of a package is now also symlinked into `<prefix>/gnubin`.
 - The `check` and `fix` commands now accept `[<PACKAGE-NAME>[@<VERSION>] ...]` instead of just `[<PACKAGE-NAME>@<VERSION> ...]`.
+- The `update` command now updates the latest install version, unless otherwise specified.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Lists all the installed packages.
 Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata. If the version is given that specific version is searched for.
 
 #### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
-Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and --new-version cannot be used). If multiple versions of the same package are installed, the `--new-version` flag is required, note that this cannot be done with multiple packages at once. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.
+Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and `--new-version` cannot be used). If multiple versions of the same package are installed, the latest installed version is assumed. The `--new-version` flag can be used to specify the new version to install. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.
 
 #### `pit info <PACKAGE-NAME>[@<VERSION>] [-v] [--tree]`
 Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown.

--- a/README.md
+++ b/README.md
@@ -68,8 +68,8 @@ Lists all the installed packages.
 #### `pit search <PACKAGE-NAME>[@<VERSION>]`
 Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata. If the version is given that specific version is searched for.
 
-#### `pit update <PACKAGE-NAME>[@<VERSION>] [<NEW-VERSION>]`
-Updates the specified package to the new version, or the latest version if no new version is specified. If multiple versions of the same package are installed, the `<VERSION>` option is required.
+#### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
+Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and --new-version cannot be used). If multiple versions of the same package are installed, the `--new-version` flag is required, note that this cannot be done with multiple packages at once. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.
 
 #### `pit info <PACKAGE-NAME>[@<VERSION>] [-v] [--tree]`
 Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown.

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -4,7 +4,10 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display},
     config::Config,
-    installer::Installer,
+    installer::{
+        Installer,
+        types::{OptionalPackageId, PackageId},
+    },
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::manager::RepositoryManager,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -57,6 +60,16 @@ impl ListArgs {
             return;
         }
 
-        display::print_grid(&updatables);
+        // Expand the updatables with all installed versions instead of just the highest one
+        let mut expanded_updatables = Vec::new();
+        for package in updatables {
+            for version in register.get_package(&package.name).expect("Expected package to exist").versions.keys() {
+                let package_id = PackageId::new(package.name.clone(), version.clone());
+                let optional_id = OptionalPackageId::from(package_id);
+                expanded_updatables.push(optional_id);
+            }
+        }
+
+        display::print_grid(&expanded_updatables);
     }
 }

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -5,7 +5,7 @@ use crate::{
     cli::{commands::HandleCommand, display},
     config::Config,
     installer::{
-        Installer,
+        Installer, InstallerOptions,
         types::{OptionalPackageId, PackageId},
     },
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
@@ -29,10 +29,10 @@ impl HandleCommand for ListArgs {
     fn handle(&self) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
-        let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
+        let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
         if self.updatables {
-            self.updatables_list(&config, &register);
+            self.updatables_list(&config, &mut register);
 
             return;
         }
@@ -51,10 +51,12 @@ impl HandleCommand for ListArgs {
 
 impl ListArgs {
     /// Lists all updatable packages.
-    fn updatables_list(&self, config: &Config, register: &PackageRegister) {
+    fn updatables_list(&self, config: &Config, register: &mut PackageRegister) {
         let manager = RepositoryManager::new(config);
-        let updatables = Installer::get_updatables(register, &manager).unwrap_or_exit(1);
+        let options = InstallerOptions::default();
+        let installer = Installer::new(&config, register, &manager, options);
 
+        let updatables = installer.get_updatables().unwrap_or_exit(1);
         if updatables.is_empty() {
             println!("All packages are up-to-date!");
             return;

--- a/src/cli/commands/list.rs
+++ b/src/cli/commands/list.rs
@@ -4,8 +4,7 @@ use clap::Args;
 use crate::{
     cli::{commands::HandleCommand, display},
     config::Config,
-    installer::types::PackageId,
-    platforms::Target,
+    installer::Installer,
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::manager::RepositoryManager,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -36,14 +35,14 @@ impl HandleCommand for ListArgs {
         }
 
         if self.active {
-            display::print_grid(register.iterate_active_packages().collect());
+            display::print_grid(&register.iterate_active_packages().collect());
 
             return;
         }
 
         let mut packages: Vec<&InstalledPackageVersion> = register.iterate_all().collect();
         packages.sort_by_key(|a| a.package_id.to_string());
-        display::print_grid(packages.iter().map(|p| &p.package_id).collect());
+        display::print_grid(&packages.iter().map(|p| &p.package_id).collect());
     }
 }
 
@@ -51,27 +50,13 @@ impl ListArgs {
     /// Lists all updatable packages.
     fn updatables_list(&self, config: &Config, register: &PackageRegister) {
         let manager = RepositoryManager::new(config);
-        let mut updatables = Vec::new();
-        for (package_name, package) in register.iterate_packages() {
-            let (_, package_meta) = manager.read_package(&package_name).unwrap_or_exit(1);
-            let latest_available_version = package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1);
-
-            // Get the latest installed version
-            let latest_installed_version = package.versions.keys().max().expect("Expected a latest installed version");
-
-            // Check if the latest version exists
-            if latest_available_version == latest_installed_version {
-                continue;
-            }
-
-            updatables.push(PackageId::new(package_name.clone(), latest_installed_version.clone()));
-        }
+        let updatables = Installer::get_updatables(register, &manager).unwrap_or_exit(1);
 
         if updatables.is_empty() {
-            println!("No updatable packages found");
+            println!("All packages are up-to-date!");
             return;
         }
 
-        display::print_grid(updatables);
+        display::print_grid(&updatables);
     }
 }

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -63,7 +63,7 @@ impl SearchArgs {
             return;
         }
 
-        print_grid(matches.into_iter().collect());
+        print_grid(&matches.into_iter().collect());
     }
 
     /// Searches information of a package based on the provided `OptionalPackageId`.

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -26,7 +26,7 @@ use crate::{
 /// cannot be done with multiple packages at once.
 #[derive(Args, Debug)]
 pub struct UpdateArgs {
-    /// The packages to update specified with <PACKAGE-NAME>[@<VERSION>]
+    /// The packages to update specified with <PACKAGE-NAME>[@<VERSION>] ...
     #[arg(conflicts_with = "all")]
     optional_ids: Vec<OptionalPackageId>,
 
@@ -38,7 +38,7 @@ pub struct UpdateArgs {
     #[arg(long, default_value = "false", conflicts_with_all = ["optional_ids"])]
     all: bool,
 
-    /// Exclude packages when using the `--all` flag
+    /// Exclude packages when using the `--all` flag, specified with <PACKAGE-NAME> ...
     #[arg(long, requires = "all")]
     exclude: Vec<PackageName>,
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -28,14 +28,14 @@ use crate::{
 pub struct UpdateArgs {
     /// The packages to update specified with <PACKAGE-NAME>[@<VERSION>] ...
     #[arg(conflicts_with = "all")]
-    optional_ids: Vec<OptionalPackageId>,
+    packages: Vec<OptionalPackageId>,
 
     /// The version to update to. This can only be a higher version than the current version and can only be used when a single package is specified
-    #[arg(long, requires = "optional_ids")]
+    #[arg(long, requires = "packages")]
     new_version: Option<Version>,
 
     /// Updates all the installed packages to the latest version possible
-    #[arg(long, default_value = "false", conflicts_with_all = ["optional_ids"])]
+    #[arg(long, default_value = "false", conflicts_with = "packages")]
     all: bool,
 
     /// Exclude packages when using the `--all` flag, specified with <PACKAGE-NAME> ...
@@ -50,20 +50,18 @@ impl HandleCommand for UpdateArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
+        let options = InstallerOptions::default();
+        let installer = Installer::new(&config, &mut register, &manager, options);
+
         // If `--all` is specified use all the updatable pacakges
         let optional_ids = match self.all {
-            true => &self.get_updatables(&register, &manager),
-            false if self.optional_ids.is_empty() => {
+            true => &self.get_updatables(installer),
+            false if self.packages.is_empty() => {
                 error!(msg: "No packages specified to update");
                 exit(1);
             },
-            false => &self.optional_ids,
+            false => &self.packages,
         };
-
-        if optional_ids.is_empty() {
-            error!(msg: "No packages were specified or found to be updatable");
-            exit(1);
-        }
 
         if optional_ids.len() > 1 && self.new_version.is_some() {
             error!(msg: "Cannot specify new version when multiple packages are given");
@@ -118,10 +116,15 @@ impl HandleCommand for UpdateArgs {
                 },
             };
 
-            println!("Successfully updated {} to {new_package_id}", optional_id);
+            match new_package_id {
+                Some(new_package_id) => {
+                    println!("Successfully updated {} to {new_package_id}", optional_id);
 
-            // Save changes
-            register.save_to(&register_dir).unwrap_or_exit(1);
+                    // Save changes
+                    register.save_to(&register_dir).unwrap_or_exit(1);
+                },
+                None => println!("{} is up-to-date!", optional_id.name),
+            }
         }
     }
 }
@@ -129,8 +132,8 @@ impl HandleCommand for UpdateArgs {
 impl UpdateArgs {
     /// Gets the updatables and prints them. It will also exclude the packages specified with the exclude flag.
     /// Returns the updatables or exits with status 0 in case all packages are up-to-date.
-    pub fn get_updatables(&self, register: &PackageRegister, manager: &RepositoryManager) -> Vec<OptionalPackageId> {
-        let updatables = Installer::get_updatables(register, manager).unwrap_or_exit(1);
+    pub fn get_updatables(&self, installer: Installer) -> Vec<OptionalPackageId> {
+        let updatables = installer.get_updatables().unwrap_or_exit(1);
 
         // Filter the packages to exclude
         let mut filtered_updatables = Vec::new();

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -12,7 +12,7 @@ use crate::{
     config::Config,
     installer::{
         Installer, InstallerOptions,
-        types::{OptionalPackageId, Version},
+        types::{OptionalPackageId, PackageName, Version},
     },
     platforms::Target,
     register::package_register::PackageRegister,
@@ -26,17 +26,21 @@ use crate::{
 /// cannot be done with multiple packages at once.
 #[derive(Args, Debug)]
 pub struct UpdateArgs {
-    /// The name of the package to update, with an optional version specified with NAME@VERSION
+    /// The packages to update specified with <PACKAGE-NAME>[@<VERSION>]
     #[arg(conflicts_with = "all")]
     optional_ids: Vec<OptionalPackageId>,
 
-    /// The version to update to. This can only be a higher version than the current version and is only used when a single package is specified
+    /// The version to update to. This can only be a higher version than the current version and can only be used when a single package is specified
     #[arg(long, requires = "optional_ids")]
     new_version: Option<Version>,
 
     /// Updates all the installed packages to the latest version possible
     #[arg(long, default_value = "false", conflicts_with_all = ["optional_ids"])]
     all: bool,
+
+    /// Exclude packages when using the `--all` flag
+    #[arg(long, requires = "all")]
+    exclude: Vec<PackageName>,
 }
 
 impl HandleCommand for UpdateArgs {
@@ -123,17 +127,26 @@ impl HandleCommand for UpdateArgs {
 }
 
 impl UpdateArgs {
-    /// Gets the updatables and prints them.
+    /// Gets the updatables and prints them. It will also exclude the packages specified with the exclude flag.
     /// Returns the updatables or exits with status 0 in case all packages are up-to-date.
     pub fn get_updatables(&self, register: &PackageRegister, manager: &RepositoryManager) -> Vec<OptionalPackageId> {
         let updatables = Installer::get_updatables(register, manager).unwrap_or_exit(1);
-        if updatables.is_empty() {
+
+        // Filter the packages to exclude
+        let mut filtered_updatables = Vec::new();
+        for package_id in updatables {
+            if !self.exclude.contains(&package_id.name) {
+                filtered_updatables.push(package_id);
+            }
+        }
+
+        if filtered_updatables.is_empty() {
             println!("All packages are up-to-date!");
             exit(0);
         }
 
         println!("The following packages will be updated:");
-        grid::print_grid(&updatables);
+        grid::print_grid(&filtered_updatables);
 
         // Check if the user wants to proceed with the update of the found packages
         let question = "Do you wish to proceed?";
@@ -142,6 +155,6 @@ impl UpdateArgs {
             exit(0);
         }
 
-        updatables.into_iter().map(|p| OptionalPackageId::from(p)).collect()
+        filtered_updatables.into_iter().map(|p| OptionalPackageId::from(p)).collect()
     }
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -6,7 +6,7 @@ use clap::Args;
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{logging::error, not_found},
+        display::{QuestionResponse, ask_user, grid, logging::error, not_found},
         parameter_checks,
     },
     config::Config,
@@ -21,15 +21,22 @@ use crate::{
 };
 
 /// Updates the specified package to the new version, or the latest version if no new version is specified.
-/// If multiple versions of the same package are installed, the <VERSION> option is required.
+/// If multiple packages are specified they are all updated to the latest version.
+/// If multiple versions of the same package are installed, the <VERSION> option is required, note that this
+/// cannot be done with multiple packages at once.
 #[derive(Args, Debug)]
 pub struct UpdateArgs {
     /// The name of the package to update, with an optional version specified with NAME@VERSION
+    #[arg(conflicts_with = "all")]
     optional_ids: Vec<OptionalPackageId>,
 
     /// The version to update to. This can only be a higher version than the current version and is only used when a single package is specified
     #[arg(long, requires = "optional_ids")]
     new_version: Option<Version>,
+
+    /// Updates all the installed packages to the latest version possible
+    #[arg(long, default_value = "false", conflicts_with_all = ["optional_ids"])]
+    all: bool,
 }
 
 impl HandleCommand for UpdateArgs {
@@ -39,13 +46,28 @@ impl HandleCommand for UpdateArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        if self.optional_ids.len() > 1 && self.new_version.is_some() {
+        // If `--all` is specified use all the updatable pacakges
+        let optional_ids = match self.all {
+            true => &self.get_updatables(&register, &manager),
+            false if self.optional_ids.is_empty() => {
+                error!(msg: "No packages specified to update");
+                exit(1);
+            },
+            false => &self.optional_ids,
+        };
+
+        if optional_ids.is_empty() {
+            error!(msg: "No packages were specified or found to be updatable");
+            exit(1);
+        }
+
+        if optional_ids.len() > 1 && self.new_version.is_some() {
             error!(msg: "Cannot specify new version when multiple packages are given");
             exit(1);
         }
 
         // Check for duplicates, because updating twice will result in an error
-        let duplicates = parameter_checks::get_duplicates(&self.optional_ids);
+        let duplicates = parameter_checks::get_duplicates(optional_ids);
         if !duplicates.is_empty() {
             let mut duplicate_string = String::new();
             for duplicate in duplicates {
@@ -57,7 +79,7 @@ impl HandleCommand for UpdateArgs {
             exit(1);
         }
 
-        for optional_id in &self.optional_ids {
+        for optional_id in optional_ids {
             match optional_id.versioned() {
                 Some(package_id) if register.get_package_version(&package_id).is_some() => {},
                 Some(package_id) => not_found::register_package_version(&package_id, &register),
@@ -97,5 +119,29 @@ impl HandleCommand for UpdateArgs {
             // Save changes
             register.save_to(&register_dir).unwrap_or_exit(1);
         }
+    }
+}
+
+impl UpdateArgs {
+    /// Gets the updatables and prints them.
+    /// Returns the updatables or exits with status 0 in case all packages are up-to-date.
+    pub fn get_updatables(&self, register: &PackageRegister, manager: &RepositoryManager) -> Vec<OptionalPackageId> {
+        let updatables = Installer::get_updatables(register, manager).unwrap_or_exit(1);
+        if updatables.is_empty() {
+            println!("All packages are up-to-date!");
+            exit(0);
+        }
+
+        println!("The following packages will be updated:");
+        grid::print_grid(&updatables);
+
+        // Check if the user wants to proceed with the update of the found packages
+        let question = "Do you wish to proceed?";
+        if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no_or_invalid() {
+            println!("Update canceled");
+            exit(0);
+        }
+
+        updatables.into_iter().map(|p| OptionalPackageId::from(p)).collect()
     }
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -7,6 +7,7 @@ use crate::{
     cli::{
         commands::HandleCommand,
         display::{logging::error, not_found},
+        parameter_checks,
     },
     config::Config,
     installer::{
@@ -24,9 +25,10 @@ use crate::{
 #[derive(Args, Debug)]
 pub struct UpdateArgs {
     /// The name of the package to update, with an optional version specified with NAME@VERSION
-    optional_id: OptionalPackageId,
+    optional_ids: Vec<OptionalPackageId>,
 
-    /// The version to update to. This can only be a higher version than the current version
+    /// The version to update to. This can only be a higher version than the current version and is only used when a single package is specified
+    #[arg(long, requires = "optional_ids")]
     new_version: Option<Version>,
 }
 
@@ -37,35 +39,63 @@ impl HandleCommand for UpdateArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        match self.optional_id.versioned() {
-            Some(package_id) if register.get_package_version(&package_id).is_some() => {},
-            Some(package_id) => not_found::register_package_version(&package_id, &register),
-            None if register.get_package(&self.optional_id.name).is_some() => {},
-            None => not_found::register_package(&self.optional_id.name, &register),
-        }
-
-        let (_, package_meta) = manager.read_package(&self.optional_id.name).unwrap_or_exit(1);
-
-        let new_version = match &self.new_version {
-            Some(version) => version,
-            None => package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1),
-        };
-
-        // Check if the new version exists
-        if !package_meta.versions.contains(new_version) {
-            error!(msg: "New package version '{new_version}' does not exist.");
-            not_found::repository_version(&self.optional_id.name, &manager);
+        if self.optional_ids.len() > 1 && self.new_version.is_some() {
+            error!(msg: "Cannot specify new version when multiple packages are given");
             exit(1);
         }
 
-        let options = InstallerOptions::default();
-        let mut installer = Installer::new(&config, &mut register, &manager, options);
+        // Check for duplicates, because updating twice will result in an error
+        let duplicates = parameter_checks::get_duplicates(&self.optional_ids);
+        if !duplicates.is_empty() {
+            let mut duplicate_string = String::new();
+            for duplicate in duplicates {
+                duplicate_string.push_str(&duplicate.to_string());
+                duplicate_string.push(' ');
+            }
 
-        let new_package_id = installer.update(&self.optional_id, new_version).unwrap_or_exit(1);
+            error!(msg: "Duplicate package arguments are not allowed. The following duplicates were found: {duplicate_string}");
+            exit(1);
+        }
 
-        println!("Successfully updated {} to {new_package_id}", self.optional_id);
+        for optional_id in &self.optional_ids {
+            match optional_id.versioned() {
+                Some(package_id) if register.get_package_version(&package_id).is_some() => {},
+                Some(package_id) => not_found::register_package_version(&package_id, &register),
+                None if register.get_package(&optional_id.name).is_some() => {},
+                None => not_found::register_package(&optional_id.name, &register),
+            }
 
-        // Save changes
-        register.save_to(&register_dir).unwrap_or_exit(1);
+            let (_, package_meta) = manager.read_package(&optional_id.name).unwrap_or_exit(1);
+
+            // Note that there is a check earlier which checks if the new_version is `None` in case of multiple packages
+            let new_version = match &self.new_version {
+                Some(version) => version,
+                None => package_meta.get_latest_version(&Target::current()).unwrap_or_exit(1),
+            };
+
+            // Check if the new version exists
+            if !package_meta.versions.contains(new_version) {
+                error!(msg: "New package version '{new_version}' does not exist.");
+                not_found::repository_version(&optional_id.name, &manager);
+                exit(1);
+            }
+
+            let options = InstallerOptions::default();
+            let mut installer = Installer::new(&config, &mut register, &manager, options);
+
+            // Do the update, and in case of an error throw the error, but continue
+            let new_package_id = match installer.update(&optional_id, new_version) {
+                Ok(new_package_id) => new_package_id,
+                Err(error) => {
+                    error!(error, "Cannot update package {optional_id}");
+                    continue;
+                },
+            };
+
+            println!("Successfully updated {} to {new_package_id}", optional_id);
+
+            // Save changes
+            register.save_to(&register_dir).unwrap_or_exit(1);
+        }
     }
 }

--- a/src/cli/display/grid.rs
+++ b/src/cli/display/grid.rs
@@ -5,7 +5,7 @@ use terminal_size::{Height, Width, terminal_size};
 
 /// Prints the given items in a grid.
 /// Falls back to vertical print if the terminal width cannot be obtained.
-pub fn print_grid<T>(items: Vec<T>)
+pub fn print_grid<T>(items: &Vec<T>)
 where
     T: Display,
 {
@@ -17,7 +17,7 @@ where
 
     // Get the widest string in the given items
     let mut widest = String::from("");
-    for item in &items {
+    for item in items {
         let item = item.to_string();
         if item.len() > widest.len() {
             widest = item;
@@ -46,7 +46,7 @@ where
 }
 
 /// Prints items vertically.
-fn vertical_print<T>(items: Vec<T>)
+fn vertical_print<T>(items: &Vec<T>)
 where
     T: Display,
 {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -663,10 +663,14 @@ impl<'a> Installer<'a> {
     }
 
     /// Updates a package to a newer version.
-    /// Returns a `PackageId` from the updated package if successful.
-    /// Returns an `InstallerError::VersionTooLowError` if the old version is newer then the given new version
-    /// or an `InstallerError::AlreadyInstalledError` if the new package version is already installed.
-    pub fn update(&mut self, optional_id: &OptionalPackageId, new_version: &Version) -> Result<PackageId> {
+    /// Returns a `PackageId` from the updated package if successful, `None` in case the package is already up-to-date.
+    /// Returns an `InstallerError::VersionTooLowError` if the old version is newer then the given new version.
+    pub fn update(&mut self, optional_id: &OptionalPackageId, new_version: &Version) -> Result<Option<PackageId>> {
+        // Check if the new version of the package already exists
+        if self.register.get_package_version(&PackageId::new(optional_id.name.clone(), new_version.clone())).is_some() {
+            return Ok(None);
+        }
+
         let old_package = self.get_specific_package_update(optional_id)?;
         let new_package_id = PackageId::new(old_package.package_id.name.clone(), new_version.clone());
 
@@ -674,13 +678,6 @@ impl<'a> Installer<'a> {
         if old_package.package_id.version > *new_version {
             return Err(InstallerError::VersionTooLowError {
                 new_version: new_version.clone(),
-            });
-        }
-
-        // Check if the new version is already installed
-        if old_package.package_id.version == *new_version {
-            return Err(InstallerError::AlreadyInstalledError {
-                package_id: old_package.package_id.clone(),
             });
         }
 
@@ -773,13 +770,14 @@ impl<'a> Installer<'a> {
             self.uninstall(&old_package_id.into())?;
         }
 
-        Ok(new_package_id)
+        Ok(Some(new_package_id))
     }
 
     /// Gets a specific installed package version. If a version is specified that version is used.
     /// If the version is not specified, but only one version exists, then that version is used.
-    /// Returns an `InstallerError::PackageNotFound` if the package cannot be found or
-    /// an `InstallerError::SpecificityError` if multiple versions exist, but the version isn't specified.
+    /// When multiple versions are installed the latest version is returned.
+    /// Returns an `InstallerError::PackageNotFound` if the package cannot be found or an
+    /// `InstallerError::InstallationCanceled` if the user chooses to cancel the update.
     fn get_specific_package_update(&self, optional_id: &OptionalPackageId) -> Result<&InstalledPackageVersion> {
         // Use the specified version if it exists
         if let Some(package_id) = optional_id.versioned() {
@@ -791,26 +789,38 @@ impl<'a> Installer<'a> {
 
         // Get installed versions
         let installed_versions = self.register.get_all_package_versions(&optional_id.name);
+        let latest_installed_version = match installed_versions.iter().max_by_key(|p| &p.package_id.version) {
+            Some(latest) => latest,
+            None => {
+                return Err(InstallerError::PackageNotFound {
+                    package_name: optional_id.name.to_string(),
+                    version: Some("any".to_string()),
+                });
+            },
+        };
 
-        // Check if version is specified when multiple versions are installed
         if installed_versions.len() > 1 && optional_id.version.is_none() {
-            return Err(InstallerError::SpecificityError);
+            let question = format!(
+                "Multiple versions of '{}' are installed, the latest version '{}' will be updated, do you wish to continue?",
+                optional_id.name, latest_installed_version.package_id.version
+            );
+            if ask_user(&question, QuestionResponse::Yes)?.is_no_or_invalid() {
+                return Err(InstallerError::InstallationCanceled {
+                    reason: "Latest version may not be used, but version not specified".to_string(),
+                });
+            }
         }
 
-        // Get the installed package version and simultaneously check if any version of the package exists
-        Ok(installed_versions.first().ok_or(InstallerError::PackageNotFound {
-            package_name: optional_id.name.to_string(),
-            version: Some("any".to_string()),
-        })?)
+        Ok(*latest_installed_version)
     }
 
     /// Gets the packages which could be updated.
     /// Note that it doesn't take into account package dependencies.
     /// Returns a list of packages which could be updated or a `RepositoryError`.
-    pub fn get_updatables(register: &PackageRegister, manager: &RepositoryManager) -> Result<Vec<PackageId>> {
+    pub fn get_updatables(&self) -> Result<Vec<PackageId>> {
         let mut updatables = Vec::new();
-        for (package_name, package) in register.iterate_packages() {
-            let (_, package_meta) = manager.read_package(&package_name)?;
+        for (package_name, package) in self.register.iterate_packages() {
+            let (_, package_meta) = self.repository_manager.read_package(&package_name)?;
             let latest_available_version = package_meta.get_latest_version(&Target::current())?;
 
             // Get the latest installed version

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -803,4 +803,27 @@ impl<'a> Installer<'a> {
             version: Some("any".to_string()),
         })?)
     }
+
+    /// Gets the packages which could be updated.
+    /// Note that it doesn't take into account package dependencies.
+    /// Returns a list of packages which could be updated or a `RepositoryError`.
+    pub fn get_updatables(register: &PackageRegister, manager: &RepositoryManager) -> Result<Vec<PackageId>> {
+        let mut updatables = Vec::new();
+        for (package_name, package) in register.iterate_packages() {
+            let (_, package_meta) = manager.read_package(&package_name)?;
+            let latest_available_version = package_meta.get_latest_version(&Target::current())?;
+
+            // Get the latest installed version
+            let latest_installed_version = package.versions.keys().max().expect("Expected a latest installed version");
+
+            // Check if the latest version exists
+            if latest_available_version == latest_installed_version {
+                continue;
+            }
+
+            updatables.push(PackageId::new(package_name.clone(), latest_installed_version.clone()));
+        }
+
+        Ok(updatables)
+    }
 }


### PR DESCRIPTION
This PR adds two new flags to the `update` command:
- The `--all` flag to update all outdated packages.
- The `--exclude` flag to exclude packages when using the `--all` flag.

The `update` command now also accepts multiple optional packages as input. Note that the new version is now a flag `--new-version` and can only be used when one packages is given.

The `update` command now assumes the latest installed version for the update, unless otherwise specified.