### PR TITLE
Improve integrity logging

### DIFF
--- a/src/cli/commands/check.rs
+++ b/src/cli/commands/check.rs
@@ -18,14 +18,15 @@ pub struct CheckArgs {
 }
 
 const ISSUE_FOUND_MESSAGE: &str = "Consider running `pit fix` to resolve the issues above.";
-const NO_ISSUE_FOUND_MESSAGE: &str = "No issues were found!";
 
 impl HandleCommand for CheckArgs {
     fn handle(&self) {
         // Always do initial checks first
         let mut verifier = Verifier::new();
-        while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
-            println!("{issue}")
+        while verifier.get_initial_check_index() < verifier.get_initial_check_length() {
+            if let Some(issue) = verifier.next_initial_check().unwrap_or_exit(1) {
+                println!("{issue}")
+            }
         }
 
         // Return correct message based on found issues
@@ -47,15 +48,17 @@ impl HandleCommand for CheckArgs {
             false => &package_ids,
         };
 
-        while let Some(issue) = verifier.next_issue(&packages, &register, &config).unwrap_or_exit(1) {
-            println!("{issue}")
+        while verifier.get_check_index() < verifier.get_check_length() {
+            if let Some(issue) = verifier.next_check(&packages, &register, &config).unwrap_or_exit(1) {
+                println!("{issue}")
+            }
         }
 
         // Return correct message based on found issues
         if verifier.issues_found() {
             println!("{ISSUE_FOUND_MESSAGE}");
         } else {
-            println!("{NO_ISSUE_FOUND_MESSAGE}");
+            println!("No issues were found!");
         }
     }
 }

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::process::exit;
-
 use clap::Args;
+use colored::Colorize;
+use std::process::exit;
 
 use crate::{
     cli::{
@@ -41,12 +41,22 @@ impl FixArgs {
     /// Fixes the initial issues, which check basic files that Packit requires to run properly (for example Config.toml or Register.toml).
     fn fix_initial(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
         let mut issue_index = -1;
-        while let Some(issue) = verifier.next_initial_issue().unwrap_or_exit(1) {
-            // Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
-            if verifier.get_initial_check_index() as i32 - 1 == issue_index {
-                error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
-                exit(1);
-            }
+        while verifier.get_initial_check_index() < verifier.get_initial_check_length() {
+            let check_result = verifier.next_initial_check().unwrap_or_exit(1);
+            // TODO: REMOVE THIS: Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
+            let issue = match check_result {
+                Some(_) if verifier.get_initial_check_index() as i32 - 1 == issue_index => {
+                    error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
+                    exit(1);
+                },
+                Some(issue) => issue,
+
+                None if verifier.get_initial_check_index() as i32 - 1 == issue_index => {
+                    println!("{}", "Successfully fixed the issue".bold().green());
+                    continue;
+                },
+                None => continue,
+            };
 
             println!("{issue}");
             println!("{}", issue.get_fix_message());
@@ -80,12 +90,22 @@ impl FixArgs {
 
         // Retrieve and fix the issues one by one
         let mut issue_index = -1;
-        while let Some(issue) = verifier.next_issue(packages, &register, &config).unwrap_or_exit(1) {
-            // Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
-            if verifier.get_check_index() as i32 - 1 == issue_index {
-                error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
-                exit(1);
-            }
+        while verifier.get_check_index() < verifier.get_check_length() {
+            let check_result = verifier.next_check(packages, &register, &config).unwrap_or_exit(1);
+            // TODO: REMOVE THIS: Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
+            let issue = match check_result {
+                Some(_) if verifier.get_check_index() as i32 - 1 == issue_index => {
+                    error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
+                    exit(1);
+                },
+                Some(issue) => issue,
+
+                None if verifier.get_check_index() as i32 - 1 == issue_index => {
+                    println!("{}", "Successfully fixed the issue".bold().green());
+                    continue;
+                },
+                None => continue,
+            };
 
             println!("{issue}");
             println!("{}", issue.get_fix_message());

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -40,19 +40,18 @@ impl HandleCommand for FixArgs {
 impl FixArgs {
     /// Fixes the initial issues, which check basic files that Packit requires to run properly (for example Config.toml or Register.toml).
     fn fix_initial(&self, verifier: &mut Verifier, repairer: &mut Repairer) {
-        let mut issue_index = -1;
+        let mut fixed_issue = false;
         while verifier.get_initial_check_index() < verifier.get_initial_check_length() {
             let check_result = verifier.next_initial_check().unwrap_or_exit(1);
-            // TODO: REMOVE THIS: Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
             let issue = match check_result {
-                Some(_) if verifier.get_initial_check_index() as i32 - 1 == issue_index => {
+                Some(_) if fixed_issue => {
                     error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                     exit(1);
                 },
                 Some(issue) => issue,
-
-                None if verifier.get_initial_check_index() as i32 - 1 == issue_index => {
+                None if fixed_issue => {
                     println!("{}", "Successfully fixed the issue".bold().green());
+                    fixed_issue = false;
                     continue;
                 },
                 None => continue,
@@ -68,7 +67,9 @@ impl FixArgs {
             repairer.fix_initial_issues(issue).unwrap_or_exit(1);
 
             // Reverse the verifier to redo the check to make sure the fix worked
-            issue_index = verifier.reverse_initial_check() as i32;
+            verifier.reverse_initial_check();
+
+            fixed_issue = true;
         }
     }
 
@@ -89,19 +90,18 @@ impl FixArgs {
         };
 
         // Retrieve and fix the issues one by one
-        let mut issue_index = -1;
+        let mut fixed_issue = false;
         while verifier.get_check_index() < verifier.get_check_length() {
             let check_result = verifier.next_check(packages, &register, &config).unwrap_or_exit(1);
-            // TODO: REMOVE THIS: Check if the index is the same as the previously found issue (meaning the same issue is found and the fix didn't work)
             let issue = match check_result {
-                Some(_) if verifier.get_check_index() as i32 - 1 == issue_index => {
+                Some(_) if fixed_issue => {
                     error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                     exit(1);
                 },
                 Some(issue) => issue,
-
-                None if verifier.get_check_index() as i32 - 1 == issue_index => {
+                None if fixed_issue => {
                     println!("{}", "Successfully fixed the issue".bold().green());
+                    fixed_issue = false;
                     continue;
                 },
                 None => continue,
@@ -120,7 +120,9 @@ impl FixArgs {
             register.save_to(&register_dir).unwrap_or_exit(1);
 
             // Reverse the verifier to redo the check to make sure the fix worked
-            issue_index = verifier.reverse_check() as i32;
+            verifier.reverse_check();
+
+            fixed_issue = true;
         }
 
         if !verifier.issues_found() {

--- a/src/cli/commands/fix.rs
+++ b/src/cli/commands/fix.rs
@@ -44,16 +44,23 @@ impl FixArgs {
         while verifier.get_initial_check_index() < verifier.get_initial_check_length() {
             let check_result = verifier.next_initial_check().unwrap_or_exit(1);
             let issue = match check_result {
+                // If there is an issue and we previously attempted to fix it, error and exit
                 Some(_) if fixed_issue => {
                     error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                     exit(1);
                 },
+
+                // If there is an issue, return the issue to fix it
                 Some(issue) => issue,
+
+                // If there is no issue and we previously attempted to fix it, show a success message and reset `fixed_issue`
                 None if fixed_issue => {
                     println!("{}", "Successfully fixed the issue".bold().green());
                     fixed_issue = false;
                     continue;
                 },
+
+                // If there is no issue, continue
                 None => continue,
             };
 
@@ -94,16 +101,23 @@ impl FixArgs {
         while verifier.get_check_index() < verifier.get_check_length() {
             let check_result = verifier.next_check(packages, &register, &config).unwrap_or_exit(1);
             let issue = match check_result {
+                // If there is an issue and we previously attempted to fix it, error and exit
                 Some(_) if fixed_issue => {
                     error!(msg: UNSUCCESSFUL_FIX_MESSAGE);
                     exit(1);
                 },
+
+                // If there is an issue, return the issue to fix it
                 Some(issue) => issue,
+
+                // If there is no issue and we previously attempted to fix it, show a success message and reset `fixed_issue`
                 None if fixed_issue => {
                     println!("{}", "Successfully fixed the issue".bold().green());
                     fixed_issue = false;
                     continue;
                 },
+
+                // If there is no issue, continue
                 None => continue,
             };
 

--- a/src/integrity/verifier.rs
+++ b/src/integrity/verifier.rs
@@ -148,12 +148,10 @@ impl Verifier {
 
     /// Reverses the initial checks counter by 1. Except if the current is 0.
     /// Returns the new value of current_intial_check.
-    pub fn reverse_initial_check(&mut self) -> usize {
+    pub fn reverse_initial_check(&mut self) {
         if self.current_intial_check > 0 {
             self.current_intial_check -= 1;
         }
-
-        self.current_intial_check
     }
 
     /// Reverses the checks counter by 1. Except if the current is 0.

--- a/src/integrity/verifier.rs
+++ b/src/integrity/verifier.rs
@@ -32,13 +32,13 @@ impl Verifier {
         }
     }
 
-    /// Gets the next initial issue if it exists.
+    /// Gets the result of the next initial check.
     /// If an error occurs during the check it's only returned if no previous issues were found.
-    pub fn next_initial_issue(&mut self) -> Result<Option<Issue>> {
-        match self.next_initial_issue_impl() {
+    pub fn next_initial_check(&mut self) -> Result<Option<Issue>> {
+        match self.next_initial_check_impl() {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
-                debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
+                debug!(err: e, "An error occured when issues were already found, skipping remaining checks.");
                 self.current_intial_check = Check::get_initial_checks().len();
                 Ok(None)
             },
@@ -46,52 +46,51 @@ impl Verifier {
         }
     }
 
-    /// Gets the next initial issue.
-    /// Returns None if there are no issues to return.
-    fn next_initial_issue_impl(&mut self) -> Result<Option<Issue>> {
-        loop {
-            let ordered_checks = Check::get_ordered_checks(Check::get_initial_checks());
-            let check = match ordered_checks.get(self.current_intial_check) {
-                Some(check) => check,
-                None => return Ok(None),
-            };
+    /// Gets the result of the next initial check.
+    /// Returns and `Issue` if an issue is found, `None` if no issues are found.
+    fn next_initial_check_impl(&mut self) -> Result<Option<Issue>> {
+        let ordered_checks = Check::get_ordered_checks(Check::get_initial_checks());
+        let check = match ordered_checks.get(self.current_intial_check) {
+            Some(check) => check,
+            None => return Ok(None),
+        };
 
-            // Increase current issue
-            self.current_intial_check += 1;
+        // Increase current issue
+        self.current_intial_check += 1;
 
-            let issue = match check {
-                Check::Permissions => initial::check_permissions()?,
-                Check::ConfigExistence => initial::check_config_existence()?,
-                Check::ConfigSyntax => initial::check_config_syntax()?,
-                Check::RegisterExistence => initial::check_register_existence()?,
-                Check::RegisterSyntax => initial::check_register_syntax()?,
+        let issue = match check {
+            Check::Permissions => initial::check_permissions()?,
+            Check::ConfigExistence => initial::check_config_existence()?,
+            Check::ConfigSyntax => initial::check_config_syntax()?,
+            Check::RegisterExistence => initial::check_register_existence()?,
+            Check::RegisterSyntax => initial::check_register_syntax()?,
 
-                // Return `VerifierError::UnimplementedCheck` if the current check is an initial check (meaning it's not implemented).
-                _ if Check::get_initial_checks().contains(check) => return Err(VerifierError::UnimplementedCheck),
+            // Return `VerifierError::UnimplementedCheck` if the current check is an initial check (meaning it's not implemented).
+            _ if Check::get_initial_checks().contains(check) => return Err(VerifierError::UnimplementedCheck),
 
-                // Continue if the check is not an initial check
-                _ => continue,
-            };
+            // Return early if the check is not an initial check
+            _ => return Ok(None),
+        };
 
-            if let Some(issue) = issue {
-                self.issues_found = true;
-                return Ok(Some(issue));
-            }
+        if issue.is_some() {
+            self.issues_found = true;
         }
+
+        return Ok(issue);
     }
 
-    /// Gets the next normal issue if it exists.
+    /// Gets the next normal check result.
     /// If an error occurs during the check it's only returned if no previous issues were found.
-    pub fn next_issue(&mut self, packages: &Vec<PackageId>, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+    pub fn next_check(&mut self, packages: &Vec<PackageId>, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
         // Make sure the initial checks have been run before doing general checks
         if self.current_intial_check != Check::get_initial_checks().len() {
             return Err(VerifierError::InitialChecksSkipped);
         }
 
-        match self.next_issue_impl(packages, register, config) {
+        match self.next_check_impl(packages, register, config) {
             Ok(issue) => Ok(issue),
             Err(e) if self.issues_found => {
-                debug!(err: e, "An error occured when issues were already found, skipping remaining issues.");
+                debug!(err: e, "An error occured when issues were already found, skipping remaining checks.");
                 self.current_check = Check::get_checks().len();
                 Ok(None)
             },
@@ -99,49 +98,46 @@ impl Verifier {
         }
     }
 
-    /// Gets the next normal issue.
-    /// Returns `None` if there are no issues to return.
-    fn next_issue_impl(&mut self, packages: &Vec<PackageId>, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
-        loop {
-            let ordered_checks = Check::get_ordered_checks(Check::get_checks());
-            let check = match ordered_checks.get(self.current_check) {
-                Some(check) => check,
-                None => return Ok(None),
-            };
+    /// Gets the next normal check result.
+    /// Returns and `Issue` if an issue is found, `None` if no issues are found.
+    fn next_check_impl(&mut self, packages: &Vec<PackageId>, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
+        let ordered_checks = Check::get_ordered_checks(Check::get_checks());
+        let check = match ordered_checks.get(self.current_check) {
+            Some(check) => check,
+            None => return Ok(None),
+        };
 
-            // Increase current issue
-            self.current_check += 1;
+        // Increase current issue
+        self.current_check += 1;
 
-            let issue = match check {
-                Check::PackitGroup => general::check_packit_group(config)?,
-                Check::StrayDirectory => general::check_stray_directories(config)?,
-                Check::RegisterConsistency => package::check_register_consistency(register, config)?,
-                Check::StorageConsistency => package::check_storage_consistency(packages, config)?,
-                Check::DependencyTree => package::check_dependency_tree(packages, register),
-                Check::Alterations => package::check_alterations(packages, register, config)?,
-                Check::MissingDependencies => package::check_missing_dependencies(packages, register)?,
-                Check::InvalidDependencies => package::check_invalid_dependencies(packages, register)?,
-                Check::MissingDependents => package::check_missing_dependents(packages, register),
-                Check::InvalidDependents => package::check_invalid_dependents(packages, register),
-                Check::InvalidActive => {
-                    package::check_invalid_active(&packages.iter().map(|p| p.name.clone()).collect(), register, config)?
-                },
-                Check::ForbiddenLink => package::check_forbidden_link(packages, register)?,
-                Check::MissingLink => package::check_missing_link(packages, register, config)?,
-                Check::Test => package::check_test(packages, register, config)?,
+        let issue = match check {
+            Check::PackitGroup => general::check_packit_group(config)?,
+            Check::StrayDirectory => general::check_stray_directories(config)?,
+            Check::RegisterConsistency => package::check_register_consistency(register, config)?,
+            Check::StorageConsistency => package::check_storage_consistency(packages, config)?,
+            Check::DependencyTree => package::check_dependency_tree(packages, register),
+            Check::Alterations => package::check_alterations(packages, register, config)?,
+            Check::MissingDependencies => package::check_missing_dependencies(packages, register)?,
+            Check::InvalidDependencies => package::check_invalid_dependencies(packages, register)?,
+            Check::MissingDependents => package::check_missing_dependents(packages, register),
+            Check::InvalidDependents => package::check_invalid_dependents(packages, register),
+            Check::InvalidActive => package::check_invalid_active(&packages.iter().map(|p| p.name.clone()).collect(), register, config)?,
+            Check::ForbiddenLink => package::check_forbidden_link(packages, register)?,
+            Check::MissingLink => package::check_missing_link(packages, register, config)?,
+            Check::Test => package::check_test(packages, register, config)?,
 
-                // Return `VerifierError::UnimplementedCheck` if the current check is a general check (meaning it's not implemented).
-                _ if Check::get_checks().contains(check) => return Err(VerifierError::UnimplementedCheck),
+            // Return `VerifierError::UnimplementedCheck` if the current check is a general check (meaning it's not implemented).
+            _ if Check::get_checks().contains(check) => return Err(VerifierError::UnimplementedCheck),
 
-                // Continue if the check is an initial check
-                _ => continue,
-            };
+            // Return early if the check is an initial check
+            _ => return Ok(None),
+        };
 
-            if let Some(issue) = issue {
-                self.issues_found = true;
-                return Ok(Some(issue));
-            }
+        if issue.is_some() {
+            self.issues_found = true;
         }
+
+        return Ok(issue);
     }
 
     /// Get the issues found state.
@@ -178,5 +174,15 @@ impl Verifier {
     /// Gets the current check index.
     pub fn get_check_index(&self) -> usize {
         self.current_check
+    }
+
+    /// Gets the number of initial checks.
+    pub fn get_initial_check_length(&self) -> usize {
+        Check::get_initial_checks().len()
+    }
+
+    /// Gets the number of normal checks.
+    pub fn get_check_length(&self) -> usize {
+        Check::get_checks().len()
     }
 }


### PR DESCRIPTION
This PR refactors the verifier to return the next check result, instead of the next issue. Making integrity logging easier and clearer.