### PR TITLE
Fix error messages to represent errors correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Change display of true and false values in the `info` and `search` commands.
 - Prebuilds now have a toml metadata file instead of the checksum file, containing the checksum and size of the prebuild.
 
+### Fixed
+- Fix error messages not representing the error correctly.
+
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11
 

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -39,13 +39,13 @@ pub enum BuilderError {
     #[error("Cannot unpack response")]
     UnpackError(#[from] UnpackError),
 
-    #[error("Cannot execute build script")]
+    #[error("Error while executing build script")]
     ScriptError(#[from] ScriptError),
 
-    #[error("Cannot find a repository for building")]
+    #[error("Cannot get package data from repository")]
     RepositoryError(#[from] RepositoryError),
 
-    #[error("Cannot patch binaries")]
+    #[error("Cannot patch binary")]
     PatchBinaryError(#[from] BinaryPatcherError),
 
     #[error("Cannot apply patch file")]
@@ -54,7 +54,7 @@ pub enum BuilderError {
     #[error("Error while detecting tool on the system")]
     ToolDetectionError(#[from] ToolDetectionError),
 
-    #[error("Cannot request files for building")]
+    #[error("Error while requesting files for building")]
     RequestError(#[from] reqwest::Error),
 
     #[error("Error while interacting with filesystem")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -89,8 +89,8 @@ impl Repository {
 /// The errors that occur when reading the config file.
 #[derive(Error, Debug)]
 pub enum ConfigError {
-    #[error("Cannot read config file contents")]
-    ReadError(#[from] ioerror::IOError),
+    #[error("Error while interacting with filesystem")]
+    IOError(#[from] ioerror::IOError),
 
     #[error("Cannot parse config file")]
     ParseError(#[from] toml::de::Error),

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -62,19 +62,19 @@ pub enum InstallerError {
     },
 
     // Wrapped custom errors
-    #[error("Cannot find a repository for installation")]
+    #[error("Cannot fetch package metadata from repository")]
     RepositoryError(#[from] RepositoryError),
 
-    #[error("Cannot info package information")]
+    #[error("Cannot get information from register")]
     RegisterError(#[from] RegisterError),
 
-    #[error("Cannot display installer error")]
+    #[error("Error while displaying message on console")]
     DisplayError(#[from] DisplayError),
 
-    #[error("Cannot execute script")]
+    #[error("Error while executing script")]
     ScriptError(#[from] ScriptError),
 
-    #[error("Cannot execute symlink operation")]
+    #[error("Error while executing symlink operation")]
     SymlinkError(#[from] SymlinkError),
 
     #[error("Cannot build package")]
@@ -89,7 +89,7 @@ pub enum InstallerError {
     #[error("Cannot do tree operation")]
     TreeError(#[from] TreeError),
 
-    #[error("Cannot set or get permissions")]
+    #[error("Error while setting or getting permissions")]
     PermissionError(#[from] PermissionError),
 
     #[error("Error while interacting with filesystem")]

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -63,7 +63,7 @@ pub enum ScriptError {
     #[error("Error while detecting tool on the system")]
     ToolDetectionError(#[from] ToolDetectionError),
 
-    #[error("IOError during a script operation")]
+    #[error("IO error during a script operation")]
     IOError(#[from] ioerror::IOError),
 }
 

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -8,12 +8,12 @@ use std::{
 };
 
 use bytes::Bytes;
+use colored::Colorize;
 use tempfile::{NamedTempFile, TempDir};
 use thiserror::Error;
 
 use crate::{
     builder::{BuildEnv, BuildEnvError},
-    cli::display::logging::warning,
     config::Config,
     installer::types::{PackageId, PackageName},
     platforms::{Os, TargetArchitecture, tool_detection::error::ToolDetectionError},
@@ -39,8 +39,11 @@ pub enum ScriptError {
     #[error("Cannot find script '{0}'")]
     ScriptNotFound(String),
 
-    #[error("Script executed with status code {0}")]
-    ScriptFailed(i32),
+    #[error("{}", display_script_failed(*exit_code, last_lines))]
+    ScriptFailed {
+        exit_code: Option<i32>,
+        last_lines: Vec<String>,
+    },
 
     #[error("Cannot run script")]
     RunError(#[source] std::io::Error),
@@ -68,6 +71,30 @@ pub enum ScriptError {
 }
 
 pub type Result<T> = core::result::Result<T, ScriptError>;
+
+/// Helper function to display the `ScriptError::ScriptFailed` error message and script lines.
+fn display_script_failed(exit_code: Option<i32>, lines: &[String]) -> String {
+    // Output script execution message
+    let mut output = String::from("Script executed ");
+    match exit_code {
+        Some(exit_code) => output.push_str(&format!("with status code {exit_code}")),
+        None => output.push_str("without a status code"),
+    }
+
+    // Output last script lines if available
+    if !lines.is_empty() {
+        output.push_str("\n\n");
+        output.push_str("Last lines of script output:");
+        output.push('\n');
+
+        for line in lines {
+            output.push_str(&format!("{}", line.black())); // The format here is a workaround for getting styling to work
+            output.push('\n');
+        }
+    }
+
+    output
+}
 
 /// Describes the number of lines that should be captured from a script that has `show_output` disabled.
 const MAX_CAPTURED_OUTPUT_LINES: usize = 10;
@@ -222,28 +249,18 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         }
     }
 
-    // Display status to user
+    // Wait for exit and return error if script fails
     let status = process.wait().map_err(ScriptError::RunError)?;
     match status.code() {
         Some(0) => Ok(()),
-        Some(code) => {
-            warning!("Script executed with status code {code}");
-            if !last_lines.is_empty() {
-                eprintln!("Last lines of script output:");
-                last_lines.iter().for_each(|x| eprintln!("{x}"));
-            }
-
-            Err(ScriptError::ScriptFailed(code))
-        },
-        None => {
-            warning!("Script executed without a status code");
-            if !last_lines.is_empty() {
-                eprintln!("Last lines of script output:");
-                last_lines.iter().for_each(|x| eprintln!("{x}"));
-            }
-
-            Err(ScriptError::ScriptFailed(-1))
-        },
+        Some(code) => Err(ScriptError::ScriptFailed {
+            exit_code: Some(code),
+            last_lines: last_lines.into(),
+        }),
+        None => Err(ScriptError::ScriptFailed {
+            exit_code: None,
+            last_lines: last_lines.into(),
+        }),
     }
 }
 

--- a/src/installer/types/version.rs
+++ b/src/installer/types/version.rs
@@ -15,7 +15,7 @@ use crate::installer::types::version_number::VersionNumber;
 /// Errors that occur when parsing version related structs.
 #[derive(Error, Debug)]
 pub enum VersionError {
-    #[error("Version is none")]
+    #[error("Version is empty")]
     NoneError,
 
     #[error("Version number contains a character which is not a digit or a dot")]
@@ -27,7 +27,7 @@ pub enum VersionError {
     #[error("Multiple leading, trailing or consecutive dots are not allowed in version number")]
     DotsError,
 
-    #[error("Couldn't parse version number")]
+    #[error("Cannot parse version number")]
     ParseError(#[from] ParseIntError),
 }
 

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -646,7 +646,7 @@ fn check_package_test(package_id: &PackageId, register: &PackageRegister, config
             );
             Ok(false)
         },
-        Err(ScriptError::ScriptFailed(..)) => Ok(true),
+        Err(ScriptError::ScriptFailed { .. }) => Ok(true),
         Err(e) => Err(e.into()),
     }
 }

--- a/src/packager.rs
+++ b/src/packager.rs
@@ -15,10 +15,7 @@ use crate::{
     config::Config,
     installer::types::PackageId,
     platforms::TargetArchitecture,
-    repositories::{
-        error::RepositoryError,
-        types::{Checksum, FileSize, PrebuildFileMeta},
-    },
+    repositories::types::{Checksum, FileSize, PrebuildFileMeta},
     utils::ioerror::{self, IOResultExt},
 };
 
@@ -32,9 +29,6 @@ pub enum PackagerError {
 
     #[error("Cannot parse filename, because it contains invalid unicode")]
     InvalidUnicodeError,
-
-    #[error("Cannot get revisions from repository manager")]
-    RepositoryError(#[from] RepositoryError),
 
     #[error("Cannot parse package size to u32")]
     SizeParseError(#[source] std::num::TryFromIntError),

--- a/src/platforms/permissions/error.rs
+++ b/src/platforms/permissions/error.rs
@@ -11,7 +11,7 @@ pub enum PermissionError {
     #[error("Error during platform specific operations")]
     PlatformError(#[from] PlatformError),
 
-    #[error("Error while fetching permissions")]
+    #[error("Error while interacting with filesystem")]
     IOError(#[from] ioerror::IOError),
 }
 

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -53,7 +53,7 @@ pub enum PortableRepoError {
     #[error("The given package name is empty")]
     EmptyPackageName,
 
-    #[error("Cannot fetch package from repository")]
+    #[error("Cannot fetch package metadata from repository")]
     RepositoryError(#[from] RepositoryError),
 
     #[error("Cannot create package prebuild")]


### PR DESCRIPTION
This PR fixes error messages that describe the error incorrectly and refactors the output when a script fails.
The script output now shows the last lines of the script output after the error, and the output lines are colored black to improve readability of the error message.

This fixes the issue described in #125.