### PR TITLE
Add disable_prebuilds option to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The Packit install scripts for Unix and Windows now cleanup the created Packit files in case of an error during installation.
 - Support for a separate verbose output from scripts, file descriptor 3 can now be used for verbose output.
 - When a build script exits with a non-zero status code, the last 10 lines of the scripts output is now shown.
+- The `disable_prebuilds` field to the config, which disables usage of prebuilds when set to true.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.

--- a/README.md
+++ b/README.md
@@ -126,20 +126,21 @@ Initializes the Packit environment by setting up all required files and director
 ## Config
 All available fields in the config are listed below. The [`pit config`](#pit-config-show) command can also be used to change the config.
 
-| Field               | Explanation                                                                                                                  |
-|---------------------|------------------------------------------------------------------------------------------------------------------------------|
+| Field               | Explanation                                                       |
+| ------------------- | ----------------------------------------------------------------- |
 | `prefix_directory`  | Defines the directory used for installing packages, see [File structure](#file-structure) for the defaults on each platform. |
-| `repositories_rank` | Defines the order of repositories to search for a package.                                                                   |
-| `multiuser`         | True to run Packit in multiuser mode, false for single user mode.                                                            |
+| `repositories_rank` | Defines the order of repositories to search for a package.        |
+| `multiuser`         | True to run Packit in multiuser mode, false for single user mode. |
 
 ### Repositories
 
-| Field                | Explanation                                                              |
-|----------------------|--------------------------------------------------------------------------|
-| `url`                | Defines the url to the repository.                                       |
-| `provider`           | Defines the provider of the repository, defaults to `web`.               |
-| `prebuilds_url`      | Defines the url of the prebuilds repository for this package repository. |
-| `prebuilds_provider` | Defines the provider of the prebuilds repository, defaults to `fs`.      |
+| Field                | Explanation                                                                            |
+| -------------------- | -------------------------------------------------------------------------------------- |
+| `url`                | Defines the url to the repository.                                                     |
+| `provider`           | Defines the provider of the repository, defaults to `web`.                             |
+| `prebuilds_url`      | Defines the url of the prebuilds repository for this package repository.               |
+| `prebuilds_provider` | Defines the provider of the prebuilds repository, defaults to `fs`.                    |
+| `disable_prebuilds`  | True to disable prebuild usage for the repository, false to use prebuild if available. |
 
 Specifying a prebuild repository is optional and overrides the value specified in the repository metadata.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,6 +61,10 @@ pub struct Repository {
 
     /// The provider of the prebuild packages repository
     pub prebuilds_provider: Option<String>,
+
+    /// True to disable prebuild usage for the repository, false otherwise
+    #[serde(default)]
+    pub disable_prebuilds: bool,
 }
 
 impl Repository {
@@ -71,6 +75,7 @@ impl Repository {
             provider: provider.to_string(),
             prebuilds_url: None,
             prebuilds_provider: None,
+            disable_prebuilds: false,
         }
     }
 
@@ -169,6 +174,7 @@ impl Default for EditableConfig {
             provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.to_string(),
             prebuilds_url: None,
             prebuilds_provider: None,
+            disable_prebuilds: false,
         };
 
         let config = Config {
@@ -247,6 +253,9 @@ impl EditableConfig {
         }
         if let Some(prebuilds_provider) = &repository.prebuilds_provider {
             new_value["prebuilds_provider"] = prebuilds_provider.into();
+        }
+        if repository.disable_prebuilds {
+            new_value["disable_prebuilds"] = true.into();
         }
         self.document["repositories"][id] = new_value.into();
 

--- a/src/integrity/repairer/initial.rs
+++ b/src/integrity/repairer/initial.rs
@@ -113,6 +113,7 @@ fn get_used_repositories(register: &PackageRegister) -> Vec<Repository> {
             provider: package.metadata_repository_provider.clone(),
             prebuilds_url: package.prebuilds_repository_url.clone(),
             prebuilds_provider: package.prebuilds_repository_provider.clone(),
+            disable_prebuilds: false,
         };
 
         match seen_repositories.get_mut(&repository) {

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -60,6 +60,11 @@ impl<'a> RepositoryManager<'a> {
 
             metadata_providers.insert(id.clone(), provider);
 
+            // Skip prebuild provider creation if prebuilds are disabled
+            if repository.disable_prebuilds {
+                continue;
+            }
+
             // Try to create the prebuild provider
             let prebuild_provider = provider::create_prebuild_provider(repository, repository_meta);
             let Some(prebuild_provider) = prebuild_provider else {


### PR DESCRIPTION
This PR adds the `disable_prebuilds` option to the config, to disable the usage of prebuilds for a specific repository.