### PR TITLE
Add build and test requirements to metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased](https://github.com/pack-it/packit/compare/0.0.3...HEAD)
 
+### Added
+- The `build_requirements` and `test_requirements` fields, with the `msvc` requirement.
+
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -92,18 +92,26 @@ The `deprecation` fields in package.toml and targets.toml describe when a packag
 | `reason`          | Defines the reason the package is deprecated.                                    |
 
 #### Target fields
-
 Targets are specified as `[targets.<bounds>]`, where bounds specify the support target as described in [Target bounds](#target-bounds).
 
 | Field                           | Explanation                                                                          |
 | ------------------------------- | ------------------------------------------------------------------------------------ |
 | `dependencies`                  | Defines all the dependencies of the package for the target, additional to the dependencies specified in the global field. |
 | `build_dependencies`            | Defines all build dependencies of the package for the target, additional to the build dependencies specified in the global field. |
+| `build_requirements`            | Defines all requirements that are needed on the system for building the package, these need to be installed by the user manually. |
+| `test_requirements`             | Defines all requirements that are needed on the system for testing the package, these need to be installed by the user manually. |
 | `skip_symlinking`               | When set to yes, the package is not symlinked after installation, preventing the package to be detectable through the PATH. Overrides the value defined in the global field. |
 | `<script-type>_script`          | Defines the name of the script to use instead of the default script name.            |
 | `script_args`                   | A table of key-value pairs containing arguments passed to scripts, additional to the args defined in the global field. |
 | `source`                        | Defines which source to use, required when multiple sources are defined.             |
 | `external_test_files`           | A list of external test files that are needed for executing the test script for this target, additional to the files specified in the global field. These files are automatically downloaded. |
+
+#### Available requirements
+All available requirements for use with the `build_requirements` and `test_requirements` fields. Requirements are things that need to be available on the system before building or testing, they need to be installed by the user manually.
+
+| Field  | Explanation                                                                                                   |
+| ------ | ------------------------------------------------------------------------------------------------------------- |
+| `msvc` | The Microsoft Visual C++ toolchain, automatically adds `PACKIT_VS_PATH`, `PACKIT_VCVARSALL`, `PACKIT_VCVARSALL_ARCH` and `PACKIT_MSVC_VERSION` to the build environment. (Windows only) |
 
 
 ### Target bounds

--- a/docs/verifier.md
+++ b/docs/verifier.md
@@ -43,6 +43,4 @@ This is a list of checks which are currently implemented in the verifier. With a
 | MissingLink         | Package | Checks if symlinks are missing for packages.                                                                                                                                                                             |
 | MissingDependencies | Package | Checks for missing dependencies in packages. A dependency is missing if one of the dependencies specified in the repository metadata is not satisfied by the dependencies from the register.                             |
 | InvalidDependencies | Package | Checks for invalid dependencies in packages. A dependency from the register is invalid if it doesn't satisfy any of the dependencies specified in the repository metadata.                                               |
-| Test                | Package | Checks if the test from the repository metadata for a package works.                                                                                                                                                     |
-
-
+| Test                | Package | Checks if the test from the repository metadata for a package works. Check is skipped when the `test_requirements` are not satisfied.                                                                                    |

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -1,9 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{collections::HashMap, path::PathBuf};
 
+use thiserror::Error;
+
 use crate::{
     cli::display::{logging::warning, styled::Styled},
+    platforms::tool_detection::{self, error::ToolDetectionError},
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
+    repositories::types::Requirement,
     utils::env::Environment,
 };
 
@@ -27,18 +31,39 @@ const PATH_SEPARATOR: &str = ":";
 #[cfg(target_os = "windows")]
 const PATH_SEPARATOR: &str = ";";
 
+/// The errors that occur during creating the build environment.
+#[derive(Error, Debug)]
+pub enum BuildEnvError {
+    #[error("Cannot add {} to build env {variable}: cannot convert PathBuf to string", path.display())]
+    PathBufConversion {
+        path: PathBuf,
+        variable: String,
+    },
+
+    #[error("Cannot find tool {0} on the system")]
+    ToolNotFound(String),
+
+    #[error("Error while detecting tool on the system")]
+    ToolDetectionError(#[from] ToolDetectionError),
+}
+
+pub type Result<T> = core::result::Result<T, BuildEnvError>;
+
 /// Holds all the data necessary to build a normalized build environment.
 pub struct BuildEnv<'a> {
     prefix_directory: &'a PathBuf,
     dependencies: &'a Vec<&'a InstalledPackageVersion>,
     build_dependencies: Vec<&'a InstalledPackageVersion>,
+    build_requirements: &'a Vec<Requirement>,
     register: &'a PackageRegister,
 }
 
 #[expect(clippy::from_over_into)]
-impl<'a> Into<Environment> for BuildEnv<'a> {
+impl<'a> TryInto<Environment> for BuildEnv<'a> {
+    type Error = BuildEnvError;
+
     /// Converts the `BuildEnv` struct into a normalized `Environment` struct.
-    fn into(self) -> Environment {
+    fn try_into(self) -> Result<Environment> {
         let mut env = Environment::new();
 
         // TODO: maybe also sandbox TMPDIR variable
@@ -65,6 +90,9 @@ impl<'a> Into<Environment> for BuildEnv<'a> {
             };
         }
 
+        // Add requirement specific vars to the build env
+        env.insert_vars(self.create_requirements_vars()?);
+
         // Add macos specific environment variables
         #[cfg(target_os = "macos")]
         {
@@ -74,7 +102,7 @@ impl<'a> Into<Environment> for BuildEnv<'a> {
             // TODO: add xcode paths
         }
 
-        env
+        Ok(env)
     }
 }
 
@@ -84,12 +112,14 @@ impl<'a> BuildEnv<'a> {
         prefix_directory: &'a PathBuf,
         dependencies: &'a Vec<&'a InstalledPackageVersion>,
         build_dependencies: Vec<&'a InstalledPackageVersion>,
+        build_requirements: &'a Vec<Requirement>,
         register: &'a PackageRegister,
     ) -> Self {
         Self {
             prefix_directory,
             dependencies,
             build_dependencies,
+            build_requirements,
             register,
         }
     }
@@ -268,5 +298,38 @@ impl<'a> BuildEnv<'a> {
         };
 
         parts.join(PATH_SEPARATOR)
+    }
+
+    /// Creates environment variables from the specified build requirements.
+    fn create_requirements_vars(&self) -> Result<HashMap<&str, String>> {
+        let mut vars = HashMap::new();
+
+        for requirement in self.build_requirements {
+            match requirement {
+                Requirement::Msvc => {
+                    let Some(vspath) = tool_detection::detect_msvc()? else {
+                        return Err(BuildEnvError::ToolNotFound("msvc".into()));
+                    };
+                    let vcvarsall = vspath.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat");
+
+                    vars.insert("PACKIT_VS_PATH", path_to_string(&vspath, "PACKIT_VS_PATH")?.into());
+                    vars.insert("PACKIT_VCVARSALL", path_to_string(&vcvarsall, "PACKIT_VCVARSALL")?.into());
+                },
+            }
+        }
+
+        Ok(vars)
+    }
+}
+
+/// Converts a `PathBuf` to a string.
+/// Returns an `Err` if the path cannot be converted.
+fn path_to_string<'a>(path: &'a PathBuf, env_var: &str) -> Result<&'a str> {
+    match path.to_str() {
+        Some(string) => Ok(string),
+        None => Err(BuildEnvError::PathBufConversion {
+            path: path.clone(),
+            variable: env_var.into(),
+        }),
     }
 }

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -93,7 +93,7 @@ impl<'a> TryInto<Environment> for BuildEnv<'a> {
         }
 
         // Add requirement specific vars to the build env
-        env.insert_vars(self.create_requirements_vars()?);
+        env.expand(Self::create_requirement_environment(self.build_requirements)?);
 
         // Add macos specific environment variables
         #[cfg(target_os = "macos")]
@@ -249,11 +249,11 @@ impl<'a> BuildEnv<'a> {
         Ok(parts.join(PATH_SEPARATOR))
     }
 
-    /// Creates environment variables from the specified build requirements.
-    fn create_requirements_vars(&self) -> Result<HashMap<&str, String>> {
-        let mut vars = HashMap::new();
+    /// Creates an environment from the given requirements.
+    pub fn create_requirement_environment(requirements: &Vec<Requirement>) -> Result<Environment> {
+        let mut environment = Environment::new();
 
-        for requirement in self.build_requirements {
+        for requirement in requirements {
             match requirement {
                 Requirement::Msvc => {
                     // Detect MSVC toolchain
@@ -263,20 +263,22 @@ impl<'a> BuildEnv<'a> {
 
                     // Get arch, skip requirement if arch is `None`.
                     let Some(arch) = msvc.get_vcvarsall_arch(&Target::current()) else {
-                        warning!("Tried to load MSVC for an unsupported target, skipping adding to build env");
+                        warning!("Tried to load MSVC for an unsupported target, skipping adding to env");
                         continue;
                     };
 
                     // Add requirement specific environment vars to result
-                    vars.insert("PACKIT_VS_PATH", path_to_string(msvc.get_vs_path(), "PACKIT_VS_PATH")?);
-                    vars.insert("PACKIT_VCVARSALL", path_to_string(&msvc.get_vcvarsall_path(), "PACKIT_VCVARSALL")?);
-                    vars.insert("PACKIT_VCVARSALL_ARCH", arch.into());
-                    vars.insert("PACKIT_MSVC_VERSION", msvc.get_version().to_string());
+                    environment.insert_vars(HashMap::from([
+                        ("PACKIT_VS_PATH", path_to_string(msvc.get_vs_path(), "PACKIT_VS_PATH")?),
+                        ("PACKIT_VCVARSALL", path_to_string(&msvc.get_vcvarsall_path(), "PACKIT_VCVARSALL")?),
+                        ("PACKIT_VCVARSALL_ARCH", arch.into()),
+                        ("PACKIT_MSVC_VERSION", msvc.get_version().to_string()),
+                    ]));
                 },
             }
         }
 
-        Ok(vars)
+        Ok(environment)
     }
 }
 

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -283,7 +283,7 @@ impl<'a> BuildEnv<'a> {
 }
 
 /// Converts a `PathBuf` to a string.
-/// Returns an `Err` if the path cannot be converted.
+/// Returns a `BuildEnvError::PathBufConversion` if the path cannot be converted.
 fn path_to_string(path: &Path, env_var: &str) -> Result<String> {
     match path.to_str() {
         Some(string) => Ok(string.into()),

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -317,15 +317,17 @@ impl<'a> BuildEnv<'a> {
                         return Err(BuildEnvError::ToolNotFound("msvc".into()));
                     };
 
-                    // Get target, skip requirement if target is `None`.
-                    let Some(target) = msvc.get_vcvarsall_target(&Target::current()) else {
+                    // Get arch, skip requirement if arch is `None`.
+                    let Some(arch) = msvc.get_vcvarsall_arch(&Target::current()) else {
                         warning!("Tried to load MSVC for an unsupported target, skipping adding to build env");
                         continue;
                     };
 
+                    // Add requirement specific environment vars to result
                     vars.insert("PACKIT_VS_PATH", path_to_string(msvc.get_vs_path(), "PACKIT_VS_PATH")?);
                     vars.insert("PACKIT_VCVARSALL", path_to_string(&msvc.get_vcvarsall_path(), "PACKIT_VCVARSALL")?);
-                    vars.insert("PACKIT_VCVARSALL_TARGET", target.into());
+                    vars.insert("PACKIT_VCVARSALL_ARCH", arch.into());
+                    vars.insert("PACKIT_MSVC_VERSION", msvc.get_version().to_string());
                 },
             }
         }

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -1,5 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashMap, path::PathBuf};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
 
 use thiserror::Error;
 
@@ -58,7 +61,6 @@ pub struct BuildEnv<'a> {
     register: &'a PackageRegister,
 }
 
-#[expect(clippy::from_over_into)]
 impl<'a> TryInto<Environment> for BuildEnv<'a> {
     type Error = BuildEnvError;
 
@@ -307,13 +309,12 @@ impl<'a> BuildEnv<'a> {
         for requirement in self.build_requirements {
             match requirement {
                 Requirement::Msvc => {
-                    let Some(vspath) = tool_detection::detect_msvc()? else {
+                    let Some(msvc) = tool_detection::detect_msvc()? else {
                         return Err(BuildEnvError::ToolNotFound("msvc".into()));
                     };
-                    let vcvarsall = vspath.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat");
 
-                    vars.insert("PACKIT_VS_PATH", path_to_string(&vspath, "PACKIT_VS_PATH")?.into());
-                    vars.insert("PACKIT_VCVARSALL", path_to_string(&vcvarsall, "PACKIT_VCVARSALL")?.into());
+                    vars.insert("PACKIT_VS_PATH", path_to_string(msvc.get_vs_path(), "PACKIT_VS_PATH")?);
+                    vars.insert("PACKIT_VCVARSALL", path_to_string(&msvc.get_vcvarsall_path(), "PACKIT_VCVARSALL")?);
                 },
             }
         }
@@ -324,11 +325,11 @@ impl<'a> BuildEnv<'a> {
 
 /// Converts a `PathBuf` to a string.
 /// Returns an `Err` if the path cannot be converted.
-fn path_to_string<'a>(path: &'a PathBuf, env_var: &str) -> Result<&'a str> {
+fn path_to_string(path: &Path, env_var: &str) -> Result<String> {
     match path.to_str() {
-        Some(string) => Ok(string),
+        Some(string) => Ok(string.into()),
         None => Err(BuildEnvError::PathBufConversion {
-            path: path.clone(),
+            path: path.to_path_buf(),
             variable: env_var.into(),
         }),
     }

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -7,7 +7,7 @@ use std::{
 use thiserror::Error;
 
 use crate::{
-    cli::display::{logging::warning, styled::Styled},
+    cli::display::logging::warning,
     platforms::{
         Target,
         tool_detection::{self, error::ToolDetectionError},
@@ -74,11 +74,11 @@ impl<'a> TryInto<Environment> for BuildEnv<'a> {
         // TODO: maybe also sandbox TMPDIR variable
         // TODO: maybe use active version path instead of real version path for all dependencies
         env.insert_vars(HashMap::from([
-            ("PATH", self.create_path()),
-            ("PKG_CONFIG_PATH", self.create_pkg_config_path()),
+            ("PATH", self.create_path()?),
+            ("PKG_CONFIG_PATH", self.create_pkg_config_path()?),
             ("PKG_CONFIG_LIBDIR", "".into()),
-            ("CMAKE_PREFIX_PATH", self.create_cmake_prefix_path()),
-            ("ACLOCAL_PATH", self.create_aclocal_path()),
+            ("CMAKE_PREFIX_PATH", self.create_cmake_prefix_path()?),
+            ("ACLOCAL_PATH", self.create_aclocal_path()?),
             ("TZ", "UTC0".into()), // Ensure timezone is the same across all builds
         ]));
 
@@ -89,10 +89,7 @@ impl<'a> TryInto<Environment> for BuildEnv<'a> {
 
         // Add M4 variable if m4 is a build dependency
         if let Some(m4) = self.build_dependencies.iter().find(|x| *x.package_id.name == "m4") {
-            match m4.install_path.to_str() {
-                Some(path) => env.insert_var("M4", path),
-                None => warning!("Cannot add M4 var to build env: cannot convert PathBuf to string"),
-            };
+            env.insert_var("M4", path_to_string(&m4.install_path, "M4")?);
         }
 
         // Add requirement specific vars to the build env
@@ -131,7 +128,7 @@ impl<'a> BuildEnv<'a> {
 
     /// Creates the `PATH` for the `Environment`. The path will include the bin directories
     /// of all (build) dependencies and standard Unix system bin paths (if on Unix).
-    fn create_path(&self) -> String {
+    fn create_path(&self) -> Result<String> {
         let mut parts = Vec::new();
 
         //TODO: add compiler wrappers to path
@@ -146,16 +143,7 @@ impl<'a> BuildEnv<'a> {
                 continue;
             }
 
-            match bin_path.to_str() {
-                Some(path) => parts.push(path.into()),
-                None => {
-                    warning!(
-                        "Cannot add dependency {} to build env PATH: cannot convert PathBuf to string",
-                        dependency.package_id.style()
-                    );
-                    continue;
-                },
-            };
+            parts.push(path_to_string(&bin_path, "PATH")?);
         }
 
         // Add standard Unix system bin paths to PATH
@@ -180,12 +168,12 @@ impl<'a> BuildEnv<'a> {
             );
         }
 
-        parts.join(PATH_SEPARATOR)
+        Ok(parts.join(PATH_SEPARATOR))
     }
 
     /// Creates the `PKG_CONFIG_PATH` to pkgconfig inside of the lib and share directories of the (build) dependencies.
     /// It also adds the necessary platform specific paths.
-    fn create_pkg_config_path(&self) -> String {
+    fn create_pkg_config_path(&self) -> Result<String> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add dependencies to PKG_CONFIG_PATH
@@ -195,30 +183,12 @@ impl<'a> BuildEnv<'a> {
 
             // Add lib dir to PKG_CONFIG_PATH if it exists and is a directory
             if lib_path.is_dir() {
-                match lib_path.to_str() {
-                    Some(path) => parts.push(path.into()),
-                    None => {
-                        warning!(
-                            "Cannot add dependency {} lib/pkgconfig to build env PKG_CONFIG_PATH: cannot convert PathBuf to string",
-                            dependency.package_id.style()
-                        );
-                        continue;
-                    },
-                };
+                parts.push(path_to_string(&lib_path, "PKG_CONFIG_PATH")?);
             }
 
             // Add share dir to PKG_CONFIG_PATH if it exists and is a directory
             if share_path.is_dir() {
-                match share_path.to_str() {
-                    Some(path) => parts.push(path.into()),
-                    None => {
-                        warning!(
-                            "Cannot add dependency {} share/pkgconfig to build env PKG_CONFIG_PATH: cannot convert PathBuf to string",
-                            dependency.package_id.style()
-                        );
-                        continue;
-                    },
-                };
+                parts.push(path_to_string(&share_path, "PKG_CONFIG_PATH")?);
             }
         }
 
@@ -228,11 +198,11 @@ impl<'a> BuildEnv<'a> {
             parts.push("/usr/lib/pkgconfig".into());
         }
 
-        parts.join(PATH_SEPARATOR)
+        Ok(parts.join(PATH_SEPARATOR))
     }
 
     /// Creates the `CMAKE_PREFIX_PATH` with the (build) dependency install paths.
-    fn create_cmake_prefix_path(&self) -> String {
+    fn create_cmake_prefix_path(&self) -> Result<String> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add non symlinked dependencies to CMAKE_PREFIX_PATH
@@ -243,30 +213,17 @@ impl<'a> BuildEnv<'a> {
                 }
             }
 
-            let path = &dependency.install_path;
-            match path.to_str() {
-                Some(path) => parts.push(path.into()),
-                None => {
-                    warning!(
-                        "Cannot add dependency {} to build env CMAKE_PREFIX_PATH: cannot convert PathBuf to string",
-                        dependency.package_id.style()
-                    );
-                    continue;
-                },
-            };
+            parts.push(path_to_string(&dependency.install_path, "CMAKE_PREFIX_PATH")?);
         }
 
         // Add prefix directory to CMAKE_PREFIX_PATH
-        match self.prefix_directory.to_str() {
-            Some(path) => parts.push(path.into()),
-            None => warning!("Cannot add Packit prefix directory to build env CMAKE_PREFIX_PATH: cannot convert PathBuf to string"),
-        };
+        parts.push(path_to_string(self.prefix_directory, "CMAKE_PREFIX_PATH")?);
 
-        parts.join(PATH_SEPARATOR)
+        Ok(parts.join(PATH_SEPARATOR))
     }
 
     /// Creates the `ACLOCAL_PATH` from the share/aclocal in each (build) dependency.
-    fn create_aclocal_path(&self) -> String {
+    fn create_aclocal_path(&self) -> Result<String> {
         let mut parts: Vec<String> = Vec::new();
 
         // Add non symlinked dependencies to ACLOCAL_PATH
@@ -279,30 +236,17 @@ impl<'a> BuildEnv<'a> {
 
             let share_path = dependency.install_path.join("share").join("aclocal");
 
-            // Skip adding if the share dir does not exist
-            if !share_path.exists() {
-                continue;
+            // Adding the share dir if it exists
+            if share_path.exists() {
+                parts.push(path_to_string(&share_path, "ACLOCAL_PATH")?);
             }
-
-            match share_path.to_str() {
-                Some(path) => parts.push(path.into()),
-                None => {
-                    warning!(
-                        "Cannot add dependency {} to build env ACLOCAL_PATH: cannot convert PathBuf to string",
-                        dependency.package_id.style()
-                    );
-                    continue;
-                },
-            };
         }
 
         // Add prefix directory to ACLOCAL_PATH
-        match self.prefix_directory.join("share").join("aclocal").to_str() {
-            Some(path) => parts.push(path.into()),
-            None => warning!("Cannot add Packit prefix directory to build env ACLOCAL_PATH: cannot convert PathBuf to string"),
-        };
+        let global_aclocal = self.prefix_directory.join("share").join("aclocal");
+        parts.push(path_to_string(&global_aclocal, "ACLOCAL_PATH")?);
 
-        parts.join(PATH_SEPARATOR)
+        Ok(parts.join(PATH_SEPARATOR))
     }
 
     /// Creates environment variables from the specified build requirements.

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -8,7 +8,10 @@ use thiserror::Error;
 
 use crate::{
     cli::display::{logging::warning, styled::Styled},
-    platforms::tool_detection::{self, error::ToolDetectionError},
+    platforms::{
+        Target,
+        tool_detection::{self, error::ToolDetectionError},
+    },
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::types::Requirement,
     utils::env::Environment,
@@ -309,12 +312,20 @@ impl<'a> BuildEnv<'a> {
         for requirement in self.build_requirements {
             match requirement {
                 Requirement::Msvc => {
+                    // Detect MSVC toolchain
                     let Some(msvc) = tool_detection::detect_msvc()? else {
                         return Err(BuildEnvError::ToolNotFound("msvc".into()));
                     };
 
+                    // Get target, skip requirement if target is `None`.
+                    let Some(target) = msvc.get_vcvarsall_target(&Target::current()) else {
+                        warning!("Tried to load MSVC for an unsupported target, skipping adding to build env");
+                        continue;
+                    };
+
                     vars.insert("PACKIT_VS_PATH", path_to_string(msvc.get_vs_path(), "PACKIT_VS_PATH")?);
                     vars.insert("PACKIT_VCVARSALL", path_to_string(&msvc.get_vcvarsall_path(), "PACKIT_VCVARSALL")?);
+                    vars.insert("PACKIT_VCVARSALL_TARGET", target.into());
                 },
             }
         }

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -92,6 +92,15 @@ impl<'a> Builder<'a> {
             });
         }
 
+        // Check if all build requirements are satisfied
+        for requirement in &target.build_requirements {
+            if !requirement.is_satisfied()? {
+                return Err(BuilderError::MissingRequirementError {
+                    requirement: requirement.clone(),
+                });
+            }
+        }
+
         // Get source from the package version
         let source = install_meta.version_metadata.get_source(&install_meta.target_bounds)?;
         debug!("Source size: {}", source.size);

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -151,6 +151,7 @@ impl<'a> Builder<'a> {
             &self.config.prefix_directory,
             &installed_dependencies,
             installed_build_dependencies,
+            &target.build_requirements,
             self.register,
         );
 

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -51,7 +51,7 @@ pub enum BuilderError {
     #[error("Cannot apply patch file")]
     ApplyPatchError(#[from] PatchError),
 
-    #[error("Cannot detect tool on the system")]
+    #[error("Error while detecting tool on the system")]
     ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("Cannot request files for building")]

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -5,7 +5,8 @@ use crate::{
     builder::BinaryPatcherError,
     cli::display::styled::Styled,
     installer::{scripts::ScriptError, types::PackageName, unpack::UnpackError},
-    repositories::error::RepositoryError,
+    platforms::tool_detection::error::ToolDetectionError,
+    repositories::{error::RepositoryError, types::Requirement},
     utils::{ioerror, patches::PatchError},
 };
 
@@ -16,6 +17,11 @@ pub enum BuilderError {
     MissingDependencyError {
         dependency_type: String,
         package_name: PackageName,
+    },
+
+    #[error("Requirement '{requirement}' is not satisfied.\n{}", requirement.get_not_satisfied_message())]
+    MissingRequirementError {
+        requirement: Requirement,
     },
 
     #[error("Checksum does not match")]
@@ -44,6 +50,9 @@ pub enum BuilderError {
 
     #[error("Cannot apply patch file")]
     ApplyPatchError(#[from] PatchError),
+
+    #[error("Cannot detect tool on the system")]
+    ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("Cannot request files for building")]
     RequestError(#[from] reqwest::Error),

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -7,6 +7,7 @@ mod patcher;
 pub use self::builder::Builder;
 
 pub use self::build_env::BuildEnv;
+pub use self::build_env::BuildEnvError;
 
 pub use self::patcher::BinaryPatcher;
 pub use self::patcher::BinaryPatcherError;

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -10,7 +10,7 @@ use crate::{
         types::{PackageId, PackageIdError, PackageName, Version},
         unpack::UnpackError,
     },
-    platforms::{permissions::error::PermissionError, symlink::SymlinkError},
+    platforms::{permissions::error::PermissionError, symlink::SymlinkError, tool_detection::error::ToolDetectionError},
     register::error::RegisterError,
     repositories::error::RepositoryError,
     utils::{ioerror, tree::TreeError},
@@ -91,6 +91,9 @@ pub enum InstallerError {
 
     #[error("Cannot set or get permissions")]
     PermissionError(#[from] PermissionError),
+
+    #[error("Error while detecting tool on the system")]
+    ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("Error while interacting with filesystem")]
     IOError(#[from] ioerror::IOError),

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -10,7 +10,7 @@ use crate::{
         types::{PackageId, PackageIdError, PackageName, Version},
         unpack::UnpackError,
     },
-    platforms::{permissions::error::PermissionError, symlink::SymlinkError, tool_detection::error::ToolDetectionError},
+    platforms::{permissions::error::PermissionError, symlink::SymlinkError},
     register::error::RegisterError,
     repositories::error::RepositoryError,
     utils::{ioerror, tree::TreeError},
@@ -91,9 +91,6 @@ pub enum InstallerError {
 
     #[error("Cannot set or get permissions")]
     PermissionError(#[from] PermissionError),
-
-    #[error("Error while detecting tool on the system")]
-    ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("Error while interacting with filesystem")]
     IOError(#[from] ioerror::IOError),

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -19,7 +19,7 @@ use crate::{
         error::{InstallerError, Result},
         install_tree::{InstallMeta, InstallTree, InstallTreeBuilder, InstallType},
         options::InstallerOptions,
-        scripts::{self, ScriptData},
+        scripts::{self, ScriptData, ScriptError},
         symlinker::Symlinker,
         types::{OptionalPackageId, PackageId, PackageName, Version},
         unpack::unpack,
@@ -469,30 +469,36 @@ impl<'a> Installer<'a> {
             }
         }
 
-        // Check if all test requirements are satisfied
-        for requirement in &target.test_requirements {
-            if !requirement.is_satisfied()? {
+        // Only create a spinner when not verbose
+        let spinner = match self.options.verbose {
+            true => {
+                println!("Testing {}", package_id.style());
+                None
+            },
+            false => {
+                let spinner_message = format!("Testing {}", package_id.style());
+                let spinner = Spinner::new(spinner_message);
+                spinner.show();
+                Some(spinner)
+            },
+        };
+
+        // Run script
+        match scripts::run_test_script(&script_data, &read_files, &target.test_requirements) {
+            Ok(_) => (),
+            Err(ScriptError::RequirementNotSatisfied(requirement)) => {
                 warning!(
                     "Skipping test, because requirement '{requirement}' is not satisfied.\n{}",
                     requirement.get_not_satisfied_message()
                 );
-                return Ok(());
-            }
+            },
+            Err(e) => return Err(e.into()),
         }
 
-        // Only show a spinner when not verbose
-        if self.options.verbose {
-            println!("Testing {}", package_id.style());
-            scripts::run_test_script(&script_data, &read_files, &target.test_requirements)?;
-            return Ok(());
+        // Finish spinner if it was created
+        if let Some(spinner) = spinner {
+            spinner.finish();
         }
-
-        // Run script with spinner shown
-        let spinner_message = format!("Testing {}", package_id.style());
-        let spinner = Spinner::new(spinner_message);
-        spinner.show();
-        scripts::run_test_script(&script_data, &read_files, &target.test_requirements)?;
-        spinner.finish();
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -456,7 +456,6 @@ impl<'a> Installer<'a> {
         // Download external files necessary for testing
         let external_files = install_meta.version_metadata.external_test_files.iter().chain(&target.external_test_files);
         let mut read_files = Vec::new();
-        let mut skip_test = false;
         for file in external_files {
             let file_content =
                 self.repository_manager.read_file_bytes(&install_meta.repository_id, &install_meta.package_metadata.name, file)?;
@@ -465,21 +464,26 @@ impl<'a> Installer<'a> {
                 Some(content) => read_files.push((file, content)),
                 None => {
                     warning!("Skipping test, because the required files could not be downloaded.");
-                    skip_test = true;
-                    break;
+                    return Ok(());
                 },
             }
         }
 
-        // Return early if the test should be skipped
-        if skip_test {
-            return Ok(());
+        // Check if all test requirements are satisfied
+        for requirement in &target.test_requirements {
+            if !requirement.is_satisfied()? {
+                warning!(
+                    "Skipping test, because requirement '{requirement}' is not satisfied.\n{}",
+                    requirement.get_not_satisfied_message()
+                );
+                return Ok(());
+            }
         }
 
         // Only show a spinner when not verbose
         if self.options.verbose {
             println!("Testing {}", package_id.style());
-            scripts::run_test_script(&script_data, &read_files)?;
+            scripts::run_test_script(&script_data, &read_files, &target.test_requirements)?;
             return Ok(());
         }
 
@@ -487,7 +491,7 @@ impl<'a> Installer<'a> {
         let spinner_message = format!("Testing {}", package_id.style());
         let spinner = Spinner::new(spinner_message);
         spinner.show();
-        scripts::run_test_script(&script_data, &read_files)?;
+        scripts::run_test_script(&script_data, &read_files, &target.test_requirements)?;
         spinner.finish();
 
         Ok(())

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -16,7 +16,7 @@ use crate::{
     cli::display::logging::warning,
     config::Config,
     installer::types::{PackageId, PackageName},
-    platforms::{Os, TargetArchitecture},
+    platforms::{Os, TargetArchitecture, tool_detection::error::ToolDetectionError},
     repositories::{error::RepositoryError, manager::RepositoryManager, types::Requirement},
     utils::{
         env::Environment,
@@ -32,6 +32,9 @@ use std::os::{fd::IntoRawFd, unix::process::CommandExt};
 pub enum ScriptError {
     #[error("Cannot parse PathBuf to string")]
     InvalidPathString,
+
+    #[error("Requirement {0} is not satisfied")]
+    RequirementNotSatisfied(Requirement),
 
     #[error("Cannot find script '{0}'")]
     ScriptNotFound(String),
@@ -56,6 +59,9 @@ pub enum ScriptError {
 
     #[error("Cannot create build environment")]
     BuildEnvError(#[from] BuildEnvError),
+
+    #[error("Error while detecting tool on the system")]
+    ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("IOError during a script operation")]
     IOError(#[from] ioerror::IOError),
@@ -119,6 +125,13 @@ pub fn run_post_script(script_data: &ScriptData) -> Result<()> {
 /// It also writes the specified external test files to the temp directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
 pub fn run_test_script(script_data: &ScriptData, external_files: &Vec<(&String, Bytes)>, requirements: &Vec<Requirement>) -> Result<()> {
+    // Check if all test requirements are satisfied
+    for requirement in requirements {
+        if !requirement.is_satisfied()? {
+            return Err(ScriptError::RequirementNotSatisfied(requirement.clone()));
+        }
+    }
+
     let temp_dir = TempDir::new().map_err(ScriptError::TempCreationError)?;
 
     // Install external files into the temp directory

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -12,7 +12,7 @@ use tempfile::{NamedTempFile, TempDir};
 use thiserror::Error;
 
 use crate::{
-    builder::BuildEnv,
+    builder::{BuildEnv, BuildEnvError},
     cli::display::logging::warning,
     config::Config,
     installer::types::{PackageId, PackageName},
@@ -53,6 +53,9 @@ pub enum ScriptError {
 
     #[error("Cannot fetch script from repository")]
     FetchScriptError(#[from] RepositoryError),
+
+    #[error("Cannot create build environment")]
+    BuildEnvError(#[from] BuildEnvError),
 
     #[error("IOError during a script operation")]
     IOError(#[from] ioerror::IOError),
@@ -103,7 +106,7 @@ pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Re
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
 pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv) -> Result<()> {
-    run_script(script_data, run_dir, build_env.into(), script_data.verbose)
+    run_script(script_data, run_dir, build_env.try_into()?, script_data.verbose)
 }
 
 /// Runs the given post install script, in the package install directory.

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -17,7 +17,7 @@ use crate::{
     config::Config,
     installer::types::{PackageId, PackageName},
     platforms::{Os, TargetArchitecture},
-    repositories::{error::RepositoryError, manager::RepositoryManager},
+    repositories::{error::RepositoryError, manager::RepositoryManager, types::Requirement},
     utils::{
         env::Environment,
         ioerror::{self, IOResultExt},
@@ -118,7 +118,7 @@ pub fn run_post_script(script_data: &ScriptData) -> Result<()> {
 /// Runs the given test script, in a newly created temp directory.
 /// It also writes the specified external test files to the temp directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_test_script(script_data: &ScriptData, external_files: &Vec<(&String, Bytes)>) -> Result<()> {
+pub fn run_test_script(script_data: &ScriptData, external_files: &Vec<(&String, Bytes)>, requirements: &Vec<Requirement>) -> Result<()> {
     let temp_dir = TempDir::new().map_err(ScriptError::TempCreationError)?;
 
     // Install external files into the temp directory
@@ -126,7 +126,10 @@ pub fn run_test_script(script_data: &ScriptData, external_files: &Vec<(&String, 
         fs::write(temp_dir.path().join(file_name), file_content).map_err(ScriptError::SaveError)?;
     }
 
-    run_script(script_data, &temp_dir, Environment::new(), true)
+    // Create environment containing the requirements
+    let env = BuildEnv::create_requirement_environment(requirements)?;
+
+    run_script(script_data, &temp_dir, env, true)
 }
 
 /// Runs the given uninstall script, in the package install directory.

--- a/src/integrity/error.rs
+++ b/src/integrity/error.rs
@@ -10,7 +10,7 @@ use crate::{
         types::{PackageNameError, VersionError},
     },
     packager::PackagerError,
-    platforms::{permissions::error::PermissionError, symlink::SymlinkError, tool_detection::error::ToolDetectionError},
+    platforms::{permissions::error::PermissionError, symlink::SymlinkError},
     register::error::RegisterError,
     repositories::error::RepositoryError,
     utils::ioerror,
@@ -63,9 +63,6 @@ pub enum VerifierError {
 
     #[error("Cannot perform check, because of an error when executing a script")]
     ScriptError(#[from] ScriptError),
-
-    #[error("Error while detecting tool on the system")]
-    ToolDetectionError(#[from] ToolDetectionError),
 
     #[error("Cannot perform check or fix, because of an error while interacting with the filesystem")]
     IOError(#[from] ioerror::IOError),

--- a/src/integrity/error.rs
+++ b/src/integrity/error.rs
@@ -10,7 +10,7 @@ use crate::{
         types::{PackageNameError, VersionError},
     },
     packager::PackagerError,
-    platforms::{permissions::error::PermissionError, symlink::SymlinkError},
+    platforms::{permissions::error::PermissionError, symlink::SymlinkError, tool_detection::error::ToolDetectionError},
     register::error::RegisterError,
     repositories::error::RepositoryError,
     utils::ioerror,
@@ -61,11 +61,14 @@ pub enum VerifierError {
     #[error("Could not use repository manager for check or fix")]
     RepositoryError(#[from] RepositoryError),
 
-    #[error("Cannot perform check or fix, because of an error while interacting with the filesystem")]
-    IOError(#[from] ioerror::IOError),
-
     #[error("Cannot perform check, because of an error when executing a script")]
     ScriptError(#[from] ScriptError),
+
+    #[error("Error while detecting tool on the system")]
+    ToolDetectionError(#[from] ToolDetectionError),
+
+    #[error("Cannot perform check or fix, because of an error while interacting with the filesystem")]
+    IOError(#[from] ioerror::IOError),
 }
 
 pub(super) type Result<T> = std::result::Result<T, VerifierError>;

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -16,11 +16,7 @@ use crate::{
         scripts::{self, ScriptData, ScriptError},
         types::{Dependency, PackageId, PackageName},
     },
-    integrity::{
-        Issue,
-        error::{Result, VerifierError},
-        utils::get_storage_packages,
-    },
+    integrity::{Issue, error::Result, utils::get_storage_packages},
     packager,
     platforms::Target,
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
@@ -645,23 +641,19 @@ fn check_package_test(package_id: &PackageId, register: &PackageRegister, config
         }
     }
 
-    // Check if all test requirements are satisfied
-    for requirement in &target.test_requirements {
-        if !requirement.is_satisfied()? {
+    // Run the test script and only return true if the test itself failed
+    match scripts::run_test_script(&script_data, &read_files, &target.test_requirements) {
+        Ok(_) => Ok(false),
+        Err(ScriptError::RequirementNotSatisfied(requirement)) => {
             warning!(
                 "Skipping {} test, because requirement '{requirement}' is not satisfied.\n{}",
                 package_id.style(),
                 requirement.get_not_satisfied_message()
             );
-            return Ok(false);
-        }
-    }
-
-    // Run the test script and only return true if the test itself failed
-    match scripts::run_test_script(&script_data, &read_files, &target.test_requirements) {
-        Ok(_) => Ok(false),
+            Ok(false)
+        },
         Err(ScriptError::ScriptFailed(..)) => Ok(true),
-        Err(e) => Err(VerifierError::ScriptError(e)),
+        Err(e) => Err(e.into()),
     }
 }
 

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -636,14 +636,29 @@ fn check_package_test(package_id: &PackageId, register: &PackageRegister, config
         match file_content {
             Some(content) => read_files.push((file, content)),
             None => {
-                warning!("Skipping test, because the required files could not be downloaded.");
+                warning!(
+                    "Skipping {} test, because the required files could not be downloaded.",
+                    package_id.style()
+                );
                 return Ok(false);
             },
         }
     }
 
+    // Check if all test requirements are satisfied
+    for requirement in &target.test_requirements {
+        if !requirement.is_satisfied()? {
+            warning!(
+                "Skipping {} test, because requirement '{requirement}' is not satisfied.\n{}",
+                package_id.style(),
+                requirement.get_not_satisfied_message()
+            );
+            return Ok(false);
+        }
+    }
+
     // Run the test script and only return true if the test itself failed
-    match scripts::run_test_script(&script_data, &read_files) {
+    match scripts::run_test_script(&script_data, &read_files, &target.test_requirements) {
         Ok(_) => Ok(false),
         Err(ScriptError::ScriptFailed(..)) => Ok(true),
         Err(e) => Err(VerifierError::ScriptError(e)),

--- a/src/platforms/mod.rs
+++ b/src/platforms/mod.rs
@@ -5,6 +5,7 @@ pub mod permissions;
 pub mod symlink;
 mod target;
 mod target_architecture;
+pub mod tool_detection;
 
 pub use defaults::DEFAULT_CONFIG_DIR;
 pub use defaults::DEFAULT_PREFIX;

--- a/src/platforms/tool_detection.rs
+++ b/src/platforms/tool_detection.rs
@@ -1,12 +1,11 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pub mod error;
+pub mod tools;
 
 #[cfg(target_os = "windows")]
 mod windows;
 
-use std::path::PathBuf;
-
-use crate::platforms::tool_detection::error::Result;
+use crate::platforms::tool_detection::{error::Result, tools::Msvc};
 
 #[cfg(target_os = "windows")]
 pub use self::windows::detect_msvc;
@@ -14,6 +13,6 @@ pub use self::windows::detect_msvc;
 #[cfg(not(target_os = "windows"))]
 /// Detects if MSVC is installed on the system.
 /// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
-pub fn detect_msvc() -> Result<Option<PathBuf>> {
+pub fn detect_msvc() -> Result<Option<Msvc>> {
     Ok(None)
 }

--- a/src/platforms/tool_detection.rs
+++ b/src/platforms/tool_detection.rs
@@ -5,14 +5,15 @@ pub mod tools;
 #[cfg(target_os = "windows")]
 mod windows;
 
+#[cfg(not(target_os = "windows"))]
 use crate::platforms::tool_detection::{error::Result, tools::Msvc};
 
 #[cfg(target_os = "windows")]
 pub use self::windows::detect_msvc;
 
-#[cfg(not(target_os = "windows"))]
 /// Detects if MSVC is installed on the system.
-/// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
+/// Returns the installation path of Visual Studio if it is found, or `None` if MSVC is not found.
+#[cfg(not(target_os = "windows"))]
 pub fn detect_msvc() -> Result<Option<Msvc>> {
     Ok(None)
 }

--- a/src/platforms/tool_detection.rs
+++ b/src/platforms/tool_detection.rs
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-only
+pub mod error;
+
+#[cfg(target_os = "windows")]
+mod windows;
+
+use std::path::PathBuf;
+
+use crate::platforms::tool_detection::error::Result;
+
+#[cfg(target_os = "windows")]
+pub use self::windows::detect_msvc;
+
+#[cfg(not(target_os = "windows"))]
+/// Detects if MSVC is installed on the system.
+/// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
+pub fn detect_msvc() -> Result<Option<PathBuf>> {
+    Ok(None)
+}

--- a/src/platforms/tool_detection/error.rs
+++ b/src/platforms/tool_detection/error.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use thiserror::Error;
 
-use crate::utils::ioerror;
+use crate::{installer::types::VersionError, utils::ioerror};
 
 #[derive(Error, Debug)]
 pub enum ToolDetectionError {
     #[error("Error while parsing bytes to string")]
     Utf8Error(#[from] std::str::Utf8Error),
+
+    #[error("Error while parsing version")]
+    VersionError(#[from] VersionError),
 
     #[error("IO error while trying to detect tool")]
     IOError(#[from] ioerror::IOError),

--- a/src/platforms/tool_detection/error.rs
+++ b/src/platforms/tool_detection/error.rs
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use thiserror::Error;
+
+use crate::utils::ioerror;
+
+#[derive(Error, Debug)]
+pub enum ToolDetectionError {
+    #[error("Error while parsing bytes to string")]
+    Utf8Error(#[from] std::str::Utf8Error),
+
+    #[error("IO error while trying to detect tool")]
+    IOError(#[from] ioerror::IOError),
+}
+
+pub type Result<T> = core::result::Result<T, ToolDetectionError>;

--- a/src/platforms/tool_detection/tools.rs
+++ b/src/platforms/tool_detection/tools.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::path::PathBuf;
 
+use crate::platforms::Target;
+
 /// Represents the Microsoft Visual C++ toolchain.
 pub struct Msvc {
     vs_path: PathBuf,
@@ -21,5 +23,15 @@ impl Msvc {
     /// Gets the path of the vcvarsall.bat script.
     pub fn get_vcvarsall_path(&self) -> PathBuf {
         self.vs_path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat")
+    }
+
+    /// Gets the target needed for the vcvarsall.bat execution.
+    /// Returns `None` if the given target is not supported
+    pub fn get_vcvarsall_target(&self, target: &Target) -> Option<&str> {
+        match target.architecture {
+            crate::platforms::TargetArchitecture::WindowsX86_64Msvc => Some("x64"),
+            crate::platforms::TargetArchitecture::WindowsAarch64Msvc => Some("arm64"),
+            _ => None,
+        }
     }
 }

--- a/src/platforms/tool_detection/tools.rs
+++ b/src/platforms/tool_detection/tools.rs
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use std::path::PathBuf;
+
+/// Represents the Microsoft Visual C++ toolchain.
+pub struct Msvc {
+    vs_path: PathBuf,
+}
+
+impl Msvc {
+    /// Creates a new `Msvc`, holding the path to the toolchain.
+    #[cfg(windows)]
+    pub fn new(vs_path: PathBuf) -> Self {
+        Self { vs_path }
+    }
+
+    /// Gets the installation path of Visual Studio.
+    pub fn get_vs_path(&self) -> &PathBuf {
+        &self.vs_path
+    }
+
+    /// Gets the path of the vcvarsall.bat script.
+    pub fn get_vcvarsall_path(&self) -> PathBuf {
+        self.vs_path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat")
+    }
+}

--- a/src/platforms/tool_detection/tools.rs
+++ b/src/platforms/tool_detection/tools.rs
@@ -1,18 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::path::PathBuf;
 
-use crate::platforms::Target;
+use crate::{
+    installer::types::Version,
+    platforms::{Target, TargetArchitecture},
+};
 
 /// Represents the Microsoft Visual C++ toolchain.
 pub struct Msvc {
     vs_path: PathBuf,
+    version: Version,
 }
 
 impl Msvc {
     /// Creates a new `Msvc`, holding the path to the toolchain.
     #[cfg(windows)]
-    pub fn new(vs_path: PathBuf) -> Self {
-        Self { vs_path }
+    pub fn new(vs_path: PathBuf, version: Version) -> Self {
+        Self { vs_path, version }
     }
 
     /// Gets the installation path of Visual Studio.
@@ -20,17 +24,22 @@ impl Msvc {
         &self.vs_path
     }
 
+    /// Gets the version of the MSVC toolchain.
+    pub fn get_version(&self) -> &Version {
+        &self.version
+    }
+
     /// Gets the path of the vcvarsall.bat script.
     pub fn get_vcvarsall_path(&self) -> PathBuf {
         self.vs_path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat")
     }
 
-    /// Gets the target needed for the vcvarsall.bat execution.
+    /// Gets the arch needed for the vcvarsall.bat execution.
     /// Returns `None` if the given target is not supported
-    pub fn get_vcvarsall_target(&self, target: &Target) -> Option<&str> {
+    pub fn get_vcvarsall_arch(&self, target: &Target) -> Option<&str> {
         match target.architecture {
-            crate::platforms::TargetArchitecture::WindowsX86_64Msvc => Some("x64"),
-            crate::platforms::TargetArchitecture::WindowsAarch64Msvc => Some("arm64"),
+            TargetArchitecture::WindowsX86_64Msvc => Some("x64"),
+            TargetArchitecture::WindowsAarch64Msvc => Some("arm64"),
             _ => None,
         }
     }

--- a/src/platforms/tool_detection/tools.rs
+++ b/src/platforms/tool_detection/tools.rs
@@ -29,12 +29,12 @@ impl Msvc {
         &self.version
     }
 
-    /// Gets the path of the vcvarsall.bat script.
+    /// Gets the path of the `vcvarsall.bat` script.
     pub fn get_vcvarsall_path(&self) -> PathBuf {
         self.vs_path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat")
     }
 
-    /// Gets the arch needed for the vcvarsall.bat execution.
+    /// Gets the arch needed for the `vcvarsall.bat` execution.
     /// Returns `None` if the given target is not supported
     pub fn get_vcvarsall_arch(&self, target: &Target) -> Option<&str> {
         match target.architecture {

--- a/src/platforms/tool_detection/tools.rs
+++ b/src/platforms/tool_detection/tools.rs
@@ -14,7 +14,7 @@ pub struct Msvc {
 
 impl Msvc {
     /// Creates a new `Msvc`, holding the path to the toolchain.
-    #[cfg(windows)]
+    #[cfg(target_os = "windows")]
     pub fn new(vs_path: PathBuf, version: Version) -> Self {
         Self { vs_path, version }
     }

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -4,7 +4,7 @@ use std::{path::PathBuf, process::Command};
 use crate::{cli::display::logging::debug, platforms::tool_detection::error::Result, utils::ioerror::IOResultExt};
 
 /// Detects if MSVC is installed on the system.
-/// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
+/// Returns the installation path of Visual Studio if it is found, or `None` if MSVC is not found.
 pub fn detect_msvc() -> Result<Option<PathBuf>> {
     // Check if `vswhere` exists
     let vswhere = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe");
@@ -33,5 +33,5 @@ pub fn detect_msvc() -> Result<Option<PathBuf>> {
         return Ok(None);
     }
 
-    Ok(Some(vcvarsall))
+    Ok(Some(path))
 }

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -1,32 +1,35 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{path::PathBuf, process::Command};
 
-use crate::{platforms::tool_detection::error::Result, utils::ioerror::IOResultExt};
+use crate::{cli::display::logging::debug, platforms::tool_detection::error::Result, utils::ioerror::IOResultExt};
 
 /// Detects if MSVC is installed on the system.
 /// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
 pub fn detect_msvc() -> Result<Option<PathBuf>> {
     // Check if `vswhere` exists
-    let vswhere = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere");
+    let vswhere = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe");
     if !vswhere.exists() {
+        debug!("Cannot find 'vswhere.exe'");
         return Ok(None);
     }
 
     // Read Visual Studio install path from `vswhere`
     let mut command = Command::new(vswhere);
-    command.args(["-latest", "-property installationPath"]);
+    command.args(["-latest", "-property", "installationPath"]);
     let output = command.output().err_operation("run vswhere command")?;
     let path = str::from_utf8(&output.stdout)?;
-    let path = PathBuf::from(path);
+    let path = PathBuf::from(path.trim());
 
     // Check if install path exists
     if !path.exists() {
+        debug!("The Visual Studio install does not exist at '{}'", path.display());
         return Ok(None);
     }
 
     // Check if vcvarsall.bat exists
     let vcvarsall = path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat");
     if !vcvarsall.exists() {
+        debug!("The vcvarsall.bat script does not exist at '{}'", vcvarsall.display());
         return Ok(None);
     }
 

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -1,11 +1,15 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{path::PathBuf, process::Command};
 
-use crate::{cli::display::logging::debug, platforms::tool_detection::error::Result, utils::ioerror::IOResultExt};
+use crate::{
+    cli::display::logging::debug,
+    platforms::tool_detection::{error::Result, tools::Msvc},
+    utils::ioerror::IOResultExt,
+};
 
 /// Detects if MSVC is installed on the system.
 /// Returns the installation path of Visual Studio if it is found, or `None` if MSVC is not found.
-pub fn detect_msvc() -> Result<Option<PathBuf>> {
+pub fn detect_msvc() -> Result<Option<Msvc>> {
     // Check if `vswhere` exists
     let vswhere = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere.exe");
     if !vswhere.exists() {
@@ -17,21 +21,23 @@ pub fn detect_msvc() -> Result<Option<PathBuf>> {
     let mut command = Command::new(vswhere);
     command.args(["-latest", "-property", "installationPath"]);
     let output = command.output().err_operation("run vswhere command")?;
-    let path = str::from_utf8(&output.stdout)?;
-    let path = PathBuf::from(path.trim());
+    let vs_path = str::from_utf8(&output.stdout)?;
+    let vs_path = PathBuf::from(vs_path.trim());
 
     // Check if install path exists
-    if !path.exists() {
-        debug!("The Visual Studio install does not exist at '{}'", path.display());
+    if !vs_path.exists() {
+        debug!("The Visual Studio install does not exist at '{}'", vs_path.display());
         return Ok(None);
     }
 
+    let msvc = Msvc::new(vs_path);
+
     // Check if vcvarsall.bat exists
-    let vcvarsall = path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat");
+    let vcvarsall = msvc.get_vcvarsall_path();
     if !vcvarsall.exists() {
         debug!("The vcvarsall.bat script does not exist at '{}'", vcvarsall.display());
         return Ok(None);
     }
 
-    Ok(Some(path))
+    Ok(Some(msvc))
 }

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -34,7 +34,7 @@ pub fn detect_msvc() -> Result<Option<Msvc>> {
     // Read MSVC version
     let version_path = vs_path.join("VC").join("Auxiliary").join("Build").join("Microsoft.VCToolsVersion.default.txt");
     let version_str = fs::read_to_string(&version_path).err_with_path("read", version_path)?;
-    let version = Version::from_str(&version_str)?;
+    let version = Version::from_str(&version_str.trim())?;
 
     let msvc = Msvc::new(vs_path, version);
 

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{path::PathBuf, process::Command};
+use std::{fs, path::PathBuf, process::Command, str::FromStr};
 
 use crate::{
     cli::display::logging::debug,
+    installer::types::Version,
     platforms::tool_detection::{error::Result, tools::Msvc},
     utils::ioerror::IOResultExt,
 };
@@ -30,7 +31,12 @@ pub fn detect_msvc() -> Result<Option<Msvc>> {
         return Ok(None);
     }
 
-    let msvc = Msvc::new(vs_path);
+    // Read MSVC version
+    let version_path = vs_path.join("VC").join("Auxiliary").join("Build").join("Microsoft.VCToolsVersion.default.txt");
+    let version_str = fs::read_to_string(&version_path).err_with_path("read", version_path)?;
+    let version = Version::from_str(&version_str)?;
+
+    let msvc = Msvc::new(vs_path, version);
 
     // Check if vcvarsall.bat exists
     let vcvarsall = msvc.get_vcvarsall_path();

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -42,10 +42,10 @@ pub fn detect_msvc() -> Result<Option<Msvc>> {
 
     let msvc = Msvc::new(vs_path, version);
 
-    // Check if vcvarsall.bat exists
+    // Check if `vcvarsall.bat` exists
     let vcvarsall = msvc.get_vcvarsall_path();
     if !vcvarsall.exists() {
-        debug!("vcvarsall.bat script does not exist at '{}'", vcvarsall.display());
+        debug!("'vcvarsall.bat' script does not exist at '{}'", vcvarsall.display());
         return Ok(None);
     }
 

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -27,21 +27,25 @@ pub fn detect_msvc() -> Result<Option<Msvc>> {
 
     // Check if install path exists
     if !vs_path.exists() {
-        debug!("The Visual Studio install does not exist at '{}'", vs_path.display());
+        debug!("Visual Studio install does not exist at '{}'", vs_path.display());
         return Ok(None);
     }
 
     // Read MSVC version
     let version_path = vs_path.join("VC").join("Auxiliary").join("Build").join("Microsoft.VCToolsVersion.default.txt");
+    if !version_path.exists() {
+        debug!("MSVC version cannot be read from '{}'", version_path.display());
+        return Ok(None);
+    }
     let version_str = fs::read_to_string(&version_path).err_with_path("read", version_path)?;
-    let version = Version::from_str(&version_str.trim())?;
+    let version = Version::from_str(version_str.trim())?;
 
     let msvc = Msvc::new(vs_path, version);
 
     // Check if vcvarsall.bat exists
     let vcvarsall = msvc.get_vcvarsall_path();
     if !vcvarsall.exists() {
-        debug!("The vcvarsall.bat script does not exist at '{}'", vcvarsall.display());
+        debug!("vcvarsall.bat script does not exist at '{}'", vcvarsall.display());
         return Ok(None);
     }
 

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use std::{path::PathBuf, process::Command};
+
+use crate::{platforms::tool_detection::error::Result, utils::ioerror::IOResultExt};
+
+/// Detects if MSVC is installed on the system.
+/// Returns the path to vcvarsall.bat if it is found, or `None` if MSVC is not found.
+pub fn detect_msvc() -> Result<Option<PathBuf>> {
+    // Check if `vswhere` exists
+    let vswhere = PathBuf::from("C:\\Program Files (x86)\\Microsoft Visual Studio\\Installer\\vswhere");
+    if !vswhere.exists() {
+        return Ok(None);
+    }
+
+    // Read Visual Studio install path from `vswhere`
+    let mut command = Command::new(vswhere);
+    command.args(["-latest", "-property installationPath"]);
+    let output = command.output().err_operation("run vswhere command")?;
+    let path = str::from_utf8(&output.stdout)?;
+    let path = PathBuf::from(path);
+
+    // Check if install path exists
+    if !path.exists() {
+        return Ok(None);
+    }
+
+    // Check if vcvarsall.bat exists
+    let vcvarsall = path.join("VC").join("Auxiliary").join("Build").join("vcvarsall.bat");
+    if !vcvarsall.exists() {
+        return Ok(None);
+    }
+
+    Ok(Some(vcvarsall))
+}

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -7,6 +7,7 @@ mod package;
 mod package_target;
 mod package_version;
 mod repository;
+mod requirement;
 mod target_bounds;
 
 pub use self::repository::RepositoryMeta;
@@ -32,3 +33,7 @@ pub use self::index::IndexMeta;
 pub use self::license::Licenses;
 
 pub use self::target_bounds::TargetBounds;
+
+pub use self::requirement::Requirement;
+#[expect(unused_imports)]
+pub use self::requirement::RequirementError;

--- a/src/repositories/types/package_target.rs
+++ b/src/repositories/types/package_target.rs
@@ -3,7 +3,10 @@ use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
-use crate::{installer::types::Dependency, repositories::types::Script};
+use crate::{
+    installer::types::Dependency,
+    repositories::types::{Requirement, Script},
+};
 
 /// Represents the package target data, containing the download url and installer type.
 #[derive(Serialize, Deserialize, Debug)]
@@ -13,6 +16,9 @@ pub struct PackageTarget {
 
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub build_dependencies: Vec<Dependency>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub build_requirements: Vec<Requirement>,
 
     pub skip_symlinking: Option<bool>,
 

--- a/src/repositories/types/package_target.rs
+++ b/src/repositories/types/package_target.rs
@@ -20,6 +20,9 @@ pub struct PackageTarget {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub build_requirements: Vec<Requirement>,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub test_requirements: Vec<Requirement>,
+
     pub skip_symlinking: Option<bool>,
 
     pub source: Option<String>,

--- a/src/repositories/types/requirement.rs
+++ b/src/repositories/types/requirement.rs
@@ -60,7 +60,7 @@ impl Serialize for Requirement {
 
 impl Requirement {
     /// Checks if a requirement is satisfied.
-    /// Returns true if the requirement is satisfied, false otherwise
+    /// Returns true if the requirement is satisfied, false otherwise.
     pub fn is_satisfied(&self) -> tool_detection::error::Result<bool> {
         match self {
             Requirement::Msvc => Ok(tool_detection::detect_msvc()?.is_some()),
@@ -70,7 +70,7 @@ impl Requirement {
     /// Gets the message that should be shown when the requirement is not satisfied.
     pub fn get_not_satisfied_message(&self) -> &str {
         match self {
-            Requirement::Msvc => "Microsoft Visual C++ cannot be found, please install it first.",
+            Requirement::Msvc => "Microsoft Visual C++ cannot be found, please install it from the Microsoft website first.",
         }
     }
 }

--- a/src/repositories/types/requirement.rs
+++ b/src/repositories/types/requirement.rs
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: GPL-3.0-only
+use std::{fmt::Display, str::FromStr};
+
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+use crate::platforms::tool_detection;
+
+/// Errors that occur when parsing requirements.
+#[derive(Error, Debug)]
+pub enum RequirementError {
+    #[error("Requirement '{0}' is unknown")]
+    InvalidRequirement(String),
+}
+
+/// Represents requirements of a build or test process of a package.
+#[derive(Clone, Debug)]
+pub enum Requirement {
+    Msvc,
+}
+
+impl FromStr for Requirement {
+    type Err = RequirementError;
+
+    fn from_str(string: &str) -> Result<Self, Self::Err> {
+        match string {
+            "msvc" => Ok(Self::Msvc),
+            _ => Err(RequirementError::InvalidRequirement(string.into())),
+        }
+    }
+}
+
+impl Display for Requirement {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Requirement::Msvc => write!(f, "msvc"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Requirement {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let string: String = serde::de::Deserialize::deserialize(deserializer)?;
+
+        Self::from_str(&string).map_err(serde::de::Error::custom)
+    }
+}
+
+impl Serialize for Requirement {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.collect_str(&self.to_string())
+    }
+}
+
+impl Requirement {
+    /// Checks if a requirement is satisfied.
+    /// Returns true if the requirement is satisfied, false otherwise
+    pub fn is_satisfied(&self) -> tool_detection::error::Result<bool> {
+        match self {
+            Requirement::Msvc => Ok(tool_detection::detect_msvc()?.is_some()),
+        }
+    }
+
+    /// Gets the message that should be shown when the requirement is not satisfied.
+    pub fn get_not_satisfied_message(&self) -> &str {
+        match self {
+            Requirement::Msvc => "Microsoft Visual C++ cannot be found, please install it first.",
+        }
+    }
+}

--- a/src/utils/env.rs
+++ b/src/utils/env.rs
@@ -40,4 +40,13 @@ impl Environment {
         self.env_vars.remove(&key);
         self.stripped_vars.push(key);
     }
+
+    /// Expands the environment with another environment.
+    pub fn expand(&mut self, other_environment: Environment) {
+        self.insert_vars(other_environment.env_vars);
+
+        for stripped_var in other_environment.stripped_vars {
+            self.strip_var(stripped_var);
+        }
+    }
 }


### PR DESCRIPTION
This PR adds the `build_requirements` and `test_requirements` fields to the metadata. The current only available requirement is `msvc`, detecting the Microsoft Visual C++ toolchain and adding required paths to the environment.