### PR TITLE
Fix version variable in install.bat

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -190,7 +190,7 @@ if not ERRORLEVEL 1 (
     if ERRORLEVEL 1 goto cleanup
 
     echo Building Packit from source
-    cargo build-install --destination ..\$VERSION
+    cargo build-install --destination ..\%VERSION%
     if ERRORLEVEL 1 goto cleanup
     cd ..
     if ERRORLEVEL 1 goto cleanup


### PR DESCRIPTION
In `build.bat` to use the version variable a line uses `$VERSION` instead of `%VERSION%` causing packit to be installed to an incorrect location and the installation to fail.