### PR TITLE
Improved Packit install scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `size` field in the source fields in the `targets.toml` metadata file.
 - Deprecation information fields (deprecated_from, disabled_from and reason), to allow specifying deprecation and disabling dates of packages or specific versions.
 - The `--overwrite` flag to the link command to overwrite existing links from another package that are conflicting.
+- The Packit install scripts for Unix and Windows now cleanup the created Packit files in case of an error during installation.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.

--- a/install.bat
+++ b/install.bat
@@ -25,17 +25,17 @@ set "CONFIG_DIR=C:\Program Files\packit"
 echo Prefix directory: %PREFIX_DIR%
 echo Config directory: %CONFIG_DIR%
 
+REM TODO: Use choice command everywhere
+REM Ask the user for administrator rights
+choice /M "The Packit install script requires root to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue? (Y/n) "
+if ERRORLEVEL 2 (
+    echo Packit install cancelled
+    goto cleanup
+)
+
 REM Check for administrator privileges 
 fltmc >nul 2>&1
 if ERRORLEVEL 1 (
-    echo The Packit install requires administrator privileges to modify '%PREFIX_DIR%' and '%CONFIG_DIR%'.
-    choice /M "Do you wish to continue as administrator?"
-
-    if ERRORLEVEL 2 (
-        echo Packit install cancelled
-        goto cleanup
-    )
-
     REM Rerun the script with elevated permissions (this will first prompt the user)
     powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/k \"%~f0\"'"
 

--- a/install.bat
+++ b/install.bat
@@ -31,7 +31,7 @@ goto cleanup_end
 set STATUS_CODE=%ERRORLEVEL%
 
 popd
-echo Remove installed Packit files
+echo Removing installed Packit files
 
 REM Remove the prefix directory if `PREFIX_DIR` exists
 if exist "%PREFIX_DIR%" (
@@ -92,6 +92,10 @@ if exist "%CONFIG_DIR%\Config.toml" (
     echo Packit already seems to be installed, config file found in '%CONFIG_DIR%'
     exit /b 0
 )
+if exist "%PREFIX_DIR%\Register.toml" (
+    echo Packit already seems to be installed, register file found in '%PREFIX_DIR%'
+    exit /b 0
+)
 
 REM Go into the prefix directory 
 mkdir "%PREFIX_DIR%\packages\packit"
@@ -137,22 +141,21 @@ if not ERRORLEVEL 1 (
             goto cleanup
         )
 
-        REM Install the correct rustup version for the current platform
+        REM Choose the correct rustup version for the current platform
         if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
-            echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe'
-            curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
-            if ERRORLEVEL 1 goto cleanup
+            set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe"
         ) else (
             if defined PROCESSOR_ARCHITEW6432 (
-                echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe'
-                curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
-                if ERRORLEVEL 1 goto cleanup
+                set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe"
             ) else (
-                echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe'
-                curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
-                if ERRORLEVEL 1 goto cleanup
+                set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe"
             )
         )
+
+        REM Install cargo
+        echo Installing cargo from '%RUSTUP_URL%'
+        curl --proto "=https" --tlsv1.2 -sSfL "%RUSTUP_URL%" --output rustup-init.exe
+        if ERRORLEVEL 1 goto cleanup
         
         .\rustup-init.exe
         if ERRORLEVEL 1 goto cleanup

--- a/install.bat
+++ b/install.bat
@@ -32,8 +32,8 @@ if ERRORLEVEL 1 (
     choice /M "Do you wish to continue as administrator?"
 
     if ERRORLEVEL 2 (
-        echo Packit installed cancelled
-        exit /b 1
+        echo Packit install cancelled
+        goto cleanup
     )
 
     REM Rerun the script with elevated permissions (this will first prompt the user)
@@ -42,17 +42,29 @@ if ERRORLEVEL 1 (
     exit /b
 )
 
+REM Exit early with code 0 if there already is a version of Packit installed
+REM Note that we can't rely on the `packit init` command, because we don't know if it fails because of an already existing config file
+if exist "%CONFIG_DIR%\Config.toml" (
+    echo Packit already seems to be installed, config file found in '%CONFIG_DIR%'
+    exit /b 0
+)
+
 REM Go into the prefix directory 
 mkdir "%PREFIX_DIR%\packages\packit"
+if ERRORLEVEL 1 goto cleanup
 pushd "%PREFIX_DIR%\packages\packit"
+if ERRORLEVEL 1 goto cleanup
 
 REM Install Packit to the prefix directory 
 echo Downloading Packit prebuild from `%PREBUILD_URL%`
 curl --proto "=https" -sSfL %PREBUILD_URL% --output packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
 if not ERRORLEVEL 1 (
     tar -xf packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
+    if ERRORLEVEL 1 goto cleanup
     del packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
+    if ERRORLEVEL 1 goto cleanup
     ren packit@%VERSION%-%REVISION%-%TARGET% %VERSION%
+    if ERRORLEVEL 1 goto cleanup
 
     echo Downloading Packit prebuild successful
 ) else (
@@ -61,7 +73,7 @@ if not ERRORLEVEL 1 (
     if ERRORLEVEL 1 (
         echo Retrieving prebuilds failed, because there is no working internet connection
         echo Canceling installation of Packit
-        exit /b 1
+        goto cleanup
     )
 
     set "answer="
@@ -71,8 +83,7 @@ if not ERRORLEVEL 1 (
     if "!answer!"=="no" set "match=1"
     if "!match!"=="1" (
         echo Canceling installation of Packit
-        popd
-        exit /b 1
+        goto cleanup
     )
 
     set RUSTUP_INSTALLED=0
@@ -88,33 +99,36 @@ if not ERRORLEVEL 1 (
         if "!answer!"=="" set "match=1"
         if "!match!"=="1" (
             echo Canceling installation of Packit
-            popd
-            exit /b 1
+            goto cleanup
         )
 
         REM Install the correct rustup version for the current platform
         if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
             echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe'
             curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
+            if ERRORLEVEL 1 goto cleanup
         ) else (
             if defined PROCESSOR_ARCHITEW6432 (
                 echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe'
                 curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
+                if ERRORLEVEL 1 goto cleanup
             ) else (
                 echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe'
                 curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
+                if ERRORLEVEL 1 goto cleanup
             )
         )
         
         .\rustup-init.exe
+        if ERRORLEVEL 1 goto cleanup
         del .\rustup-init.exe
+        if ERRORLEVEL 1 goto cleanup
 
         REM Make sure that the rustup install was successful
         where cargo 2>nul >nul
         if ERRORLEVEL 1 (
             echo Installing rustup failed, canceling Packit installation
-            popd
-            exit /b 1
+            goto cleanup
         )
 
         echo Installing cargo successful
@@ -123,19 +137,26 @@ if not ERRORLEVEL 1 (
 
     echo Downloading Packit source files from '%SOURCE_URL%'
     curl --proto "=https" -sSfL %SOURCE_URL% --output packit@%VERSION%.tar.gz
+    if ERRORLEVEL 1 goto cleanup
     echo Downloading Packit source files successful
 
     echo Unpacking Packit source files
     tar -xf packit@%VERSION%.tar.gz
+    if ERRORLEVEL 1 goto cleanup
     echo Unpacking Packit source files successful
 
     del packit@%VERSION%.tar.gz
+    if ERRORLEVEL 1 goto cleanup
     cd packit@%VERSION%
+    if ERRORLEVEL 1 goto cleanup
 
     echo Building Packit from source
     cargo build-install --destination ..\$VERSION
+    if ERRORLEVEL 1 goto cleanup
     cd ..
+    if ERRORLEVEL 1 goto cleanup
     rmdir /s /q .\packit@%VERSION%
+    if ERRORLEVEL 1 goto cleanup
 
     if "!RUSTUP_INSTALLED!"==1 (
         set "answer="
@@ -147,6 +168,8 @@ if not ERRORLEVEL 1 (
         if "!match!"=="1" (
             echo Uninstalling rustup
             rustup self uninstall
+            if ERRORLEVEL 1 goto cleanup
+            echo Uninstalling rustup successful
         )
     )
 
@@ -155,33 +178,35 @@ if not ERRORLEVEL 1 (
 
 if not exist "%CONFIG_DIR%" (
     mkdir "%CONFIG_DIR%"
+    if ERRORLEVEL 1 goto cleanup
 )
 
 echo Initializing Packit
 "%PREFIX_DIR%\packages\packit\%VERSION%\bin\packit.exe" init
+if ERRORLEVEL 1 goto cleanup
 echo Initializing Packit successful
 
 REM Make sure that packit words
-echo "Testing Packit install"
+echo Testing Packit install
 "%PREFIX_DIR%\bin\pit.exe" --version 2>nul >nul
 if ERRORLEVEL 1 (
     echo Unsuccessfull install of Packit, the 'pit' command cannot be found
-    popd
-    exit /b 1
+    goto cleanup
 )
 
 "%PREFIX_DIR%\bin\packit.exe" --version 2>nul >nul
 if ERRORLEVEL 1 (
     echo Unsuccessfull install of Packit, the 'packit' command cannot be found
-    popd
-    exit /b 1
+    goto cleanup
 )
 
 echo Successfully installed Packit!
 
 REM Exit early if Packit is already in the user PATH
 echo ";%PATH%;" | find /I ";%PREFIX_DIR%\bin;" >nul
-if %ERRORLEVEL%==0 (
+if ERRORLEVEL 0 (
+    echo Packit already found in PATH, no further actions should be required
+    popd
     exit /b 0
 )
 
@@ -194,6 +219,7 @@ if "!answer!"=="yes" set "match=1"
 if "!answer!"=="" set "match=1"
 if "!match!"=="1" (
     setx PATH "%PATH%;%PREFIX_DIR%\bin"
+    if ERRORLEVEL 1 goto cleanup
     echo Restart your shell to refresh your path and use Packit
     popd
     exit /b 0
@@ -203,3 +229,23 @@ echo Add '%PREFIX_DIR%\bin' to your PATH by adding the command below to your she
 echo setx PATH "%%PATH%%;%PREFIX_DIR%\bin"
 
 popd
+exit /b 0
+
+REM Removes all created files in case of an error and exits with the appropriate status code
+:cleanup
+set STATUS_CODE = %ERRORLEVEL%
+
+popd
+echo Remove installed Packit files
+
+REM Remove the prefix directory if `PREFIX_DIR` exists
+if exist "%PREFIX_DIR%" (
+    rmdir /s /q "%PREFIX_DIR%"
+)
+
+REM Remove the config directory if `PREFIX_DIR` exists
+if exist "%CONFIG_DIR%" (
+    rmdir /s /q "%CONFIG_DIR%"
+)
+
+exit /b %STATUS_CODE%

--- a/install.bat
+++ b/install.bat
@@ -56,6 +56,14 @@ if not ERRORLEVEL 1 (
 
     echo Downloading Packit prebuild successful
 ) else (
+    REM Check internet connection with reliable site
+    curl -sSf http://www.google.com >NUL 2>&1
+    if ERRORLEVEL 1 (
+        echo Retrieving prebuilds failed, because there is no working internet connection
+        echo Canceling installation of Packit
+        exit /b 1
+    )
+
     set "answer="
     set /p "answer=Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
     set "match="

--- a/install.bat
+++ b/install.bat
@@ -71,7 +71,7 @@ echo Prefix directory: %PREFIX_DIR%
 echo Config directory: %CONFIG_DIR%
 
 REM Ask the user for administrator rights
-call :ask "Y" "The Packit install script requires root to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue"
+call :ask "Y" "The Packit install script requires administrator privileges to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue"
 if not ERRORLEVEL 1 (
     echo Canceling installation of Packit
     goto cleanup
@@ -144,17 +144,16 @@ if not ERRORLEVEL 1 (
         REM Choose the correct rustup version for the current platform
         if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
             set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe"
+        ) else if "%PROCESSOR_ARCHITECTURE%"=="AMD64" (
+            set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe"
         ) else (
-            if defined PROCESSOR_ARCHITEW6432 (
-                set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe"
-            ) else (
-                set "RUSTUP_URL=https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe"
-            )
+            echo Current target not supported
+            goto cleanup
         )
 
         REM Install cargo
-        echo Installing cargo from '%RUSTUP_URL%'
-        curl --proto "=https" --tlsv1.2 -sSfL "%RUSTUP_URL%" --output rustup-init.exe
+        echo Installing cargo from '!RUSTUP_URL!'
+        curl --proto "=https" --tlsv1.2 -sSfL "!RUSTUP_URL!" --output rustup-init.exe
         if ERRORLEVEL 1 goto cleanup
         
         .\rustup-init.exe

--- a/install.bat
+++ b/install.bat
@@ -1,6 +1,30 @@
 @echo off
 setlocal enabledelayedexpansion
 
+REM A function to handle (yes/no) questions
+REM Returns 1 if the default option was chosen, 0 otherwise
+goto ask_end
+:ask
+REM The preferred answer to the question (the default), needs to be a string of value 'Y' or 'N'
+set "PREFERRED=%~1"
+
+REM The question to ask
+set "QUESTION=%~2"
+
+if "!PREFERRED!"=="Y" (
+    set /p "answer=!QUESTION! (Y/n) "
+    if /I "!answer!"=="N" exit /b 0
+    if /I "!answer!"=="NO" exit /b 0
+    exit /b 1
+)
+
+set /p "answer=!QUESTION! (y/N) "
+if /I "!answer!"=="Y" exit /b 0
+if /I "!answer!"=="YES" exit /b 0
+exit /b 1
+
+:ask_end
+
 set "VERSION=0.0.2"
 set "REVISION=0"
 
@@ -25,11 +49,10 @@ set "CONFIG_DIR=C:\Program Files\packit"
 echo Prefix directory: %PREFIX_DIR%
 echo Config directory: %CONFIG_DIR%
 
-REM TODO: Use choice command everywhere
 REM Ask the user for administrator rights
-choice /M "The Packit install script requires root to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue? (Y/n) "
-if ERRORLEVEL 2 (
-    echo Packit install cancelled
+call :ask "Y" "The Packit install script requires root to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue"
+if not ERRORLEVEL 1 (
+    echo Canceling installation of Packit
     goto cleanup
 )
 
@@ -76,12 +99,8 @@ if not ERRORLEVEL 1 (
         goto cleanup
     )
 
-    set "answer="
-    set /p "answer=Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
-    set "match="
-    if "!answer!"=="n" set "match=1"
-    if "!answer!"=="no" set "match=1"
-    if "!match!"=="1" (
+    call :ask "Y" "Retrieving prebuilds failed. Do you wish to build Packit from source"
+    if not ERRORLEVEL 1 (
         echo Canceling installation of Packit
         goto cleanup
     )
@@ -91,13 +110,8 @@ if not ERRORLEVEL 1 (
     REM Make sure cargo exists before building Packit
     where cargo 2>nul >nul
     if ERRORLEVEL 1 (
-        set "answer="
-        set /p "answer=Cargo is not installed, do you wish to install it to build Packit? (y/N) "
-        set "match="
-        if "!answer!"=="n" set "match=1"
-        if "!answer!"=="no" set "match=1"
-        if "!answer!"=="" set "match=1"
-        if "!match!"=="1" (
+        call :ask "N" "Cargo is not installed, do you wish to install it to build Packit"
+        if ERRORLEVEL 1 (
             echo Canceling installation of Packit
             goto cleanup
         )
@@ -159,13 +173,8 @@ if not ERRORLEVEL 1 (
     if ERRORLEVEL 1 goto cleanup
 
     if "!RUSTUP_INSTALLED!"==1 (
-        set "answer="
-        set /p "answer=You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n) "
-        set "match="
-        if "!answer!"=="y" set "match=1"
-        if "!answer!"=="yes" set "match=1"
-        if "!answer!"=="" set "match=1"
-        if "!match!"=="1" (
+        call :ask "Y" "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it"
+        if ERRORLEVEL 1 (
             echo Uninstalling rustup
             rustup self uninstall
             if ERRORLEVEL 1 goto cleanup
@@ -204,20 +213,15 @@ echo Successfully installed Packit!
 
 REM Exit early if Packit is already in the user PATH
 echo ";%PATH%;" | find /I ";%PREFIX_DIR%\bin;" >nul
-if ERRORLEVEL 0 (
+if %ERRORLEVEL%==0 (
     echo Packit already found in PATH, no further actions should be required
     popd
     exit /b 0
 )
 
 REM Ask the user if they want to automatically add Packit to their PATH
-set "answer="
-set /p "answer=Do you wish to automatically add Packit to your user PATH? (Y/n) "
-set "match="
-if "!answer!"=="y" set "match=1"
-if "!answer!"=="yes" set "match=1"
-if "!answer!"=="" set "match=1"
-if "!match!"=="1" (
+call :ask "Y" "Do you wish to automatically add Packit to your user PATH"
+if ERRORLEVEL 1 (
     setx PATH "%PATH%;%PREFIX_DIR%\bin"
     if ERRORLEVEL 1 goto cleanup
     echo Restart your shell to refresh your path and use Packit
@@ -233,7 +237,7 @@ exit /b 0
 
 REM Removes all created files in case of an error and exits with the appropriate status code
 :cleanup
-set STATUS_CODE = %ERRORLEVEL%
+set STATUS_CODE=%ERRORLEVEL%
 
 popd
 echo Remove installed Packit files

--- a/install.bat
+++ b/install.bat
@@ -3,18 +3,27 @@ setlocal enabledelayedexpansion
 
 set "VERSION=0.0.2"
 set "REVISION=0"
+
+echo Installing Packit %VERSION% (%REVISION%)
+echo Current OS: Windows
+
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
-    set "CURRENT_OS=aarch64-pc-windows-msvc"
+    set "TARGET=aarch64-pc-windows-msvc"
 ) else (
-    set "CURRENT_OS=x86_64-pc-windows-msvc"
+    set "TARGET=x86_64-pc-windows-msvc"
 )
 
+echo Current target: %TARGET%
+
 set "SOURCE_URL=https://github.com/pack-it/packit/releases/download/%VERSION%/packit@%VERSION%.tar.gz"
-set "PREBUILD_URL=https://github.com/pack-it/packit/releases/download/%VERSION%/packit@%VERSION%-%REVISION%-%CURRENT_OS%.tar.gz"
+set "PREBUILD_URL=https://github.com/pack-it/packit/releases/download/%VERSION%/packit@%VERSION%-%REVISION%-%TARGET%.tar.gz"
 
 REM Determine the prefix and config directory
 set "PREFIX_DIR=C:\Program Files\packit"
 set "CONFIG_DIR=C:\Program Files\packit"
+
+echo Prefix directory: %PREFIX_DIR%
+echo Config directory: %CONFIG_DIR%
 
 REM Check for administrator privileges 
 fltmc >nul 2>&1
@@ -38,14 +47,14 @@ mkdir "%PREFIX_DIR%\packages\packit"
 pushd "%PREFIX_DIR%\packages\packit"
 
 REM Install Packit to the prefix directory 
-echo Downloading Packit prebuild
-curl --proto "=https" -sSfL %PREBUILD_URL% --output packit@%VERSION%-%REVISION%-%CURRENT_OS%.tar.gz
+echo Downloading Packit prebuild from `%PREBUILD_URL%`
+curl --proto "=https" -sSfL %PREBUILD_URL% --output packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
 if not ERRORLEVEL 1 (
-    tar -xf packit@%VERSION%-%REVISION%-%CURRENT_OS%.tar.gz
-    del packit@%VERSION%-%REVISION%-%CURRENT_OS%.tar.gz
-    ren packit@%VERSION%-%REVISION%-%CURRENT_OS% %VERSION%
+    tar -xf packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
+    del packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
+    ren packit@%VERSION%-%REVISION%-%TARGET% %VERSION%
 
-    echo Downloaded prebuild
+    echo Downloading Packit prebuild successful
 ) else (
     set "answer="
     set /p "answer=Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
@@ -77,11 +86,14 @@ if not ERRORLEVEL 1 (
 
         REM Install the correct rustup version for the current platform
         if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
+            echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe'
             curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/aarch64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
         ) else (
             if defined PROCESSOR_ARCHITEW6432 (
+                echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe'
                 curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/x86_64-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
             ) else (
+                echo Installing cargo from 'https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe'
                 curl --proto "=https" --tlsv1.2 -sSfL https://static.rust-lang.org/rustup/dist/i686-pc-windows-msvc/rustup-init.exe --output rustup-init.exe
             )
         )
@@ -97,13 +109,22 @@ if not ERRORLEVEL 1 (
             exit /b 1
         )
 
+        echo Installing cargo successful
         set RUSTUP_INSTALLED=1
     )
 
+    echo Downloading Packit source files from '%SOURCE_URL%'
     curl --proto "=https" -sSfL %SOURCE_URL% --output packit@%VERSION%.tar.gz
+    echo Downloading Packit source files successful
+
+    echo Unpacking Packit source files
     tar -xf packit@%VERSION%.tar.gz
+    echo Unpacking Packit source files successful
+
     del packit@%VERSION%.tar.gz
     cd packit@%VERSION%
+
+    echo Building Packit from source
     cargo build-install --destination ..\$VERSION
     cd ..
     rmdir /s /q .\packit@%VERSION%
@@ -120,15 +141,20 @@ if not ERRORLEVEL 1 (
             rustup self uninstall
         )
     )
+
+    echo Building Packit from source successful
 )
 
 if not exist "%CONFIG_DIR%" (
     mkdir "%CONFIG_DIR%"
 )
 
+echo Initializing Packit
 "%PREFIX_DIR%\packages\packit\%VERSION%\bin\packit.exe" init
+echo Initializing Packit successful
 
 REM Make sure that packit words
+echo "Testing Packit install"
 "%PREFIX_DIR%\bin\pit.exe" --version 2>nul >nul
 if ERRORLEVEL 1 (
     echo Unsuccessfull install of Packit, the 'pit' command cannot be found
@@ -143,7 +169,7 @@ if ERRORLEVEL 1 (
     exit /b 1
 )
 
-echo Successfully installed Packit
+echo Successfully installed Packit!
 
 REM Exit early if Packit is already in the user PATH
 echo ";%PATH%;" | find /I ";%PREFIX_DIR%\bin;" >nul
@@ -160,11 +186,12 @@ if "!answer!"=="yes" set "match=1"
 if "!answer!"=="" set "match=1"
 if "!match!"=="1" (
     setx PATH "%PATH%;%PREFIX_DIR%\bin"
+    echo Restart your shell to refresh your path and use Packit
     popd
     exit /b 0
 )
 
-echo Add %PREFIX_DIR%\bin to your PATH by adding the command below to your shell:
+echo Add '%PREFIX_DIR%\bin' to your PATH by adding the command below to your shell:
 echo setx PATH "%%PATH%%;%PREFIX_DIR%\bin"
 
 popd

--- a/install.bat
+++ b/install.bat
@@ -28,7 +28,9 @@ exit /b 1
 REM Removes all created files in case of an error and exits with the appropriate status code.
 goto cleanup_end
 :cleanup
-set STATUS_CODE=%ERRORLEVEL%
+REM Set the status code to the errorlevel, if the errorlevel is zero set it to 1 (cleanup only happens in case of error)
+set STATUS_CODE=!ERRORLEVEL!
+if !STATUS_CODE!==0 set STATUS_CODE=1
 
 popd
 echo Removing installed Packit files
@@ -74,7 +76,7 @@ REM Ask the user for administrator rights
 call :ask "Y" "The Packit install script requires administrator privileges to modify '%PREFIX_DIR%' and '%CONFIG_DIR%', do you wish to continue"
 if not ERRORLEVEL 1 (
     echo Canceling installation of Packit
-    goto cleanup
+    exit /b 1
 )
 
 REM Check for administrator privileges 

--- a/install.bat
+++ b/install.bat
@@ -1,23 +1,6 @@
 @echo off
 setlocal enabledelayedexpansion
 
-REM Check for administrator privileges 
-fltmc >nul 2>&1
-if ERRORLEVEL 1 (
-    echo The Packit install requires administrator privileges.
-    choice /M "Do you wish to continue as administrator?"
-
-    if ERRORLEVEL 2 (
-        echo Packit installed cancelled
-        exit /b 1
-    )
-
-    REM Rerun the script with elevated permissions (this will first prompt the user)
-    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/k \"%~f0\"'"
-
-    exit /b
-)
-
 set "VERSION=0.0.2"
 set "REVISION=0"
 if "%PROCESSOR_ARCHITECTURE%"=="ARM64" (
@@ -32,6 +15,23 @@ set "PREBUILD_URL=https://github.com/pack-it/packit/releases/download/%VERSION%/
 REM Determine the prefix and config directory
 set "PREFIX_DIR=C:\Program Files\packit"
 set "CONFIG_DIR=C:\Program Files\packit"
+
+REM Check for administrator privileges 
+fltmc >nul 2>&1
+if ERRORLEVEL 1 (
+    echo The Packit install requires administrator privileges to modify '%PREFIX_DIR%' and '%CONFIG_DIR%'.
+    choice /M "Do you wish to continue as administrator?"
+
+    if ERRORLEVEL 2 (
+        echo Packit installed cancelled
+        exit /b 1
+    )
+
+    REM Rerun the script with elevated permissions (this will first prompt the user)
+    powershell -Command "Start-Process cmd -Verb RunAs -ArgumentList '/k \"%~f0\"'"
+
+    exit /b
+)
 
 REM Go into the prefix directory 
 mkdir "%PREFIX_DIR%\packages\packit"

--- a/install.bat
+++ b/install.bat
@@ -1,8 +1,8 @@
 @echo off
 setlocal enabledelayedexpansion
 
-REM A function to handle (yes/no) questions
-REM Returns 1 if the default option was chosen, 0 otherwise
+REM A function to handle (yes/no) questions.
+REM Returns 1 if the default option was chosen, 0 otherwise.
 goto ask_end
 :ask
 REM The preferred answer to the question (the default), needs to be a string of value 'Y' or 'N'
@@ -24,6 +24,27 @@ if /I "!answer!"=="YES" exit /b 0
 exit /b 1
 
 :ask_end
+
+REM Removes all created files in case of an error and exits with the appropriate status code.
+goto cleanup_end
+:cleanup
+set STATUS_CODE=%ERRORLEVEL%
+
+popd
+echo Remove installed Packit files
+
+REM Remove the prefix directory if `PREFIX_DIR` exists
+if exist "%PREFIX_DIR%" (
+    rmdir /s /q "%PREFIX_DIR%"
+)
+
+REM Remove the config directory if `PREFIX_DIR` exists
+if exist "%CONFIG_DIR%" (
+    rmdir /s /q "%CONFIG_DIR%"
+)
+
+exit /b %STATUS_CODE%
+:cleanup_end
 
 set "VERSION=0.0.2"
 set "REVISION=0"
@@ -233,23 +254,3 @@ echo Add '%PREFIX_DIR%\bin' to your PATH by adding the command below to your she
 echo setx PATH "%%PATH%%;%PREFIX_DIR%\bin"
 
 popd
-exit /b 0
-
-REM Removes all created files in case of an error and exits with the appropriate status code
-:cleanup
-set STATUS_CODE=%ERRORLEVEL%
-
-popd
-echo Remove installed Packit files
-
-REM Remove the prefix directory if `PREFIX_DIR` exists
-if exist "%PREFIX_DIR%" (
-    rmdir /s /q "%PREFIX_DIR%"
-)
-
-REM Remove the config directory if `PREFIX_DIR` exists
-if exist "%CONFIG_DIR%" (
-    rmdir /s /q "%CONFIG_DIR%"
-)
-
-exit /b %STATUS_CODE%

--- a/install.sh
+++ b/install.sh
@@ -58,6 +58,17 @@ else
     CONFIG_DIR="/etc/packit"
 fi
 
+# Ask the user for admin rights
+printf "The Packit install script requires root to modify '$PREFIX_DIR' and '$CONFIG_DIR', do you wish to continue? (Y/n) "
+answer=$(get_answer)
+if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
+    echo "Canceling installation of Packit"
+    exit 1
+fi
+
+# Execute sudo without doing anything
+sudo true
+
 USERNAME=$(whoami)
 
 # Go into the prefix directory
@@ -75,7 +86,7 @@ if curl --proto "=https" -sSfL $PREBUILD_URL --output packit@$VERSION-$REVISION-
     
     echo "Downloaded prebuild"
 else
-    echo "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n)"
+    printf "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
     answer=$(get_answer)
 
     if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
@@ -87,7 +98,7 @@ else
 
     # Make sure cargo exists before building Packit
     if ! command -v cargo >/dev/null 2>&1; then
-        echo "Cargo is not installed, do you wish to install it to build Packit? (y/N)"
+        printf "Cargo is not installed, do you wish to install it to build Packit? (y/N) "
         answer=$(get_answer)
 
         if [ "$answer" = "n" ] || [ "$answer" = "no" ] || [ "$answer" = "" ]; then
@@ -115,7 +126,7 @@ else
     rm -r ./packit@$VERSION
 
     if [ $RUSTUP_INSTALLED -eq 1 ]; then
-        echo "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n)"
+        printf "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n) "
         answer=$(get_answer)
 
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
@@ -161,7 +172,7 @@ case "$SHELL" in
         ;;
     *fish)
         # Fish is not POSIX, so it needs custom handling
-        echo "Do you wish to automatically add Packit to your PATH? (Y/n)"
+        printf "Do you wish to automatically add Packit to your PATH? (Y/n) "
         answer=$(get_answer)
 
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
@@ -174,7 +185,7 @@ case "$SHELL" in
 esac
 
 if [ -e "$SHELL_CONFIG_PATH" ]; then
-    echo "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n)"
+    printf "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n) "
     answer=$(get_answer)
 
     if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then

--- a/install.sh
+++ b/install.sh
@@ -119,6 +119,7 @@ echo "Config directory: $CONFIG_DIR"
 # Ask the user for admin rights
 if ! ask "Y" "The Packit install script requires root to modify '$PREFIX_DIR' and '$CONFIG_DIR', do you wish to continue"; then
     echo "Canceling installation of Packit"
+    SHOULD_CLEANUP=0
     exit 1
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -94,6 +94,13 @@ if curl --proto "=https" -sSfL $PREBUILD_URL --output packit@$VERSION-$REVISION-
     
     echo "Downloading Packit prebuild successful"
 else
+    # Check internet connection with reliable site
+    if ! curl -sSf http://www.google.com > /dev/null 2>&1; then
+        echo "Retrieving prebuilds failed, because there is no working internet connection"
+        echo "Canceling installation of Packit"
+        exit 1
+    fi
+
     printf "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
     answer=$(get_answer)
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eEu
 
 # Gets user input and uses /dev/tty when stdin is not available
 get_answer() {
@@ -12,7 +12,32 @@ get_answer() {
     echo "$answer"
 }
 
-main () {
+# Removes all created files in case of an error
+cleanup() {
+    # Don't cleanup of `SHOULD_CLEANUP` is not true
+    if [ ${SHOULD_CLEANUP-} -eq 0 ]; then
+        exit 0
+    fi
+
+    echo "Remove installed Packit files"
+
+    # Remove the prefix directory if `PREFIX_DIR` is set and it exists
+    if [ -n "${PREFIX_DIR-}" ] && [ -d "$PREFIX_DIR" ]; then
+        sudo rm -r "$PREFIX_DIR"
+    fi
+    
+    # Remove the config directory if `CONFIG_DIR` is set and it exists
+    if [ -n "${CONFIG_DIR-}" ] && [ -d "$CONFIG_DIR" ]; then
+        sudo rm -r "$CONFIG_DIR"
+    fi
+}
+
+main() {
+# Execute `handle_exit` in case of ctrl+C interupt, termination signal or exit
+# And SHOULD_CLEANUP by default
+trap cleanup INT TERM EXIT
+SHOULD_CLEANUP=1
+
 VERSION="0.0.2"
 REVISION="0"
 CURRENT_OS="$(uname -s)"
@@ -77,6 +102,14 @@ fi
 # Execute sudo without doing anything
 sudo true
 
+# Exit early with code 0 if there already is a version of Packit installed
+# Note that we can't rely on the `packit init` command, because we don't know if it fails because of an already existing config file
+if [ -f "$CONFIG_DIR/Config.toml" ]; then
+    echo "Packit already seems to be installed, config file found in '$CONFIG_DIR'"
+    SHOULD_CLEANUP=0
+    exit 0
+fi
+
 USERNAME=$(whoami)
 
 # Go into the prefix directory
@@ -96,7 +129,7 @@ if curl --proto "=https" -sSfL $PREBUILD_URL --output packit@$VERSION-$REVISION-
 else
     # Check internet connection with reliable site
     if ! curl -sSf http://www.google.com > /dev/null 2>&1; then
-        echo "Retrieving prebuilds failed, because there is no working internet connection"
+        echo "Retrieving Packit prebuilds failed, because there is no working internet connection"
         echo "Canceling installation of Packit"
         exit 1
     fi
@@ -188,6 +221,7 @@ echo "Successfully installed Packit!"
 
 # Exit early if Packit is already in the PATH
 if echo ":$PATH:" | grep -q ":$PREFIX_DIR/bin:"; then
+    SHOULD_CLEANUP=0
     exit 0
 fi
 
@@ -208,6 +242,7 @@ case "$SHELL" in
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             fish -c "fish_add_path $PREFIX_DIR/bin"
             echo "Restart your shell to refresh your path and use Packit"
+            SHOULD_CLEANUP=0
             exit 0
         fi
         ;;
@@ -223,6 +258,7 @@ if [ -e "$SHELL_CONFIG_PATH" ]; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
         export PATH="$PREFIX_DIR/bin:$PATH"
         echo "Restart your shell to refresh your path and use Packit"
+        SHOULD_CLEANUP=0
         exit 0
     fi
 fi
@@ -230,6 +266,7 @@ fi
 # If the shell is not recognized or user did not want to add Packit automatically tell the user how to add Packit to their shell config
 echo "Add '$PREFIX_DIR/bin' to your PATH by adding the command below to your shell config:"
 echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\""
+SHOULD_CLEANUP=0
 }
 
 main "$@"

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-# Gets user input and uses /dev/tty when stdin is not available
+# Gets user input and uses /dev/tty when stdin is not available.
 get_answer() {
     if [ -t 0 ]; then
         read answer
@@ -12,7 +12,32 @@ get_answer() {
     echo "$answer"
 }
 
-# Removes all created files in case of an error
+# Converts a string to lowercase.
+to_lower() {
+    printf "%s" "$1" | tr "[:upper:]" "[:lower:]"
+}
+
+# A function to handle (yes/no) questions.
+# Returns 1 if the default option was chosen, 0 otherwise.
+ask() {
+    # The preferred answer to the question (the default), needs to be a string of value 'Y' or 'N'
+    PREFERRED=$1
+
+    # The question to ask
+    QUESTION=$2
+
+    if [ "$PREFERRED" = "Y" ]; then
+        printf "$QUESTION? (Y/n) "
+        answer=$(to_lower "$(get_answer)")
+        ! { [ "$answer" = "n" ] || [ "$answer" = "no" ]; }
+    else
+        printf "$QUESTION? (y/N) "
+        answer=$(to_lower "$(get_answer)")
+        ! { [ "$answer" = "y" ] || [ "$answer" = "yes" ]; }
+    fi
+}
+
+# Removes all created files in case of an error.
 cleanup() {
     # Don't cleanup of `SHOULD_CLEANUP` is not true
     if [ ${SHOULD_CLEANUP-} -eq 0 ]; then
@@ -92,9 +117,7 @@ echo "Prefix directory: $PREFIX_DIR"
 echo "Config directory: $CONFIG_DIR"
 
 # Ask the user for admin rights
-printf "The Packit install script requires root to modify '$PREFIX_DIR' and '$CONFIG_DIR', do you wish to continue? (Y/n) "
-answer=$(get_answer)
-if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
+if ! ask "Y" "The Packit install script requires root to modify '$PREFIX_DIR' and '$CONFIG_DIR', do you wish to continue"; then
     echo "Canceling installation of Packit"
     exit 1
 fi
@@ -134,10 +157,7 @@ else
         exit 1
     fi
 
-    printf "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
-    answer=$(get_answer)
-
-    if [ "$answer" = "n" ] || [ "$answer" = "no" ]; then
+    if ! ask "Y" "Retrieving prebuilds failed. Do you wish to build Packit from source"; then
         echo "Canceling installation of Packit"
         exit 1
     fi
@@ -146,10 +166,7 @@ else
 
     # Make sure cargo exists before building Packit
     if ! command -v cargo >/dev/null 2>&1; then
-        printf "Cargo is not installed, do you wish to install it to build Packit? (y/N) "
-        answer=$(get_answer)
-
-        if [ "$answer" = "n" ] || [ "$answer" = "no" ] || [ "$answer" = "" ]; then
+        if ask "N" "Cargo is not installed, do you wish to install it to build Packit"; then
             echo "Canceling installation of Packit"
             exit 1
         fi
@@ -184,10 +201,7 @@ else
     rm -r ./packit@$VERSION
 
     if [ $RUSTUP_INSTALLED -eq 1 ]; then
-        printf "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it? (Y/n) "
-        answer=$(get_answer)
-
-        if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
+        if ask "Y" "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it"; then
             echo "Uninstalling rustup"
             rustup self uninstall
             echo "Uninstalling rustup successful"
@@ -238,10 +252,7 @@ case "$SHELL" in
         ;;
     *fish)
         # Fish is not POSIX, so it needs custom handling
-        printf "Do you wish to automatically add Packit to your PATH? (Y/n) "
-        answer=$(get_answer)
-
-        if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
+        if ask "Y" "Do you wish to automatically add Packit to your PATH"; then
             fish -c "fish_add_path $PREFIX_DIR/bin"
             echo "Restart your shell to refresh your path and use Packit"
             SHOULD_CLEANUP=0
@@ -253,10 +264,7 @@ case "$SHELL" in
 esac
 
 if [ -e "$SHELL_CONFIG_PATH" ]; then
-    printf "Do you wish to automatically add Packit to your PATH by adding it to '$SHELL_CONFIG_PATH'? (Y/n) "
-    answer=$(get_answer)
-
-    if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
+    if ask "Y" "Do you wish to automatically add Packit to your PATH by adding it to '$SHELL_CONFIG_PATH'"; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
         echo "Restart your shell to refresh your path and use Packit"
         SHOULD_CLEANUP=0

--- a/install.sh
+++ b/install.sh
@@ -17,6 +17,9 @@ VERSION="0.0.2"
 REVISION="0"
 CURRENT_OS="$(uname -s)"
 
+echo "Installing Packit $VERSION ($REVISION)"
+echo "Current OS: $CURRENT_OS"
+
 # Get the OS name
 if [ $CURRENT_OS = "Darwin" ]; then
     CURRENT_OS_NAME="apple-darwin"
@@ -47,6 +50,8 @@ fi
 # Create target
 TARGET="$CURRENT_ARCH-$CURRENT_OS_NAME"
 
+echo "Current target: $TARGET"
+
 SOURCE_URL="https://github.com/pack-it/packit/releases/download/$VERSION/packit@$VERSION.tar.gz"
 PREBUILD_URL="https://github.com/pack-it/packit/releases/download/$VERSION/packit@$VERSION-$REVISION-$TARGET.tar.gz"
 
@@ -57,6 +62,9 @@ if [ $CURRENT_OS = "Darwin" ]; then
 else
     CONFIG_DIR="/etc/packit"
 fi
+
+echo "Prefix directory: $PREFIX_DIR"
+echo "Config directory: $CONFIG_DIR"
 
 # Ask the user for admin rights
 printf "The Packit install script requires root to modify '$PREFIX_DIR' and '$CONFIG_DIR', do you wish to continue? (Y/n) "
@@ -78,13 +86,13 @@ sudo chown -R $USERNAME "$PREFIX_DIR"
 cd "$PREFIX_DIR/packages/packit/"
 
 # Install Packit to the prefix directory
-echo "Downloading Packit prebuild"
+echo "Downloading Packit prebuild from '$PREBUILD_URL'"
 if curl --proto "=https" -sSfL $PREBUILD_URL --output packit@$VERSION-$REVISION-$TARGET.tar.gz; then
     tar -xf packit@$VERSION-$REVISION-$TARGET.tar.gz
     rm packit@$VERSION-$REVISION-$TARGET.tar.gz
     mv packit@$VERSION-$REVISION-$TARGET $VERSION
     
-    echo "Downloaded prebuild"
+    echo "Downloading Packit prebuild successful"
 else
     printf "Retrieving prebuilds failed. Do you wish to build Packit from source? (Y/n) "
     answer=$(get_answer)
@@ -106,6 +114,7 @@ else
             exit 1
         fi
 
+        echo "Installing cargo from 'https://sh.rustup.rs'"
         curl --proto '=https' --tlsv1.2 -sSfL https://sh.rustup.rs | sh
 
         # Make sure that the rustup install was successful
@@ -114,13 +123,22 @@ else
             exit 1
         fi
 
+        echo "Installing cargo successful"
         RUSTUP_INSTALLED=1
     fi
 
+    echo "Downloading Packit source files from '$SOURCE_URL'"
     curl --proto "=https" -sSfL $SOURCE_URL --output packit@$VERSION.tar.gz
+    echo "Downloading Packit source files successful"
+
+    echo "Unpacking Packit source files"
     tar -xf packit@$VERSION.tar.gz
+    echo "Unpacking Packit source files successful"
+
     rm packit@$VERSION.tar.gz
     cd packit@$VERSION
+
+    echo "Building Packit from source"
     cargo build-install --destination ../$VERSION
     cd ..
     rm -r ./packit@$VERSION
@@ -134,15 +152,20 @@ else
             rustup self uninstall
         fi
     fi
+
+    echo "Building Packit from source successful"
 fi
 
 sudo mkdir -p "$CONFIG_DIR"
 sudo chmod -R 755 "$CONFIG_DIR"
 sudo chown -R $USERNAME "$CONFIG_DIR"
 
+echo "Initializing Packit"
 "$PREFIX_DIR/packages/packit/$VERSION/bin/packit" init
+echo "Initializing Packit successful"
 
 # Make sure that pit works
+echo "Testing Packit install"
 if ! command -v $PREFIX_DIR/bin/pit -h >/dev/null 2>&1; then
     echo "Unsuccessfull install of Packit, the 'pit' command cannot be found"
     exit 1
@@ -154,7 +177,7 @@ if ! command -v $PREFIX_DIR/bin/packit -h >/dev/null 2>&1; then
     exit 1
 fi
 
-echo "Successfully installed Packit"
+echo "Successfully installed Packit!"
 
 # Exit early if Packit is already in the PATH
 if echo ":$PATH:" | grep -q ":$PREFIX_DIR/bin:"; then
@@ -177,6 +200,7 @@ case "$SHELL" in
 
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             fish -c "fish_add_path $PREFIX_DIR/bin"
+            echo "Restart your shell to refresh your path and use Packit"
             exit 0
         fi
         ;;
@@ -185,18 +209,19 @@ case "$SHELL" in
 esac
 
 if [ -e "$SHELL_CONFIG_PATH" ]; then
-    printf "Do you wish to automatically add Packit to your PATH by adding it to $SHELL_CONFIG_PATH? (Y/n) "
+    printf "Do you wish to automatically add Packit to your PATH by adding it to '$SHELL_CONFIG_PATH'? (Y/n) "
     answer=$(get_answer)
 
     if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
         export PATH="$PREFIX_DIR/bin:$PATH"
+        echo "Restart your shell to refresh your path and use Packit"
         exit 0
     fi
 fi
 
 # If the shell is not recognized or user did not want to add Packit automatically tell the user how to add Packit to their shell config
-echo "Add $PREFIX_DIR/bin to your PATH by adding the command below to your shell config:"
+echo "Add '$PREFIX_DIR/bin' to your PATH by adding the command below to your shell config:"
 echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\""
 }
 

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eEu
+set -eu
 
 # Gets user input and uses /dev/tty when stdin is not available
 get_answer() {
@@ -258,7 +258,6 @@ if [ -e "$SHELL_CONFIG_PATH" ]; then
 
     if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
         echo "export PATH=\"$PREFIX_DIR/bin:\$PATH\"" >> "$SHELL_CONFIG_PATH"
-        export PATH="$PREFIX_DIR/bin:$PATH"
         echo "Restart your shell to refresh your path and use Packit"
         SHOULD_CLEANUP=0
         exit 0

--- a/install.sh
+++ b/install.sh
@@ -39,12 +39,12 @@ ask() {
 
 # Removes all created files in case of an error.
 cleanup() {
-    # Don't cleanup of `SHOULD_CLEANUP` is not true
+    # Don't cleanup if `SHOULD_CLEANUP` is not true
     if [ ${SHOULD_CLEANUP-} -eq 0 ]; then
         exit 0
     fi
 
-    echo "Remove installed Packit files"
+    echo "Removing installed Packit files"
 
     # Remove the prefix directory if `PREFIX_DIR` is set and it exists
     if [ -n "${PREFIX_DIR-}" ] && [ -d "$PREFIX_DIR" ]; then
@@ -129,6 +129,11 @@ sudo true
 # Note that we can't rely on the `packit init` command, because we don't know if it fails because of an already existing config file
 if [ -f "$CONFIG_DIR/Config.toml" ]; then
     echo "Packit already seems to be installed, config file found in '$CONFIG_DIR'"
+    SHOULD_CLEANUP=0
+    exit 0
+fi
+if [ -f "$PREFIX_DIR/Register.toml" ]; then
+    echo "Packit already seems to be installed, register file found in '$PREFIX_DIR'"
     SHOULD_CLEANUP=0
     exit 0
 fi

--- a/install.sh
+++ b/install.sh
@@ -190,6 +190,7 @@ else
         if [ "$answer" = "y" ] || [ "$answer" = "yes" ] || [ "$answer" = "" ]; then
             echo "Uninstalling rustup"
             rustup self uninstall
+            echo "Uninstalling rustup successful"
         fi
     fi
 
@@ -221,6 +222,7 @@ echo "Successfully installed Packit!"
 
 # Exit early if Packit is already in the PATH
 if echo ":$PATH:" | grep -q ":$PREFIX_DIR/bin:"; then
+    echo "Packit already found in PATH, no further actions should be required"
     SHOULD_CLEANUP=0
     exit 0
 fi


### PR DESCRIPTION
This PR adds:
- Better dialogue and information printing
- Separate ask methods in both Unix and Windows scripts (which are case insensitive)
- Cleanup functions in case of errors during the Packit installation
- A check for internet connectivity after the prebuild download fails

Note that the Windows install script cannot execute the cleanup function when a ctrl+C interrupt happens, as this is at the very least very cumbersome... (powershell is probably needed).