### PR TITLE
Bump LIEF to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,9 +170,9 @@ checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 
 [[package]]
 name = "cc"
-version = "1.2.66"
+version = "1.2.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d6cac793997bd970000024b2934968efe83b382de4fdcf4fcb46b6ee4ad996"
+checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1069,7 +1069,8 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 [[package]]
 name = "lief"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=2a95290b7efd7ca7153ff13b458bcd1e56d9a11b#2a95290b7efd7ca7153ff13b458bcd1e56d9a11b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de0f665f05a9ba810050602b14b8ddd01cc1c05d8731847118119d5aa5805216"
 dependencies = [
  "bitflags",
  "cxx",
@@ -1082,7 +1083,8 @@ dependencies = [
 [[package]]
 name = "lief-build"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=2a95290b7efd7ca7153ff13b458bcd1e56d9a11b#2a95290b7efd7ca7153ff13b458bcd1e56d9a11b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70c73568627d4e6a1a461bde280bfd3ae3f247a1d566ebf3c12f00ee24b51995"
 dependencies = [
  "git-version",
  "miette",
@@ -1094,7 +1096,8 @@ dependencies = [
 [[package]]
 name = "lief-ffi"
 version = "1.0.0"
-source = "git+https://github.com/lief-project/LIEF.git?rev=2a95290b7efd7ca7153ff13b458bcd1e56d9a11b#2a95290b7efd7ca7153ff13b458bcd1e56d9a11b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e128b75185fcbb4fccb3ce9938572f4e2a510c51375c3f2f668ea9cd9fa5bb17"
 dependencies = [
  "cxx",
  "lief-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ hex = "0.4.3"
 zip = { version = "8.6.0", default-features = false, features = ["deflate", "deflate64"] }
 regex = "1.13.0"
 xz2 = "0.1.7"
-lief = { git = "https://github.com/lief-project/LIEF.git", rev = "2a95290b7efd7ca7153ff13b458bcd1e56d9a11b" }
+lief = "1.0.0"
 url = "2.5.8"
 toml_edit = "0.25.12"
 terminal_size = "0.4.4"


### PR DESCRIPTION
This PR bumps the LIEF dependency to the newly released version 1.0.0.