### PR TITLE
Refactor prebuild repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.
+- Prebuilds now have a toml metadata file instead of the checksum file, containing the checksum and size of the prebuild.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -25,9 +25,6 @@ pub enum InstallerError {
     #[error("Prebuild checksum does not match")]
     ChecksumError,
 
-    #[error("Prebuild not found, while it was expected to exist")]
-    PrebuildNotFound,
-
     #[error("Package {} with version '{}' is not installed.", package_name.style(), version.as_ref().map_or("any".normal(), |v| v.style()))]
     PackageNotFound {
         package_name: PackageName,

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -25,6 +25,9 @@ pub enum InstallerError {
     #[error("Prebuild checksum does not match")]
     ChecksumError,
 
+    #[error("Prebuild not found, while it was expected to exist")]
+    PrebuildNotFound,
+
     #[error("Package {} with version '{}' is not installed.", package_name.style(), version.as_ref().map_or("any".normal(), |v| v.style()))]
     PackageNotFound {
         package_name: PackageName,

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -239,7 +239,7 @@ impl<'a> InstallTreeBuilder<'a> {
         // Check if a prebuild for the package is available
         let revision = install_meta.version_metadata.get_revision_count();
         let prebuild_id = Target::current().architecture.to_string();
-        match self.repository_manager.get_prebuild_url(&install_meta.repository_id, package_id, revision, &prebuild_id) {
+        match self.repository_manager.get_prebuild_meta(&install_meta.repository_id, package_id, revision, &prebuild_id) {
             Ok(Some(_)) => return Ok(None),
             Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
             Err(e) => error!(e),

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -238,7 +238,8 @@ impl<'a> InstallTreeBuilder<'a> {
 
         // Check if a prebuild for the package is available
         let revision = install_meta.version_metadata.get_revision_count();
-        match self.repository_manager.get_prebuild_url(&install_meta.repository_id, package_id, revision, &Target::current()) {
+        let prebuild_id = Target::current().architecture.to_string();
+        match self.repository_manager.get_prebuild_url(&install_meta.repository_id, package_id, revision, &prebuild_id) {
             Ok(Some(_)) => return Ok(None),
             Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
             Err(e) => error!(e),

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -240,8 +240,8 @@ impl<'a> InstallTreeBuilder<'a> {
         let revision = install_meta.version_metadata.get_revision_count();
         let prebuild_id = Target::current().architecture.to_string();
         match self.repository_manager.get_prebuild_meta(&install_meta.repository_id, package_id, revision, &prebuild_id) {
-            Ok(Some(_)) => return Ok(None),
-            Ok(None) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
+            Ok(_) => return Ok(None),
+            Err(RepositoryError::PrebuildNotFound { .. }) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
             Err(e) => error!(e),
         }
 

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -306,7 +306,10 @@ impl<'a> Installer<'a> {
 
         let prebuild_id = Target::current().architecture.to_string();
         let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &prebuild_id)?;
-        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package, revision, &prebuild_id)?;
+        let prebuild_meta = self
+            .repository_manager
+            .get_prebuild_meta(repository_id, package, revision, &prebuild_id)?
+            .ok_or(InstallerError::PrebuildNotFound)?;
 
         // Finish download spinner
         spinner.finish();
@@ -315,9 +318,9 @@ impl<'a> Installer<'a> {
         let calculated_checksum = Checksum::from_bytes(&bytes);
 
         // Check equality of checksum
-        match prebuild_meta {
-            Some(prebuild_meta) if prebuild_meta.checksum == calculated_checksum => debug!("{} prebuild checksum matches", package.style()),
-            _ => return Err(InstallerError::ChecksumError),
+        match prebuild_meta.checksum == calculated_checksum {
+            true => debug!("{} prebuild checksum matches", package.style()),
+            false => return Err(InstallerError::ChecksumError),
         }
 
         // Unpack the prebuild to the destination

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -304,8 +304,9 @@ impl<'a> Installer<'a> {
         let spinner = Spinner::new(spinner_message);
         spinner.show();
 
-        let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &Target::current())?;
-        let checksum = self.repository_manager.get_prebuild_checksum(repository_id, package, revision, &Target::current())?;
+        let prebuild_id = Target::current().architecture.to_string();
+        let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &prebuild_id)?;
+        let checksum = self.repository_manager.get_prebuild_checksum(repository_id, package, revision, &prebuild_id)?;
 
         // Finish download spinner
         spinner.finish();

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -306,10 +306,7 @@ impl<'a> Installer<'a> {
 
         let prebuild_id = Target::current().architecture.to_string();
         let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &prebuild_id)?;
-        let prebuild_meta = self
-            .repository_manager
-            .get_prebuild_meta(repository_id, package, revision, &prebuild_id)?
-            .ok_or(InstallerError::PrebuildNotFound)?;
+        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package, revision, &prebuild_id)?;
 
         // Finish download spinner
         spinner.finish();

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -306,7 +306,7 @@ impl<'a> Installer<'a> {
 
         let prebuild_id = Target::current().architecture.to_string();
         let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &prebuild_id)?;
-        let checksum = self.repository_manager.get_prebuild_checksum(repository_id, package, revision, &prebuild_id)?;
+        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package, revision, &prebuild_id)?;
 
         // Finish download spinner
         spinner.finish();
@@ -315,8 +315,8 @@ impl<'a> Installer<'a> {
         let calculated_checksum = Checksum::from_bytes(&bytes);
 
         // Check equality of checksum
-        match checksum {
-            Some(checksum) if checksum == calculated_checksum => debug!("{} prebuild checksum matches", package.style()),
+        match prebuild_meta {
+            Some(prebuild_meta) if prebuild_meta.checksum == calculated_checksum => debug!("{} prebuild checksum matches", package.style()),
             _ => return Err(InstallerError::ChecksumError),
         }
 

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -120,12 +120,12 @@ pub fn fix_inconsistent_register(
         let revisions = package_version_meta.get_revision_count();
         let prebuild_id = Target::current().architecture.to_string();
         let used_prebuild = match manager.get_prebuild_meta(&repository_id, package_id, revisions, &prebuild_id) {
-            Ok(Some(prebuild_meta)) => {
+            Ok(prebuild_meta) => {
                 let compressed = packager::compress(install_path)?;
                 let checksum = Checksum::from_bytes(&compressed);
                 prebuild_meta.checksum == checksum
             },
-            Ok(None) => false,
+            Err(RepositoryError::PrebuildNotFound { .. }) => false,
             Err(RepositoryError::RepositoryNotFoundError { .. }) => false,
             Err(e) => Err(e)?,
         };

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -118,7 +118,8 @@ pub fn fix_inconsistent_register(
         let install_path = &package_directory.join(&package_id.name).join(package_id.version.to_string());
         let (repository_id, _, package_version_meta) = manager.read_package_and_version(&package_id.clone().into(), &Target::current())?;
         let revisions = package_version_meta.get_revision_count();
-        let used_prebuild = match manager.get_prebuild_checksum(&repository_id, package_id, revisions, &Target::current()) {
+        let prebuild_id = Target::current().architecture.to_string();
+        let used_prebuild = match manager.get_prebuild_checksum(&repository_id, package_id, revisions, &prebuild_id) {
             Ok(Some(correct_checksum)) => {
                 let compressed = packager::compress(install_path)?;
                 let checksum = Checksum::from_bytes(&compressed);

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -119,11 +119,11 @@ pub fn fix_inconsistent_register(
         let (repository_id, _, package_version_meta) = manager.read_package_and_version(&package_id.clone().into(), &Target::current())?;
         let revisions = package_version_meta.get_revision_count();
         let prebuild_id = Target::current().architecture.to_string();
-        let used_prebuild = match manager.get_prebuild_checksum(&repository_id, package_id, revisions, &prebuild_id) {
-            Ok(Some(correct_checksum)) => {
+        let used_prebuild = match manager.get_prebuild_meta(&repository_id, package_id, revisions, &prebuild_id) {
+            Ok(Some(prebuild_meta)) => {
                 let compressed = packager::compress(install_path)?;
                 let checksum = Checksum::from_bytes(&compressed);
-                correct_checksum == checksum
+                prebuild_meta.checksum == checksum
             },
             Ok(None) => false,
             Err(RepositoryError::RepositoryNotFoundError { .. }) => false,

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -113,7 +113,8 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     };
 
     let revision = package_version.revisions.len() as u64;
-    let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &Target::current()) {
+    let prebuild_id = Target::current().architecture.to_string();
+    let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &prebuild_id) {
         Ok(Some(checksum)) => checksum,
         Ok(None) => {
             warning!(

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -115,14 +115,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     let revision = package_version.revisions.len() as u64;
     let prebuild_id = Target::current().architecture.to_string();
     let prebuild_meta = match provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
-        Ok(Some(prebuild_meta)) => prebuild_meta,
-        Ok(None) => {
-            warning!(
-                "Cannot perform alterations check for package {}, because prebuild metadata cannot be found, skipping check",
-                package_id.style()
-            );
-            return Ok(false);
-        },
+        Ok(prebuild_meta) => prebuild_meta,
         Err(e) => {
             warning!(
                 "Cannot perform alterations check for package {}, because prebuild metadata cannot be read, skipping check",

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -114,21 +114,21 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
 
     let revision = package_version.revisions.len() as u64;
     let prebuild_id = Target::current().architecture.to_string();
-    let correct_checksum = match provider.get_prebuild_checksum(package_id, revision, &prebuild_id) {
-        Ok(Some(checksum)) => checksum,
+    let prebuild_meta = match provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
+        Ok(Some(prebuild_meta)) => prebuild_meta,
         Ok(None) => {
             warning!(
-                "Cannot perform alterations check for package {}, because no checksum of the prebuild can be found, skipping check",
+                "Cannot perform alterations check for package {}, because prebuild metadata cannot be found, skipping check",
                 package_id.style()
             );
             return Ok(false);
         },
         Err(e) => {
             warning!(
-                "Cannot perform alterations check for package {}, because checksum cannot be read, skipping check",
+                "Cannot perform alterations check for package {}, because prebuild metadata cannot be read, skipping check",
                 package_id.style()
             );
-            debug!(err: e, "Failed to read prebuild checksum");
+            debug!(err: e, "Failed to read prebuild metadata");
             return Ok(false);
         },
     };
@@ -137,7 +137,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     let compressed = packager::compress(&install_directory)?;
     let checksum = Checksum::from_bytes(&compressed);
 
-    Ok(checksum != correct_checksum)
+    Ok(checksum != prebuild_meta.checksum)
 }
 
 /// Checks if the given packages in the register also exist in the package storage in the prefix directory.

--- a/src/packager.rs
+++ b/src/packager.rs
@@ -15,7 +15,10 @@ use crate::{
     config::Config,
     installer::types::PackageId,
     platforms::TargetArchitecture,
-    repositories::{error::RepositoryError, types::Checksum},
+    repositories::{
+        error::RepositoryError,
+        types::{Checksum, FileSize, PrebuildFileMeta},
+    },
     utils::ioerror::{self, IOResultExt},
 };
 
@@ -32,6 +35,12 @@ pub enum PackagerError {
 
     #[error("Cannot get revisions from repository manager")]
     RepositoryError(#[from] RepositoryError),
+
+    #[error("Cannot parse package size to u32")]
+    SizeParseError(#[source] std::num::TryFromIntError),
+
+    #[error("Cannot serialize package metadata")]
+    MetadataSerializeError(#[from] toml::ser::Error),
 
     #[error("Failed to finish creating tar file")]
     TarFinishError(#[source] std::io::Error),
@@ -57,22 +66,26 @@ pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revi
     // Compress the package
     let compressed = compress(&install_directory)?;
 
-    // Calculate checksum for the compressed package
+    // Calculate checksum and size for the compressed package
     let checksum = Checksum::from_bytes(&compressed);
+    let size = FileSize(compressed.len().try_into().map_err(PackagerError::SizeParseError)?);
+
+    let metadata = PrebuildFileMeta { checksum, size };
+    let metadata_string = toml::ser::to_string(&metadata)?;
 
     // Create the file names
     let target_architecture = TargetArchitecture::current().to_string();
     let filename = format!("{package_id}-{revisions}-{target_architecture}");
     let compressed_filename = format!("{filename}.tar.gz");
     let prepackage_file = destination.join(compressed_filename);
-    let checksum_filename = format!("{filename}.sha256");
-    let checksum_file_path = destination.join(checksum_filename);
+    let metadata_filename = format!("{filename}.toml");
+    let metadata_file_path = destination.join(metadata_filename);
 
-    // Store the compressed package and checksum
+    // Store the compressed package and metadata
     let mut compressed_file = File::create(&prepackage_file).err_with_path("create", &prepackage_file)?;
-    let mut checksum_file = File::create(&checksum_file_path).err_with_path("create", &checksum_file_path)?;
+    let mut metadata_file = File::create(&metadata_file_path).err_with_path("create", &metadata_file_path)?;
     compressed_file.write_all(&compressed).err_with_path("write", &prepackage_file)?;
-    checksum_file.write_all(checksum.to_string().as_bytes()).err_with_path("write", &checksum_file_path)?;
+    metadata_file.write_all(metadata_string.as_bytes()).err_with_path("write", &metadata_file_path)?;
 
     Ok(())
 }

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -29,8 +29,9 @@ pub enum RepositoryError {
         reason: PackageNotFoundReason,
     },
 
-    #[error("Cannot find prebuild of package {} revision {revision}", package_id.style())]
+    #[error("Cannot find prebuild '{prebuild_id}' of package {} revision {revision}", package_id.style())]
     PrebuildNotFound {
+        prebuild_id: String,
         package_id: PackageId,
         revision: u64,
     },

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -344,7 +344,7 @@ impl<'a> RepositoryManager<'a> {
         package: &PackageId,
         revision: u64,
         prebuild_id: &str,
-    ) -> Result<Option<PrebuildFileMeta>> {
+    ) -> Result<PrebuildFileMeta> {
         self.get_prebuid_provider(repository_id)?.get_prebuild_meta(package, revision, prebuild_id)
     }
 

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -338,8 +338,8 @@ impl<'a> RepositoryManager<'a> {
     /// Retrieves the prebuild url for the given package version.
     /// Returns the url, or `None` if a prebuild is not available for the package.
     /// Returns a `RepositoryNotFoundError` if no repository with the given `repository_id` can be found.
-    pub fn get_prebuild_url(&self, repository_id: &str, package: &PackageId, revision: u64, target: &Target) -> Result<Option<String>> {
-        self.get_prebuid_provider(repository_id)?.get_prebuild_url(package, revision, target)
+    pub fn get_prebuild_url(&self, repository_id: &str, package: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
+        self.get_prebuid_provider(repository_id)?.get_prebuild_url(package, revision, prebuild_id)
     }
 
     /// Retrieves the prebuild checksum for the given package version.
@@ -350,9 +350,9 @@ impl<'a> RepositoryManager<'a> {
         repository_id: &str,
         package: &PackageId,
         revision: u64,
-        target: &Target,
+        prebuild_id: &str,
     ) -> Result<Option<Checksum>> {
-        self.get_prebuid_provider(repository_id)?.get_prebuild_checksum(package, revision, target)
+        self.get_prebuid_provider(repository_id)?.get_prebuild_checksum(package, revision, prebuild_id)
     }
 
     /// Reads the prebuild of the given package version as bytes, returns a tuple containing the archive extension and the bytes.
@@ -362,9 +362,9 @@ impl<'a> RepositoryManager<'a> {
         repository_id: &str,
         package: &PackageId,
         revision: u64,
-        target: &Target,
+        prebuild_id: &str,
     ) -> Result<(ArchiveExtension, Bytes)> {
-        self.get_prebuid_provider(repository_id)?.read_prebuild(package, revision, target)
+        self.get_prebuid_provider(repository_id)?.read_prebuild(package, revision, prebuild_id)
     }
 
     /// Gets the latest supported package version for the given package metadata.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -335,15 +335,8 @@ impl<'a> RepositoryManager<'a> {
         self.get_metadata_provider(repository_id)?.read_file(package, file_path)
     }
 
-    /// Retrieves the prebuild url for the given package version.
-    /// Returns the url, or `None` if a prebuild is not available for the package.
-    /// Returns a `RepositoryNotFoundError` if no repository with the given `repository_id` can be found.
-    pub fn get_prebuild_url(&self, repository_id: &str, package: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
-        self.get_prebuid_provider(repository_id)?.get_prebuild_url(package, revision, prebuild_id)
-    }
-
-    /// Retrieves the prebuild checksum for the given package version.
-    /// Returns the checksum, or `None` if a prebuild is not available for the package.
+    /// Retrieves the prebuild metadata for the given package version.
+    /// Returns the metadata, or `None` if a prebuild is not available for the package.
     /// Returns a `RepositoryNotFoundError` if no repository with the given `repository_id` can be found.
     pub fn get_prebuild_meta(
         &self,

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -17,7 +17,7 @@ use crate::{
     repositories::{
         error::{PackageNotFoundReason, RepositoryError, Result},
         provider::{self, MetadataProvider, PrebuildProvider},
-        types::{Checksum, Date, IndexMeta, PackageMeta, PackageVersionMeta, RepositoryMeta},
+        types::{Date, IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, RepositoryMeta},
     },
     utils::packit_version::current_packit_version,
 };
@@ -345,14 +345,14 @@ impl<'a> RepositoryManager<'a> {
     /// Retrieves the prebuild checksum for the given package version.
     /// Returns the checksum, or `None` if a prebuild is not available for the package.
     /// Returns a `RepositoryNotFoundError` if no repository with the given `repository_id` can be found.
-    pub fn get_prebuild_checksum(
+    pub fn get_prebuild_meta(
         &self,
         repository_id: &str,
         package: &PackageId,
         revision: u64,
         prebuild_id: &str,
-    ) -> Result<Option<Checksum>> {
-        self.get_prebuid_provider(repository_id)?.get_prebuild_checksum(package, revision, prebuild_id)
+    ) -> Result<Option<PrebuildFileMeta>> {
+        self.get_prebuid_provider(repository_id)?.get_prebuild_meta(package, revision, prebuild_id)
     }
 
     /// Reads the prebuild of the given package version as bytes, returns a tuple containing the archive extension and the bytes.

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -296,8 +296,8 @@ impl<'a> PortableRepoCreator<'a> {
         // Get checksum
         let revision = package_version.get_revision_count();
         let prebuild_id = self.target.architecture.to_string();
-        let checksum = match self.repository_manager.get_prebuild_checksum(repository_id, package_id, revision, &prebuild_id) {
-            Ok(Some(checksum)) => checksum,
+        let prebuild_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, &prebuild_id) {
+            Ok(Some(prebuild_meta)) => prebuild_meta,
             // Only try to package locally if the current target is the target we generate a portable repo for
             Ok(None) if self.target == Target::current() => {
                 packager::package(self.config, package_id, &destination, revision)?;
@@ -316,10 +316,10 @@ impl<'a> PortableRepoCreator<'a> {
         // Write to file
         let prebuild_name = format!("{package_id}-{revision}-{target}.tar.gz");
         let prebuild_path = destination.join(prebuild_name);
-        let checksum_name = format!("{package_id}-{revision}-{target}.sha256");
-        let checksum_path = destination.join(checksum_name);
+        let prebuild_meta_name = format!("{package_id}-{revision}-{target}.toml");
+        let prebuild_meta_path = destination.join(prebuild_meta_name);
         fs::write(&prebuild_path, &prebuild).err_with_path("write", prebuild_path)?;
-        fs::write(&checksum_path, checksum.to_string().as_bytes()).err_with_path("write", checksum_path)?;
+        self.write_metadata(prebuild_meta, prebuild_meta_path, false)?;
 
         Ok(())
     }

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -119,7 +119,7 @@ impl<'a> PortableRepoCreator<'a> {
                     &repository_id,
                     &package_id,
                     package_version.get_revision_count(),
-                    &self.target,
+                    &self.target.architecture.to_string(),
                 )?;
 
                 // Check if prebuild is downloadable, or if package is installed
@@ -295,7 +295,8 @@ impl<'a> PortableRepoCreator<'a> {
 
         // Get checksum
         let revision = package_version.get_revision_count();
-        let checksum = match self.repository_manager.get_prebuild_checksum(repository_id, package_id, revision, &self.target) {
+        let prebuild_id = self.target.architecture.to_string();
+        let checksum = match self.repository_manager.get_prebuild_checksum(repository_id, package_id, revision, &prebuild_id) {
             Ok(Some(checksum)) => checksum,
             // Only try to package locally if the current target is the target we generate a portable repo for
             Ok(None) if self.target == Target::current() => {
@@ -310,7 +311,7 @@ impl<'a> PortableRepoCreator<'a> {
             Err(e) => return Err(e.into()),
         };
 
-        let (_, prebuild) = self.repository_manager.read_prebuild(repository_id, package_id, revision, &self.target)?;
+        let (_, prebuild) = self.repository_manager.read_prebuild(repository_id, package_id, revision, &prebuild_id)?;
 
         // Write to file
         let prebuild_name = format!("{package_id}-{revision}-{target}.tar.gz");

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -120,11 +120,15 @@ impl<'a> PortableRepoCreator<'a> {
                     &package_id,
                     package_version.get_revision_count(),
                     &self.target.architecture.to_string(),
-                )?;
+                );
+                let found_prebuild = match prebuild_meta {
+                    Ok(_) => true,
+                    Err(RepositoryError::PrebuildNotFound { .. }) => false,
+                    Err(e) => return Err(e.into()),
+                };
 
                 // Check if prebuild is downloadable, or if package is installed
-                if prebuild_meta.is_none() && (self.target != Target::current() || self.register.get_package_version(&package_id).is_none())
-                {
+                if !found_prebuild && (self.target != Target::current() || self.register.get_package_version(&package_id).is_none()) {
                     return Err(PortableRepoError::PrebuildNotFound { package_id });
                 }
             }
@@ -297,16 +301,11 @@ impl<'a> PortableRepoCreator<'a> {
         let revision = package_version.get_revision_count();
         let prebuild_id = self.target.architecture.to_string();
         let prebuild_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, &prebuild_id) {
-            Ok(Some(prebuild_meta)) => prebuild_meta,
+            Ok(prebuild_meta) => prebuild_meta,
             // Only try to package locally if the current target is the target we generate a portable repo for
-            Ok(None) if self.target == Target::current() => {
+            Err(RepositoryError::PrebuildNotFound { .. }) if self.target == Target::current() => {
                 packager::package(self.config, package_id, &destination, revision)?;
                 return Ok(());
-            },
-            Ok(None) => {
-                return Err(PortableRepoError::PrebuildNotFound {
-                    package_id: package_id.clone(),
-                });
             },
             Err(e) => return Err(e.into()),
         };

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -115,7 +115,7 @@ impl<'a> PortableRepoCreator<'a> {
 
             if !self.exclude_prebuilds {
                 // Check if the package has a prebuild
-                let prebuild_url = self.repository_manager.get_prebuild_url(
+                let prebuild_meta = self.repository_manager.get_prebuild_meta(
                     &repository_id,
                     &package_id,
                     package_version.get_revision_count(),
@@ -123,7 +123,7 @@ impl<'a> PortableRepoCreator<'a> {
                 )?;
 
                 // Check if prebuild is downloadable, or if package is installed
-                if prebuild_url.is_none() && (self.target != Target::current() || self.register.get_package_version(&package_id).is_none())
+                if prebuild_meta.is_none() && (self.target != Target::current() || self.register.get_package_version(&package_id).is_none())
                 {
                     return Err(PortableRepoError::PrebuildNotFound { package_id });
                 }

--- a/src/repositories/prebuilds/filesystem.rs
+++ b/src/repositories/prebuilds/filesystem.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fs, path::PathBuf, str::FromStr};
+use std::{fs, path::PathBuf};
 
 use bytes::Bytes;
 
@@ -8,7 +8,7 @@ use crate::{
     repositories::{
         error::{RepositoryError, Result},
         provider::PrebuildProvider,
-        types::Checksum,
+        types::PrebuildFileMeta,
     },
     utils::ioerror::IOResultExt,
 };
@@ -28,15 +28,15 @@ impl PrebuildProvider for FileSystemPrebuildProvider {
         }
     }
 
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>> {
-        let path = match self.get_file_path(package_id, revision, prebuild_id, "sha256")? {
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
+        let path = match self.get_file_path(package_id, revision, prebuild_id, "toml")? {
             Some(path) => path,
             None => return Ok(None),
         };
 
-        let checksum_string = fs::read_to_string(&path).err_with_path("read", path)?;
+        let metadata_string = fs::read_to_string(&path).err_with_path("read", path)?;
 
-        Ok(Some(Checksum::from_str(&checksum_string)?))
+        Ok(Some(toml::de::from_str(&metadata_string)?))
     }
 
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {

--- a/src/repositories/prebuilds/filesystem.rs
+++ b/src/repositories/prebuilds/filesystem.rs
@@ -5,7 +5,6 @@ use bytes::Bytes;
 
 use crate::{
     installer::{types::PackageId, unpack::ArchiveExtension},
-    platforms::Target,
     repositories::{
         error::{RepositoryError, Result},
         provider::PrebuildProvider,
@@ -22,15 +21,15 @@ pub struct FileSystemPrebuildProvider {
 }
 
 impl PrebuildProvider for FileSystemPrebuildProvider {
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<String>> {
-        match self.get_file_path(package_id, revision, target, "tar.gz")? {
+    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
+        match self.get_file_path(package_id, revision, prebuild_id, "tar.gz")? {
             Some(path) => Ok(path.as_os_str().to_str().map(|x| x.into())),
             None => Ok(None),
         }
     }
 
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<Checksum>> {
-        let path = match self.get_file_path(package_id, revision, target, "sha256")? {
+    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>> {
+        let path = match self.get_file_path(package_id, revision, prebuild_id, "sha256")? {
             Some(path) => path,
             None => return Ok(None),
         };
@@ -40,8 +39,8 @@ impl PrebuildProvider for FileSystemPrebuildProvider {
         Ok(Some(Checksum::from_str(&checksum_string)?))
     }
 
-    fn read_prebuild(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<(ArchiveExtension, Bytes)> {
-        let url = self.get_prebuild_url(package_id, revision, target)?.ok_or(RepositoryError::PrebuildNotFound {
+    fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {
+        let url = self.get_prebuild_url(package_id, revision, prebuild_id)?.ok_or(RepositoryError::PrebuildNotFound {
             package_id: package_id.clone(),
             revision,
         })?;
@@ -60,10 +59,9 @@ impl FileSystemPrebuildProvider {
         Some(Self { path: PathBuf::from(url) })
     }
 
-    fn get_file_path(&self, package_id: &PackageId, revision: u64, target: &Target, extension: &str) -> Result<Option<PathBuf>> {
+    fn get_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<Option<PathBuf>> {
         let prefix = package_id.name.get_prefix().to_string();
-        let target = target.architecture.to_string();
-        let prebuild_name = format!("{package_id}-{revision}-{target}.{extension}");
+        let prebuild_name = format!("{package_id}-{revision}-{prebuild_id}.{extension}");
         let path = self.path.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string()).join(prebuild_name);
 
         if !fs::exists(&path).err_with_path("check existance of", &path)? {

--- a/src/repositories/prebuilds/filesystem.rs
+++ b/src/repositories/prebuilds/filesystem.rs
@@ -21,22 +21,16 @@ pub struct FileSystemPrebuildProvider {
 }
 
 impl PrebuildProvider for FileSystemPrebuildProvider {
-    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
-        let path = match self.get_file_path(package_id, revision, prebuild_id, "toml")? {
-            Some(path) => path,
-            None => return Ok(None),
-        };
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<PrebuildFileMeta> {
+        let path = self.get_file_path(package_id, revision, prebuild_id, "toml")?;
 
         let metadata_string = fs::read_to_string(&path).err_with_path("read", path)?;
 
-        Ok(Some(toml::de::from_str(&metadata_string)?))
+        Ok(toml::de::from_str(&metadata_string)?)
     }
 
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {
-        let url = self.get_file_path(package_id, revision, prebuild_id, "tar.gz")?.ok_or(RepositoryError::PrebuildNotFound {
-            package_id: package_id.clone(),
-            revision,
-        })?;
+        let url = self.get_file_path(package_id, revision, prebuild_id, "tar.gz")?;
 
         // TODO: improve efficiency of file reading
         let bytes = fs::read(&url).err_with_path("read", &url)?;
@@ -52,15 +46,20 @@ impl FileSystemPrebuildProvider {
         Some(Self { path: PathBuf::from(url) })
     }
 
-    fn get_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<Option<PathBuf>> {
+    fn get_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<PathBuf> {
         let prefix = package_id.name.get_prefix().to_string();
         let prebuild_name = format!("{package_id}-{revision}-{prebuild_id}.{extension}");
         let path = self.path.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string()).join(prebuild_name);
 
+        // Check if prebuild path exists
         if !fs::exists(&path).err_with_path("check existance of", &path)? {
-            return Ok(None);
+            return Err(RepositoryError::PrebuildNotFound {
+                prebuild_id: prebuild_id.into(),
+                package_id: package_id.clone(),
+                revision,
+            });
         }
 
-        Ok(Some(path))
+        Ok(path)
     }
 }

--- a/src/repositories/prebuilds/filesystem.rs
+++ b/src/repositories/prebuilds/filesystem.rs
@@ -21,13 +21,6 @@ pub struct FileSystemPrebuildProvider {
 }
 
 impl PrebuildProvider for FileSystemPrebuildProvider {
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
-        match self.get_file_path(package_id, revision, prebuild_id, "tar.gz")? {
-            Some(path) => Ok(path.as_os_str().to_str().map(|x| x.into())),
-            None => Ok(None),
-        }
-    }
-
     fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
         let path = match self.get_file_path(package_id, revision, prebuild_id, "toml")? {
             Some(path) => path,
@@ -40,7 +33,7 @@ impl PrebuildProvider for FileSystemPrebuildProvider {
     }
 
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {
-        let url = self.get_prebuild_url(package_id, revision, prebuild_id)?.ok_or(RepositoryError::PrebuildNotFound {
+        let url = self.get_file_path(package_id, revision, prebuild_id, "tar.gz")?.ok_or(RepositoryError::PrebuildNotFound {
             package_id: package_id.clone(),
             revision,
         })?;
@@ -48,7 +41,7 @@ impl PrebuildProvider for FileSystemPrebuildProvider {
         // TODO: improve efficiency of file reading
         let bytes = fs::read(&url).err_with_path("read", &url)?;
 
-        Ok((ArchiveExtension::from_path(&url), Bytes::from(bytes)))
+        Ok((ArchiveExtension::from_path(&url.display().to_string()), Bytes::from(bytes)))
     }
 }
 

--- a/src/repositories/prebuilds/web.rs
+++ b/src/repositories/prebuilds/web.rs
@@ -23,27 +23,16 @@ pub struct WebPrebuildProvider {
 }
 
 impl PrebuildProvider for WebPrebuildProvider {
-    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
-        let response = match self.read_file_path(package_id, revision, prebuild_id, "toml")? {
-            Some((_, response)) => response,
-            None => return Ok(None),
-        };
-
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<PrebuildFileMeta> {
+        let (_, response) = self.read_file_path(package_id, revision, prebuild_id, "toml")?;
         let metadata_string = response.text()?;
 
-        Ok(Some(toml::de::from_str(&metadata_string)?))
+        Ok(toml::de::from_str(&metadata_string)?)
     }
 
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {
-        let (url, bytes) = match self.read_file_path(package_id, revision, prebuild_id, "tar.gz")? {
-            Some((url, response)) => (url, response.bytes()?),
-            None => {
-                return Err(RepositoryError::PrebuildNotFound {
-                    package_id: package_id.clone(),
-                    revision,
-                });
-            },
-        };
+        let (url, response) = self.read_file_path(package_id, revision, prebuild_id, "tar.gz")?;
+        let bytes = response.bytes()?;
 
         Ok((ArchiveExtension::from_path(url.as_ref()), bytes))
     }
@@ -62,7 +51,7 @@ impl WebPrebuildProvider {
     /// Reads a file from the repository and return the url and response.
     /// Returns `None` if the file cannot be found in the repository.
     /// Returns a `UrlParseError` if the created url cannot be parsed.
-    fn read_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<Option<(Url, Response)>> {
+    fn read_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<(Url, Response)> {
         let prefix = package_id.name.get_prefix().to_string();
         let package_name = &package_id.name;
         let package_version = &package_id.version.to_string();
@@ -75,7 +64,11 @@ impl WebPrebuildProvider {
 
         // Check if the url exists
         if response.status() == StatusCode::NOT_FOUND {
-            return Ok(None);
+            return Err(RepositoryError::PrebuildNotFound {
+                prebuild_id: prebuild_id.into(),
+                package_id: package_id.clone(),
+                revision,
+            });
         }
 
         // Return an error if something went wrong with the request (apart from not found error)
@@ -83,6 +76,6 @@ impl WebPrebuildProvider {
             return Err(RepositoryError::UnsuccessfulRequest(response.status()));
         }
 
-        Ok(Some((url, response)))
+        Ok((url, response))
     }
 }

--- a/src/repositories/prebuilds/web.rs
+++ b/src/repositories/prebuilds/web.rs
@@ -10,7 +10,7 @@ use crate::{
     repositories::{
         error::{RepositoryError, Result},
         provider::PrebuildProvider,
-        types::Checksum,
+        types::PrebuildFileMeta,
     },
     utils::requests,
 };
@@ -30,15 +30,15 @@ impl PrebuildProvider for WebPrebuildProvider {
         }
     }
 
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>> {
-        let response = match self.read_file_path(package_id, revision, prebuild_id, "sha256")? {
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
+        let response = match self.read_file_path(package_id, revision, prebuild_id, "toml")? {
             Some((_, response)) => response,
             None => return Ok(None),
         };
 
-        let checksum_string = response.text()?;
+        let metadata_string = response.text()?;
 
-        Ok(Some(Checksum::from_str(&checksum_string)?))
+        Ok(Some(toml::de::from_str(&metadata_string)?))
     }
 
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {

--- a/src/repositories/prebuilds/web.rs
+++ b/src/repositories/prebuilds/web.rs
@@ -23,13 +23,6 @@ pub struct WebPrebuildProvider {
 }
 
 impl PrebuildProvider for WebPrebuildProvider {
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
-        match self.read_file_path(package_id, revision, prebuild_id, "tar.gz")? {
-            Some((url, _)) => Ok(Some(url.to_string())),
-            None => Ok(None),
-        }
-    }
-
     fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>> {
         let response = match self.read_file_path(package_id, revision, prebuild_id, "toml")? {
             Some((_, response)) => response,

--- a/src/repositories/prebuilds/web.rs
+++ b/src/repositories/prebuilds/web.rs
@@ -7,7 +7,6 @@ use url::Url;
 
 use crate::{
     installer::{types::PackageId, unpack::ArchiveExtension},
-    platforms::Target,
     repositories::{
         error::{RepositoryError, Result},
         provider::PrebuildProvider,
@@ -24,15 +23,15 @@ pub struct WebPrebuildProvider {
 }
 
 impl PrebuildProvider for WebPrebuildProvider {
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<String>> {
-        match self.read_file_path(package_id, revision, target, "tar.gz")? {
+    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>> {
+        match self.read_file_path(package_id, revision, prebuild_id, "tar.gz")? {
             Some((url, _)) => Ok(Some(url.to_string())),
             None => Ok(None),
         }
     }
 
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<Checksum>> {
-        let response = match self.read_file_path(package_id, revision, target, "sha256")? {
+    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>> {
+        let response = match self.read_file_path(package_id, revision, prebuild_id, "sha256")? {
             Some((_, response)) => response,
             None => return Ok(None),
         };
@@ -42,8 +41,8 @@ impl PrebuildProvider for WebPrebuildProvider {
         Ok(Some(Checksum::from_str(&checksum_string)?))
     }
 
-    fn read_prebuild(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<(ArchiveExtension, Bytes)> {
-        let (url, bytes) = match self.read_file_path(package_id, revision, target, "tar.gz")? {
+    fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)> {
+        let (url, bytes) = match self.read_file_path(package_id, revision, prebuild_id, "tar.gz")? {
             Some((url, response)) => (url, response.bytes()?),
             None => {
                 return Err(RepositoryError::PrebuildNotFound {
@@ -70,12 +69,11 @@ impl WebPrebuildProvider {
     /// Reads a file from the repository and return the url and response.
     /// Returns `None` if the file cannot be found in the repository.
     /// Returns a `UrlParseError` if the created url cannot be parsed.
-    fn read_file_path(&self, package_id: &PackageId, revision: u64, target: &Target, extension: &str) -> Result<Option<(Url, Response)>> {
+    fn read_file_path(&self, package_id: &PackageId, revision: u64, prebuild_id: &str, extension: &str) -> Result<Option<(Url, Response)>> {
         let prefix = package_id.name.get_prefix().to_string();
-        let target = target.architecture.to_string();
         let package_name = &package_id.name;
         let package_version = &package_id.version.to_string();
-        let file_name = format!("{package_id}-{revision}-{target}.{extension}");
+        let file_name = format!("{package_id}-{revision}-{prebuild_id}.{extension}");
 
         let path = format!("packages/{prefix}/{package_name}/{package_version}/{file_name}");
         let url = self.url.join(&path)?;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -7,7 +7,6 @@ use crate::{
         types::{PackageId, PackageName, Version},
         unpack::ArchiveExtension,
     },
-    platforms::Target,
     repositories::{
         error::Result,
         metadata::{FILESYSTEM_METADATA_PROVIDER_ID, FileSystemMetadataProvider, WEB_METADATA_PROVIDER_ID, WebMetadataProvider},
@@ -43,13 +42,13 @@ pub trait MetadataProvider {
 /// Generic prebuild repository provider trait, reading prebuild packages from a repository.
 pub trait PrebuildProvider {
     /// Gets the url of a prebuild package, returns `None` if the prebuild package does not exist.
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<String>>;
+    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>>;
 
     /// Gets the checksum of a prebuild package, returns `None` if the prebuild package does not exist.
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<Option<Checksum>>;
+    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>>;
 
     /// Reads the prebuild package as bytes, returns a tuple containing the origin url and the bytes.
-    fn read_prebuild(&self, package_id: &PackageId, revision: u64, target: &Target) -> Result<(ArchiveExtension, Bytes)>;
+    fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)>;
 }
 
 /// Creates a metadata repository provider for the given repository.

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -14,7 +14,7 @@ use crate::{
             DEFAULT_PREBUILD_PROVIDER_ID, FILESYSTEM_PREBUILD_PROVIDER_ID, FileSystemPrebuildProvider, WEB_PREBUILD_PROVIDER_ID,
             WebPrebuildProvider,
         },
-        types::{Checksum, IndexMeta, PackageMeta, PackageVersionMeta, RepositoryMeta},
+        types::{IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, RepositoryMeta},
     },
 };
 
@@ -44,8 +44,8 @@ pub trait PrebuildProvider {
     /// Gets the url of a prebuild package, returns `None` if the prebuild package does not exist.
     fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>>;
 
-    /// Gets the checksum of a prebuild package, returns `None` if the prebuild package does not exist.
-    fn get_prebuild_checksum(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<Checksum>>;
+    /// Gets the metadata of a prebuild package, returns `None` if the prebuild package does not exist.
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>>;
 
     /// Reads the prebuild package as bytes, returns a tuple containing the origin url and the bytes.
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)>;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -42,7 +42,7 @@ pub trait MetadataProvider {
 /// Generic prebuild repository provider trait, reading prebuild packages from a repository.
 pub trait PrebuildProvider {
     /// Gets the metadata of a prebuild package, returns `None` if the prebuild package does not exist.
-    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>>;
+    fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<PrebuildFileMeta>;
 
     /// Reads the prebuild package as bytes, returns a tuple containing the origin url and the bytes.
     fn read_prebuild(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<(ArchiveExtension, Bytes)>;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -41,9 +41,6 @@ pub trait MetadataProvider {
 
 /// Generic prebuild repository provider trait, reading prebuild packages from a repository.
 pub trait PrebuildProvider {
-    /// Gets the url of a prebuild package, returns `None` if the prebuild package does not exist.
-    fn get_prebuild_url(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<String>>;
-
     /// Gets the metadata of a prebuild package, returns `None` if the prebuild package does not exist.
     fn get_prebuild_meta(&self, package_id: &PackageId, revision: u64, prebuild_id: &str) -> Result<Option<PrebuildFileMeta>>;
 

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -6,6 +6,7 @@ mod license;
 mod package;
 mod package_target;
 mod package_version;
+mod prebuilds;
 mod repository;
 mod target_bounds;
 
@@ -16,12 +17,13 @@ pub use self::package::PackageMeta;
 pub use self::package_target::PackageTarget;
 pub use self::package_version::PackageVersionMeta;
 
+pub use self::prebuilds::PrebuildFileMeta;
+
 pub use self::checksum::Checksum;
 pub use self::common::Script;
 
 pub use self::common::Date;
 pub use self::common::DeprecationInfo;
-#[cfg(test)]
 pub use self::common::FileSize;
 pub use self::common::Patch;
 pub use self::common::Source;

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+use crate::repositories::types::{Checksum, FileSize};
+
+/// Represents the metadata file that comes with a prebuild.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrebuildFileMeta {
+    pub checksum: Checksum,
+    pub size: FileSize,
+}


### PR DESCRIPTION
This PR refactors the prebuild repositories implementation and adds functionality for future use.
- Prebuilds now have a `prebuild_id` instead of the target architecture, this ensures future compatibility with other target specifications.
- Prebuilds now use a toml metadata file instead of the checksum file, which also contains the size of the prebuild.