### PR TITLE
Fix option styling

### DIFF
--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -168,10 +168,7 @@ impl SearchArgs {
         let dependencies = package_version.dependencies.iter().chain(target.dependencies.iter());
         let build_dependencies = package_version.build_dependencies.iter().chain(target.build_dependencies.iter());
 
-        let required_packit_version = match max(&package.required_packit_version, &package_version.required_packit_version) {
-            Some(version) => version.style(),
-            None => "None".dimmed(),
-        };
+        let required_packit_version = max(&package.required_packit_version, &package_version.required_packit_version);
 
         // Show package version information
         println!("{}", package_id.style());
@@ -179,7 +176,7 @@ impl SearchArgs {
         let mut pair_aligner = PairAligner::new();
         pair_aligner.add("Homepage", package.homepage.display());
         pair_aligner.add("License", &package_version.license);
-        pair_aligner.add("Required Packit version", required_packit_version);
+        pair_aligner.add("Required Packit version", required_packit_version.display_or(|v| v.style()));
         pair_aligner.add("Skip symlinking", if package_version.skip_symlinking { "on" } else { "off" });
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -124,7 +124,7 @@ impl SearchArgs {
         pair_aligner.add("Homepage", package.homepage.display());
         pair_aligner.add("Latest version", latest_version.version.style());
         pair_aligner.add("Available versions", package.versions.iter().map_styled().display(" | "));
-        pair_aligner.add("Required Packit version", package.required_packit_version.display().bold().blue());
+        pair_aligner.add("Required Packit version", package.required_packit_version.display_or(|v| v.style()));
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
 

--- a/src/cli/display/standard_print.rs
+++ b/src/cli/display/standard_print.rs
@@ -1,19 +1,31 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use colored::Colorize;
+use colored::{ColoredString, Colorize};
 use std::fmt::Display;
 
-pub trait DisplayOption {
+pub trait DisplayOption<T: Display> {
     /// Returns the correct string display for an `Option<impl Display>`, dimmed when `None`.
     fn display(&self) -> String;
+
+    /// Returns the correct string display for an `Option<impl Display>`, dimmed when `None` and styled with the given closure if `Some`.
+    fn display_or<F>(&self, some_style: F) -> String
+    where
+        F: FnOnce(&T) -> ColoredString;
 }
 
-impl<T> DisplayOption for Option<T>
-where
-    T: Display,
-{
+impl<T: Display> DisplayOption<T> for Option<T> {
     fn display(&self) -> String {
         match self {
-            Some(option) => option.to_string(),
+            Some(value) => value.to_string(),
+            None => "None".dimmed().to_string(),
+        }
+    }
+
+    fn display_or<F>(&self, some_style: F) -> String
+    where
+        F: FnOnce(&T) -> ColoredString,
+    {
+        match self {
+            Some(value) => some_style(value).to_string(),
             None => "None".dimmed().to_string(),
         }
     }


### PR DESCRIPTION
This PR fixes the styling of options. In some cases when an option was `None` it would be dimmed, bold and blue, because `some_option.display().bold().blue()` was used. The new `display_or` fixes this problem, by accepting a styling closure which is applied in case of `Some`.