### PR TITLE
Expand search with verbose and more output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - When a build script exits with a non-zero status code, the last 10 lines of the scripts output is now shown.
 - The `disable_prebuilds` field to the config, which disables usage of prebuilds when set to true.
 - The test script checks in the verifier, which use the metadata test scripts to test if packages work.
+- The `--verbose` flag for the `search` command.
 
 ### Changes
 - The build system now includes a new `package-build` xtask to create a full Packit prebuild for the release.
@@ -40,6 +41,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `util checksum` command now also shows the size of the file.
 - When the `repository.toml` file of a metadata repository cannot be fetched, the repository will not be loaded anymore.
 - Improved UI with colors and text styling.
+- The `search` command now outputs more and different information based on the given package input.
+- The `info` command now shows conflicting packages when verbose is specified.
 
 ### Fixed
 - Fix package not found issue when multiple repositories have the same package but different versions.

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ Uninstalls the specified packages, if a version is given that version will be un
 #### `pit list`
 Lists all the installed packages.
 
-#### `pit search <PACKAGE-NAME>[@<VERSION>]`
-Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata. If the version is given that specific version is searched for.
+#### `pit search <PACKAGE-NAME>[@<VERSION>] [--verbose]`
+Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata. If the version is given that specific version is searched for. The `--verbose` flag can be used to show more output.
 
 #### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
 Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and `--new-version` cannot be used). If multiple versions of the same package are installed, the latest installed version is assumed. The `--new-version` flag can be used to specify the new version to install. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -90,6 +90,12 @@ impl InfoArgs {
         pair_aligner.add("Active version", &package.active_version);
         pair_aligner.add("Symlinked", package.symlinked);
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+        println!();
+
+        if self.verbose {
+            print!("Conflicts with: ");
+            standard_print::print_list_or_none(package.conflicts_with.iter());
+        }
     }
 
     /// Displays the package version info, also checking for the verbose flag for some info.

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -13,20 +13,20 @@ use crate::{
             deprecation,
             logging::error,
             not_found,
-            standard_print::{self},
+            standard_print::{self, DisplayJoined, DisplayOption},
             styled::{MapStyled, Styled},
         },
     },
     config::Config,
-    installer::types::OptionalPackageId,
+    installer::types::{OptionalPackageId, PackageId, PackageName},
     platforms::Target,
     repositories::{error::RepositoryError, manager::RepositoryManager},
     utils::unwrap_or_exit::UnwrapOrExit,
 };
 
-/// Searches a package with `<PACKAGE-NAME>` and shows information based on the package metadata.
+/// Searches a package with `<PACKAGE-NAME>[@<PACKAGE-VERSION]` and shows information based on the package (version) metadata.
 /// Alternatively, when the regex flag is true, it uses the regex query to search for packages which match the regex.
-/// If the version is given that specific version is searched for.
+/// Package version specific information is shown when the version is given, otherwise package specific information is shown.
 #[derive(Args, Debug)]
 pub struct SearchArgs {
     /// The query to search with (can be an `OptionalPackageId` or regex string)
@@ -42,7 +42,7 @@ impl HandleCommand for SearchArgs {
     fn handle(&self) {
         match self.regex {
             true => self.regex_search(),
-            false => self.search_package(),
+            false => self.search(),
         }
     }
 }
@@ -76,18 +76,24 @@ impl SearchArgs {
 
     /// Searches information of a package based on the provided `OptionalPackageId`.
     /// Fails if the given query is not a valid `OptionalPackageId`.
-    fn search_package(&self) {
+    fn search(&self) {
         // Get the optional id
         let message = "The given search query isn't a valid package. For regex use `--regex`.";
         let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
 
+        match optional_id.versioned() {
+            Some(package_id) => self.search_package_version(&package_id),
+            None => self.search_package(&optional_id.name),
+        }
+    }
+
+    /// Searches for and shows package specific information for a given package.
+    fn search_package(&self, package_name: &PackageName) {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
-        let (repository_id, package, package_version) = match manager.read_package_and_version(&optional_id, &Target::current()) {
+        let (repository_id, package) = match manager.read_package(package_name) {
             Ok(package) => package,
-            Err(RepositoryError::PackageNotFoundError { reason, .. }) => {
-                not_found::repository_optional_package(&optional_id, &manager, reason)
-            },
+            Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package(package_name, &manager, reason),
             Err(e) => {
                 error!(e, "Cannot read package");
                 return;
@@ -107,8 +113,39 @@ impl SearchArgs {
             },
         };
 
-        // Create a package id
-        let package_id = optional_id.versioned_or_cloned(&package_version.version);
+        // Print package information
+        println!("{}", package_name.style());
+        println!("{}", package.description.italic().cyan());
+        let mut pair_aligner = PairAligner::new();
+        pair_aligner.add("Homepage", package.homepage.display());
+        pair_aligner.add("Latest version", latest_version.version.style());
+        pair_aligner.add("Available versions", package.versions.iter().map_styled().display(" | "));
+        pair_aligner.add("Required Packit version", package.required_packit_version.display().bold().blue());
+        pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+        println!();
+
+        print!("Conflicts with: ");
+        standard_print::print_list_or_none(package.conflicts_with.iter());
+
+        // Check if the package is deprecated
+        deprecation::show_package_warnings(&package);
+    }
+
+    /// Searches for and shows package version specific information for a given package.
+    fn search_package_version(&self, package_id: &PackageId) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
+        let package_and_version = manager.read_package_and_version(&package_id.clone().into(), &Target::current());
+        let (repository_id, package, package_version) = match package_and_version {
+            Ok(package) => package,
+            Err(RepositoryError::PackageNotFoundError { reason, .. }) => {
+                not_found::repository_package_version(&package_id, &manager, reason)
+            },
+            Err(e) => {
+                error!(e, "Cannot read package");
+                return;
+            },
+        };
 
         let target_bounds = package_version.get_best_target(&Target::current()).unwrap_or_exit(1);
 
@@ -121,27 +158,33 @@ impl SearchArgs {
             },
         };
 
-        let dependencies: Vec<_> = package_version.dependencies.iter().chain(target.dependencies.iter()).collect();
-        let dependencies: Vec<String> = dependencies.iter().map(|d| d.to_string()).collect();
+        // Chain the package version dependencies with the target dependencies
+        let dependencies = package_version.dependencies.iter().chain(target.dependencies.iter());
+        let build_dependencies = package_version.build_dependencies.iter().chain(target.build_dependencies.iter());
 
-        // Print package information
-        let styled_package = format!("{}@{}", package.name, package_version.version).bold().blue();
-        println!("{styled_package}");
+        let required_packit_version = package_version.required_packit_version.display().bold().blue();
+
+        // Show package version information
+        println!("{}", package_id.style());
         println!("{}", package.description.italic().cyan());
         let mut pair_aligner = PairAligner::new();
-        pair_aligner.add("Latest stable version", latest_version.version.style());
+        pair_aligner.add("Homepage", package.homepage.display());
         pair_aligner.add("License", &package_version.license);
+        pair_aligner.add("Required Packit version", required_packit_version);
+        pair_aligner.add("Skip symlinking", &package_version.skip_symlinking);
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
 
         print!("Dependencies: ");
-        standard_print::print_list_or_none(dependencies.iter());
+        standard_print::print_list_or_none(dependencies);
+
+        print!("Build dependencies: ");
+        standard_print::print_list_or_none(build_dependencies);
 
         print!("Revisions: ");
         standard_print::print_list_or_none(package_version.revisions.iter());
 
-        // Check if the package or version is deprecated
-        deprecation::show_package_warnings(&package);
-        deprecation::show_package_version_warnings(&package_version, &optional_id.name);
+        // Check if the package is deprecated
+        deprecation::show_package_version_warnings(&package_version, &package_id.name);
     }
 }

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -2,7 +2,7 @@
 use clap::Args;
 use colored::Colorize;
 use regex::Regex;
-use std::{collections::HashSet, str::FromStr};
+use std::{cmp::max, collections::HashSet, str::FromStr};
 
 use crate::{
     cli::{
@@ -35,6 +35,10 @@ pub struct SearchArgs {
     /// True if the query should be interpreted as regex
     #[arg(long, default_value = "false")]
     regex: bool,
+
+    /// True if verbose information should be shown
+    #[arg(short, long, default_value = "false")]
+    verbose: bool,
 }
 
 impl HandleCommand for SearchArgs {
@@ -124,8 +128,10 @@ impl SearchArgs {
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
 
-        print!("Conflicts with: ");
-        standard_print::print_list_or_none(package.conflicts_with.iter());
+        if self.verbose {
+            print!("Conflicts with: ");
+            standard_print::print_list_or_none(package.conflicts_with.iter());
+        }
 
         // Check if the package is deprecated
         deprecation::show_package_warnings(&package);
@@ -162,7 +168,12 @@ impl SearchArgs {
         let dependencies = package_version.dependencies.iter().chain(target.dependencies.iter());
         let build_dependencies = package_version.build_dependencies.iter().chain(target.build_dependencies.iter());
 
-        let required_packit_version = package_version.required_packit_version.display().bold().blue();
+        let required_packit_version = match max(&package.required_packit_version, &package_version.required_packit_version) {
+            Some(version) => version.style(),
+            None => "None".dimmed(),
+        };
+
+        let skip_symlinking = if package_version.skip_symlinking { "on" } else { "off" };
 
         // Show package version information
         println!("{}", package_id.style());
@@ -171,18 +182,20 @@ impl SearchArgs {
         pair_aligner.add("Homepage", package.homepage.display());
         pair_aligner.add("License", &package_version.license);
         pair_aligner.add("Required Packit version", required_packit_version);
-        pair_aligner.add("Skip symlinking", &package_version.skip_symlinking);
+        pair_aligner.add("Skip symlinking", skip_symlinking);
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
 
         print!("Dependencies: ");
         standard_print::print_list_or_none(dependencies);
 
-        print!("Build dependencies: ");
-        standard_print::print_list_or_none(build_dependencies);
+        if self.verbose {
+            print!("Build dependencies: ");
+            standard_print::print_list_or_none(build_dependencies);
 
-        print!("Revisions: ");
-        standard_print::print_list_or_none(package_version.revisions.iter());
+            print!("Revisions: ");
+            standard_print::print_list_or_none(package_version.revisions.iter());
+        }
 
         // Check if the package is deprecated
         deprecation::show_package_version_warnings(&package_version, &package_id.name);

--- a/src/cli/display/deprecation.rs
+++ b/src/cli/display/deprecation.rs
@@ -9,33 +9,31 @@ use crate::{
 
 /// Shows a warning if the given PackageMeta is deprecated or will be deprecated soon.
 pub fn show_package_warnings(package: &PackageMeta) {
-    if let Some(deprecation) = &package.deprecation {
-        let reason = match &deprecation.reason {
-            Some(reason) => format!(" with reason '{reason}'"),
-            None => String::default(),
-        };
+    let Some(deprecation) = &package.deprecation else { return };
+    let reason = match &deprecation.reason {
+        Some(reason) => format!(" with reason '{reason}'"),
+        None => String::default(),
+    };
 
-        let deprecated_from = &deprecation.deprecated_from;
-        match *deprecated_from <= Date::now() {
-            true => warning!("Package {} is deprecated since {}{reason}", package.name, deprecated_from),
-            false => warning!("Package {} will be deprecated at {}{reason}", package.name, deprecated_from),
-        }
+    let deprecated_from = &deprecation.deprecated_from;
+    match *deprecated_from <= Date::now() {
+        true => warning!("Package {} is deprecated since {}{reason}", package.name, deprecated_from),
+        false => warning!("Package {} will be deprecated at {}{reason}", package.name, deprecated_from),
     }
 }
 
 /// Shows a warning if the given PackageVersionMeta is deprecated or will be deprecated soon.
 pub fn show_package_version_warnings(package_version: &PackageVersionMeta, package_name: &PackageName) {
-    if let Some(deprecation) = &package_version.deprecation {
-        let reason = match &deprecation.reason {
-            Some(reason) => format!(" with reason '{reason}'"),
-            None => String::default(),
-        };
+    let Some(deprecation) = &package_version.deprecation else { return };
+    let reason = match &deprecation.reason {
+        Some(reason) => format!(" with reason '{reason}'"),
+        None => String::default(),
+    };
 
-        let styled_package = format!("{package_name}@{}", package_version.version).bold().blue();
-        let deprecated_from = &deprecation.deprecated_from;
-        match *deprecated_from <= Date::now() {
-            true => warning!("Package version {styled_package} is deprecated since {}{reason}", deprecated_from),
-            false => warning!("Package version {styled_package} will be deprecated at {}{reason}", deprecated_from),
-        }
+    let styled_package = format!("{package_name}@{}", package_version.version).bold().blue();
+    let deprecated_from = &deprecation.deprecated_from;
+    match *deprecated_from <= Date::now() {
+        true => warning!("Package version {styled_package} is deprecated since {}{reason}", deprecated_from),
+        false => warning!("Package version {styled_package} will be deprecated at {}{reason}", deprecated_from),
     }
 }


### PR DESCRIPTION
This PR adds the `--verbose` flag to the `search` command and differentiates between package and package version specific information. It also shows the `conflicts_with` in the info command when verbose is specified.