### PR TITLE
Add overwrite flag to link command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `conflicts_with` fields to describe conflicting packages in the `package.toml` metadata file. Two conflicting packages cannot be symlinked at the same time.
 - The `size` field in the source fields in the `targets.toml` metadata file.
 - Deprecation information fields (deprecated_from, disabled_from and reason), to allow specifying deprecation and disabling dates of packages or specific versions.
+- The `--overwrite` flag to the link command to overwrite existing links from another package that are conflicting.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ Fix all issues found by the check command. You will be asked if you want to fix 
 #### `pit switch <PACKAGE-NAME> <VERSION> [--skip-symlinking]`
 Switches the active version of the specified package to the specified version. If the `--skip-symlinking` option is given, the new active version is not symlinked into the /bin, /lib, /share, etc. directories.
 
-#### `pit link <PACKAGE-NAME> [--force]`
-Links the specified package into the /bin, /lib, /share, etc. directories. If the package metadata does not allow a package to be symlinked, the `--force` option is required to force the symlinking of the package. Please be careful with using the `--force` option, since there is most likely a good reason to skip symlinking.
+#### `pit link <PACKAGE-NAME> [--force] [--overwrite]`
+Links the specified package into the /bin, /lib, /share, etc. directories. If the package metadata does not allow a package to be symlinked, the `--force` option is required to force the symlinking of the package. Please be careful with using the `--force` option, since there is most likely a good reason to skip symlinking. The `--overwrite` option can be used to overwrite existing symlinks from another package, please note that this should normally not be used, as conflicts between packages should be avoided.
 
 #### `pit unlink <PACKAGE-NAME>`
 Unlinks the specified package, causing the package to be unavailable from the `PATH` environment variable.

--- a/src/cli/commands/link.rs
+++ b/src/cli/commands/link.rs
@@ -23,6 +23,10 @@ pub struct LinkArgs {
     /// True to force linking, even when we should not link
     #[arg(short, long, default_value = "false")]
     pub force: bool,
+
+    /// True to overwrite existing links from another package, false to skip existing links
+    #[arg(long, default_value = "false")]
+    pub overwrite: bool,
 }
 
 impl HandleCommand for LinkArgs {
@@ -38,7 +42,7 @@ impl HandleCommand for LinkArgs {
         };
 
         // Check if the package is already symlinked
-        if package.symlinked {
+        if !self.overwrite && package.symlinked {
             println!("This package is already symlinked");
             return;
         }
@@ -105,7 +109,9 @@ impl HandleCommand for LinkArgs {
         }
 
         // Create symlinks
-        Symlinker::new(&config).create_symlinks(&package_version.install_path).unwrap_or_exit_msg("Unable to link package", 1);
+        Symlinker::new(&config)
+            .create_symlinks(&package_version.install_path, self.overwrite)
+            .unwrap_or_exit_msg("Unable to link package", 1);
 
         let package = register
             .get_package_mut(&self.package_name)

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -30,7 +30,7 @@ impl<'a> Symlinker<'a> {
     /// Creates symlinks from Packit's "bin", "include", "lib", "share", etc. directories to
     /// the "bin", "include", "lib", "share", etc. directories in a given package directory.
     /// Could return an IO error.
-    pub fn create_symlinks(&self, package_directory: &Path) -> Result<()> {
+    pub fn create_symlinks(&self, package_directory: &Path, overwrite: bool) -> Result<()> {
         let prefix_dir = Path::new(&self.config.prefix_directory);
 
         // Symlink package directories bin, include, lib, share, etc.
@@ -38,7 +38,7 @@ impl<'a> Symlinker<'a> {
             let package_dir_path = package_directory.join(dir_name);
             let prefix_dir_path = prefix_dir.join(dir_name);
 
-            io::create_folder_symlinks(&package_dir_path, &prefix_dir_path)?;
+            io::create_folder_symlinks(&package_dir_path, &prefix_dir_path, overwrite)?;
         }
 
         Ok(())
@@ -74,7 +74,7 @@ impl<'a> Symlinker<'a> {
 
         // Only create new symlinks if we should symlink
         if should_symlink {
-            self.create_symlinks(Path::new(&package_version.install_path))?;
+            self.create_symlinks(Path::new(&package_version.install_path), false)?;
         }
 
         // Updates the active version and sets its symlinked state

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -315,7 +315,7 @@ pub fn fix_missing_links(missing: Vec<PackageName>, register: &mut PackageRegist
 
         let install_path = package_version.install_path.clone();
         symlinker.unlink_package(register, package_name)?;
-        symlinker.create_symlinks(&install_path)?;
+        symlinker.create_symlinks(&install_path, false)?;
 
         if let Some(package) = register.get_package_mut(package_name) {
             package.symlinked = true;

--- a/src/platforms/symlink.rs
+++ b/src/platforms/symlink.rs
@@ -46,6 +46,12 @@ pub fn remove_symlink(symlink: &Path) -> Result<()> {
     platform::remove_symlink(symlink)
 }
 
+/// Checks if a symlink exists.
+/// Returns true if it does exist, false otherwise.
+pub fn exists(symlink: &Path) -> bool {
+    fs::symlink_metadata(symlink).is_ok()
+}
+
 #[cfg(any(target_os = "macos", target_os = "linux"))]
 pub mod platform {
     use std::path::Path;

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -9,14 +9,14 @@ use std::{
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt};
 
 use crate::{
-    cli::display::logging::warning,
+    cli::display::logging::{debug, warning},
     platforms::symlink,
     utils::ioerror::{self, IOResultExt},
 };
 
 /// Recursively creates symlinks from a link directory to the original directory.
 /// Note that there is an early return when the original doesn't exist. Non-existant link directories are created.
-pub fn create_folder_symlinks(original_dir: &Path, link_dir: &Path) -> symlink::Result<()> {
+pub fn create_folder_symlinks(original_dir: &Path, link_dir: &Path, overwrite: bool) -> symlink::Result<()> {
     // Skip symlinking if source does not exist
     if !original_dir.exists() {
         return Ok(());
@@ -35,14 +35,26 @@ pub fn create_folder_symlinks(original_dir: &Path, link_dir: &Path) -> symlink::
 
         // Create the symlinks for the subdirectory
         if file.file_type().err_with_path("get file type of", file.path())?.is_dir() {
-            create_folder_symlinks(&file.path(), &link_path)?;
+            create_folder_symlinks(&file.path(), &link_path, overwrite)?;
             continue;
         }
 
         // Check if file already exists
-        if fs::exists(&link_path).err_with_path("check existance of", &link_path)? {
-            warning!("Symlink {} already exists in {}", file.file_name().display(), link_dir.display());
-            continue;
+        if symlink::exists(&link_path) {
+            // If the symlink already exists as expected, skip removing and recreation
+            if link_path.is_symlink() && fs::read_link(&link_path).err_with_path("read link", &link_path)? == file.path() {
+                continue;
+            }
+
+            // Show warning and continue if overwrite is disabled
+            if !overwrite {
+                warning!("Symlink '{}' already exists in {}", file.file_name().display(), link_dir.display());
+                continue;
+            }
+
+            // Remove existing symlink when overwrite is enabled
+            debug!("Overwriting symlink {}", link_path.display());
+            symlink::remove_symlink(&link_path)?;
         }
 
         // Symlink file in link path


### PR DESCRIPTION
This PR adds the --overwrite flag to the link command, which can be used to overwrite existing links from a conflicting package.