### PR TITLE
Implement prebuilds.toml file in the metadata repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `meta-check` utility command, which checks the metadata of a given repository.
 - The `InvalidFiles` check in the verifier, which check directories for invalid files.
 - The `MissingDependencySymlinks` check in the verifier, which checks for missing or incorrect symlinks in the dependencies directory of a certain package.
+- The `prebuilds.toml` file in the metadata, to support more advanced specification of prebuilds for a package.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.
@@ -20,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix error messages not representing the error correctly.
 - Fix MSVC detection not finding VS Build Tools.
 - Fix "check length methods" from the verifier returning wrong length in case of an incomplete check list.
+- Fix portable repositories generating an invalid prebuild repository structure.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -114,6 +114,17 @@ All available requirements for use with the `build_requirements` and `test_requi
 | `msvc` | The Microsoft Visual C++ toolchain, automatically adds `PACKIT_VS_PATH`, `PACKIT_VCVARSALL`, `PACKIT_VCVARSALL_ARCH` and `PACKIT_MSVC_VERSION` to the build environment. (Windows only) |
 
 
+### `prebuilds.toml`
+The package version directory can contain an optional `prebuilds.toml` file. This file describes which prebuilds can be generated for the package version. If the file is not available, a default list of prebuilds is assumed, consisting of a prebuild for each target architecture that is supported by the package.
+
+#### Prebuild fields
+A prebuild is specified by using `[prebuild.<prebuild-id>]`. Each prebuild can have the fields listed below.
+
+| Field     | Explanation                                                                                     |
+| --------- | ----------------------------------------------------------------------------------------------- |
+| `targets` | Defines a list of [target bounds](#target-bounds) that the prebuild can be used for. (required) |
+
+
 ### Target bounds
 
 The target bounds consist of a name, an addition and version bounds, the name is split up in three different categories.

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -7,10 +7,12 @@ use crate::{
         commands::HandleCommand,
         display::{Spinner, logging::error, not_found, styled::Styled},
     },
-    config::Config,
+    config::{Config, Repository},
     installer::types::PackageId,
     packager,
+    platforms::Target,
     register::package_register::PackageRegister,
+    repositories::provider,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
 
@@ -70,13 +72,39 @@ impl PackageArgs {
             None => not_found::register_package_version(package_id, register),
         };
 
+        // Create metadata provider
+        let repository = Repository::new(
+            &package_version.metadata_repository_url,
+            &package_version.metadata_repository_provider,
+        );
+        let Some(provider) = provider::create_metadata_provider(&repository) else {
+            error!(msg: "Cannot create provider for {}, skipping packaging.", package_id.style());
+            return;
+        };
+
+        // Request prebuilds list
+        let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+            Ok(prebuilds_list) => prebuilds_list,
+            Err(e) => {
+                error!(e, "Cannot read prebuild list for {}, skipping packaging.", package_id.style());
+                return;
+            },
+        };
+
+        // Retrieve prebuild_id to use
+        let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+            error!(msg: "Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
+            return;
+        };
+
         // Automatically create the destination directory
         fs::create_dir_all(destination).unwrap_or_exit_msg("Failed to create prebuild directory", 1);
 
+        // Call packager and show spinner
         let spinner_message = format!("Packaging {} to '{}'", package_id.style(), destination.display());
         let spinner = Spinner::new(spinner_message);
         spinner.show();
-        packager::package(config, package_id, destination, package_version.revisions.len() as u64).unwrap_or_exit(1);
+        packager::package(config, package_id, destination, package_version.revisions.len() as u64, prebuild_id).unwrap_or_exit(1);
         spinner.finish();
     }
 }

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -100,7 +100,7 @@ impl PackageArgs {
             },
         };
 
-        // Retrieve prebuild_id to use
+        // Retrieve `prebuild_id` to use
         let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
             error!(msg: "Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
             return;

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -82,8 +82,17 @@ impl PackageArgs {
             return;
         };
 
+        // Request package metadata
+        let package_meta = match provider.read_package(&package_id.name) {
+            Ok(package_meta) => package_meta,
+            Err(e) => {
+                error!(e, "Cannot read package metadata of {}, skipping packaging.", package_id.style());
+                return;
+            },
+        };
+
         // Request prebuilds list
-        let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+        let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version, &package_meta) {
             Ok(prebuilds_list) => prebuilds_list,
             Err(e) => {
                 error!(e, "Cannot read prebuild list for {}, skipping packaging.", package_id.style());

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -41,6 +41,11 @@ pub enum InstallerError {
         new_version: Version,
     },
 
+    #[error("No supported prebuild of {} can be found for the current target", package_id.style())]
+    NoSupportedPrebuild {
+        package_id: PackageId,
+    },
+
     #[error("Could not update, the given version {} is lower then the current version.", new_version.style())]
     VersionTooLowError {
         new_version: Version,

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -237,11 +237,9 @@ impl<'a> InstallTreeBuilder<'a> {
         self.checked_packages.insert(package_id.clone());
 
         // Check if a prebuild for the package is available
-        let revision = install_meta.version_metadata.get_revision_count();
-        let prebuild_id = Target::current().architecture.to_string();
-        match self.repository_manager.get_prebuild_meta(&install_meta.repository_id, package_id, revision, &prebuild_id) {
-            Ok(_) => return Ok(None),
-            Err(RepositoryError::PrebuildNotFound { .. }) | Err(RepositoryError::RepositoryNotFoundError { .. }) => {},
+        match self.find_prebuild(&install_meta, package_id) {
+            Ok(true) => return Ok(None),
+            Ok(false) => {},
             Err(e) => error!(e),
         }
 
@@ -263,6 +261,25 @@ impl<'a> InstallTreeBuilder<'a> {
 
         // Return an adjusted label
         Ok(Some(InstallLabel::new(InstallType::Build, label.is_dependency())))
+    }
+
+    /// Tries to find a prebuild for the given package.
+    /// Returns true if a prebuild is found, false otherwise
+    fn find_prebuild(&mut self, install_meta: &InstallMeta, package_id: &PackageId) -> Result<bool> {
+        let prebuilds_list =
+            self.repository_manager.read_prebuilds_list(&install_meta.repository_id, &package_id.name, &package_id.version)?;
+
+        let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+            return Ok(false);
+        };
+
+        // Check if a prebuild for the package is available
+        let revision = install_meta.version_metadata.get_revision_count();
+        match self.repository_manager.get_prebuild_meta(&install_meta.repository_id, package_id, revision, prebuild_id) {
+            Ok(_) => Ok(true),
+            Err(RepositoryError::PrebuildNotFound { .. }) | Err(RepositoryError::RepositoryNotFoundError { .. }) => Ok(false),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Updates the tree structure shown in the terminal.

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -237,7 +237,7 @@ impl<'a> InstallTreeBuilder<'a> {
         self.checked_packages.insert(package_id.clone());
 
         // Check if a prebuild for the package is available
-        match self.find_prebuild(&install_meta, package_id) {
+        match self.find_prebuild(install_meta, package_id) {
             Ok(true) => return Ok(None),
             Ok(false) => {},
             Err(e) => error!(e),

--- a/src/installer/install_tree.rs
+++ b/src/installer/install_tree.rs
@@ -264,7 +264,7 @@ impl<'a> InstallTreeBuilder<'a> {
     }
 
     /// Tries to find a prebuild for the given package.
-    /// Returns true if a prebuild is found, false otherwise
+    /// Returns true if a prebuild is found, false otherwise.
     fn find_prebuild(&mut self, install_meta: &InstallMeta, package_id: &PackageId) -> Result<bool> {
         let prebuilds_list =
             self.repository_manager.read_prebuilds_list(&install_meta.repository_id, &package_id.name, &package_id.version)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -127,6 +127,7 @@ impl<'a> Installer<'a> {
 
         self.install_nodes(&dependency_tree)?;
 
+        // TODO: don't show when installing from prebuild
         if !self.options.keep_build {
             let removed = self.remove_build_dependencies(0, &dependency_tree)?;
             print!("Removed build dependencies: ");
@@ -304,9 +305,14 @@ impl<'a> Installer<'a> {
         let spinner = Spinner::new(spinner_message);
         spinner.show();
 
-        let prebuild_id = Target::current().architecture.to_string();
-        let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, &prebuild_id)?;
-        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package, revision, &prebuild_id)?;
+        // Get the id of the prebuild
+        let prebuilds_list = self.repository_manager.read_prebuilds_list(repository_id, &package.name, &package.version)?;
+        let (prebuild_id, _) = prebuilds_list.get_best_prebuild(&Target::current()).ok_or(InstallerError::NoSupportedPrebuild {
+            package_id: package.clone(),
+        })?;
+
+        let (extension, bytes) = self.repository_manager.read_prebuild(repository_id, package, revision, prebuild_id)?;
+        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package, revision, prebuild_id)?;
 
         // Finish download spinner
         spinner.finish();

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -127,11 +127,12 @@ impl<'a> Installer<'a> {
 
         self.install_nodes(&dependency_tree)?;
 
-        // TODO: don't show when installing from prebuild
         if !self.options.keep_build {
             let removed = self.remove_build_dependencies(0, &dependency_tree)?;
-            print!("Removed build dependencies: ");
-            standard_print::print_list_or_none(removed.iter().map_styled());
+            if !removed.is_empty() {
+                print!("Removed build dependencies: ");
+                standard_print::print_list_or_none(removed.iter().map_styled());
+            }
         }
 
         Ok(package_id)

--- a/src/installer/types/version_intervals.rs
+++ b/src/installer/types/version_intervals.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize, de};
 use crate::installer::types::{Version, VersionBounds, VersionError};
 
 /// Represents multiple `VersionBounds`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
 pub struct VersionIntervals {
     version_bounds: Vec<VersionBounds>,
 }

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -165,14 +165,14 @@ fn used_prebuild(
     package_version_meta: &PackageVersionMeta,
     install_path: &PathBuf,
 ) -> Result<bool> {
-    let prebuilds_list = manager.read_prebuilds_list(&repository_id, &package_id.name, &package_id.version)?;
+    let prebuilds_list = manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
 
     let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
         return Ok(false);
     };
 
     let revisions = package_version_meta.get_revision_count();
-    match manager.get_prebuild_meta(&repository_id, package_id, revisions, &prebuild_id) {
+    match manager.get_prebuild_meta(repository_id, package_id, revisions, prebuild_id) {
         Ok(prebuild_meta) => {
             let compressed = packager::compress(install_path)?;
             let checksum = Checksum::from_bytes(&compressed);

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -178,8 +178,7 @@ fn used_prebuild(
             let checksum = Checksum::from_bytes(&compressed);
             Ok(prebuild_meta.checksum == checksum)
         },
-        Err(RepositoryError::PrebuildNotFound { .. }) => Ok(false),
-        Err(RepositoryError::RepositoryNotFoundError { .. }) => Ok(false),
+        Err(RepositoryError::PrebuildNotFound { .. }) | Err(RepositoryError::RepositoryNotFoundError { .. }) => Ok(false),
         Err(e) => Err(e.into()),
     }
 }

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{collections::HashSet, fs, str::FromStr};
+use std::{collections::HashSet, fs, path::PathBuf, str::FromStr};
 
 use crate::{
     cli::display::{logging::warning, styled::Styled},
@@ -117,18 +117,7 @@ pub fn fix_inconsistent_register(
         // Use checksum to check if a prebuild was used (use checksum to make sure it's the same prebuild)
         let install_path = &package_directory.join(&package_id.name).join(package_id.version.to_string());
         let (repository_id, _, package_version_meta) = manager.read_package_and_version(&package_id.clone().into(), &Target::current())?;
-        let revisions = package_version_meta.get_revision_count();
-        let prebuild_id = Target::current().architecture.to_string();
-        let used_prebuild = match manager.get_prebuild_meta(&repository_id, package_id, revisions, &prebuild_id) {
-            Ok(prebuild_meta) => {
-                let compressed = packager::compress(install_path)?;
-                let checksum = Checksum::from_bytes(&compressed);
-                prebuild_meta.checksum == checksum
-            },
-            Err(RepositoryError::PrebuildNotFound { .. }) => false,
-            Err(RepositoryError::RepositoryNotFoundError { .. }) => false,
-            Err(e) => Err(e)?,
-        };
+        let used_prebuild = used_prebuild(manager, &repository_id, package_id, &package_version_meta, install_path)?;
 
         // Figure out the active version
         let active_link_path = active_directory.join(&package_id.name);
@@ -165,6 +154,34 @@ pub fn fix_inconsistent_register(
     }
 
     Ok(())
+}
+
+/// Helper function to check if a prebuild was used to install the given package.
+/// Checks if the checksum of the package matches the checksum of the corresponding prebuild.
+fn used_prebuild(
+    manager: &RepositoryManager,
+    repository_id: &str,
+    package_id: &PackageId,
+    package_version_meta: &PackageVersionMeta,
+    install_path: &PathBuf,
+) -> Result<bool> {
+    let prebuilds_list = manager.read_prebuilds_list(&repository_id, &package_id.name, &package_id.version)?;
+
+    let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+        return Ok(false);
+    };
+
+    let revisions = package_version_meta.get_revision_count();
+    match manager.get_prebuild_meta(&repository_id, package_id, revisions, &prebuild_id) {
+        Ok(prebuild_meta) => {
+            let compressed = packager::compress(install_path)?;
+            let checksum = Checksum::from_bytes(&compressed);
+            Ok(prebuild_meta.checksum == checksum)
+        },
+        Err(RepositoryError::PrebuildNotFound { .. }) => Ok(false),
+        Err(RepositoryError::RepositoryNotFoundError { .. }) => Ok(false),
+        Err(e) => Err(e.into()),
+    }
 }
 
 /// Gets the latest satisfying dependencies for a given package from the given storage packages.

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -128,7 +128,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         },
     };
 
-    // Retrieve prebuild_id to use
+    // Retrieve `prebuild_id` to use
     let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
         warning!("Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
         return Ok(false);

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -108,8 +108,18 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         },
     };
 
+    // Request package metadata
+    let package_meta = match provider.read_package(&package_id.name) {
+        Ok(package_meta) => package_meta,
+        Err(e) => {
+            warning!("Cannot read package metadata of {}, skipping check.", package_id.style());
+            debug!(err: e, "Retrieving package metadata failed");
+            return Ok(false);
+        },
+    };
+
     // Request prebuilds list
-    let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+    let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version, &package_meta) {
         Ok(prebuilds_list) => prebuilds_list,
         Err(e) => {
             warning!("Cannot read prebuild list for {}, skipping check.", package_id.style());

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -65,20 +65,20 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         return Ok(false);
     };
 
+    let repository = Repository::new(
+        &package_version.metadata_repository_url,
+        &package_version.metadata_repository_provider,
+    );
+
+    let Some(provider) = provider::create_metadata_provider(&repository) else {
+        warning!("Cannot create metadata provider for {}, skipping check", package_id.style());
+        return Ok(false);
+    };
+
     let mut prebuilds_url = package_version.prebuilds_repository_url.clone();
     let mut prebuilds_provider = package_version.prebuilds_repository_provider.clone();
 
     if prebuilds_url.is_none() {
-        let repository = Repository::new(
-            &package_version.metadata_repository_url,
-            &package_version.metadata_repository_provider,
-        );
-
-        let Some(provider) = provider::create_metadata_provider(&repository) else {
-            warning!("Cannot create metadata provider for {}, skipping check", package_id.style());
-            return Ok(false);
-        };
-
         let repo_metadata = match provider.read_repository_metadata() {
             Ok(meta) => meta,
             Err(e) => {
@@ -100,7 +100,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         return Ok(false);
     };
 
-    let provider = match provider::create_prebuild_provider_from_url(prebuilds_url, prebuilds_provider) {
+    let prebuild_provider = match provider::create_prebuild_provider_from_url(prebuilds_url, prebuilds_provider) {
         Some(provider) => provider,
         None => {
             warning!("Cannot create prebuild provider for {}, skipping check", package_id.style());
@@ -108,9 +108,24 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         },
     };
 
+    // Request prebuilds list
+    let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+        Ok(prebuilds_list) => prebuilds_list,
+        Err(e) => {
+            warning!("Cannot read prebuild list for {}, skipping check.", package_id.style());
+            debug!(err: e, "Retrieving prebuilds list failed");
+            return Ok(false);
+        },
+    };
+
+    // Retrieve prebuild_id to use
+    let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+        warning!("Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
+        return Ok(false);
+    };
+
     let revision = package_version.revisions.len() as u64;
-    let prebuild_id = Target::current().architecture.to_string();
-    let prebuild_meta = match provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
+    let prebuild_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
         Ok(prebuild_meta) => prebuild_meta,
         Err(e) => {
             warning!(

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -135,7 +135,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     };
 
     let revision = package_version.revisions.len() as u64;
-    let prebuild_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
+    let prebuild_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, prebuild_id) {
         Ok(prebuild_meta) => prebuild_meta,
         Err(e) => {
             warning!(

--- a/src/packager.rs
+++ b/src/packager.rs
@@ -14,7 +14,6 @@ use thiserror::Error;
 use crate::{
     config::Config,
     installer::types::PackageId,
-    platforms::TargetArchitecture,
     repositories::types::{Checksum, FileSize, PrebuildFileMeta},
     utils::ioerror::{self, IOResultExt},
 };
@@ -47,7 +46,7 @@ pub type Result<T> = core::result::Result<T, PackagerError>;
 
 /// Packages a package to a given destination. If the destination doesn't exist, a `PackagerError::InvalidDestination` error is returned.
 /// The revision is used to create a unique filename for different package revisions.
-pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revisions: u64) -> Result<()> {
+pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revisions: u64, prebuild_id: &str) -> Result<()> {
     let install_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
     // Return an error if the destination is not a directory
@@ -68,8 +67,7 @@ pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revi
     let metadata_string = toml::ser::to_string(&metadata)?;
 
     // Create the file names
-    let target_architecture = TargetArchitecture::current().to_string();
-    let filename = format!("{package_id}-{revisions}-{target_architecture}");
+    let filename = format!("{package_id}-{revisions}-{prebuild_id}");
     let compressed_filename = format!("{filename}.tar.gz");
     let prepackage_file = destination.join(compressed_filename);
     let metadata_filename = format!("{filename}.toml");

--- a/src/platforms/target_architecture.rs
+++ b/src/platforms/target_architecture.rs
@@ -36,6 +36,19 @@ impl Display for TargetArchitecture {
 }
 
 impl TargetArchitecture {
+    /// Gets a list of all target architectures.
+    pub fn values() -> &'static [Self] {
+        &[
+            Self::MacOsX86_64,
+            Self::MacOsAarch64,
+            Self::LinuxAarch64Gnu,
+            Self::LinuxX86_64Gnu,
+            Self::LinuxX86_64Musl,
+            Self::WindowsX86_64Msvc,
+            Self::WindowsAarch64Msvc,
+        ]
+    }
+
     /// Gets the architecture of the current machine. Returns `Unknown` if the type isn't supported.
     pub fn current() -> Self {
         #[cfg(all(target_os = "macos", target_arch = "x86_64"))]

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -17,7 +17,7 @@ use crate::{
     repositories::{
         error::{PackageNotFoundReason, RepositoryError, Result},
         provider::{self, MetadataProvider, PrebuildProvider},
-        types::{Date, IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, RepositoryMeta},
+        types::{Date, IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, PrebuildsList, RepositoryMeta},
     },
     utils::packit_version::current_packit_version,
 };
@@ -320,6 +320,11 @@ impl<'a> RepositoryManager<'a> {
         }
 
         None
+    }
+
+    /// Reads the list of prebuilds that can be generated for the given version of the package.
+    pub fn read_prebuilds_list(&self, repository_id: &str, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
+        self.get_metadata_provider(repository_id)?.read_prebuilds_list(package, version)
     }
 
     /// Reads a file of the given package from the given repository.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -324,7 +324,8 @@ impl<'a> RepositoryManager<'a> {
 
     /// Reads the list of prebuilds that can be generated for the given version of the package.
     pub fn read_prebuilds_list(&self, repository_id: &str, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
-        self.get_metadata_provider(repository_id)?.read_prebuilds_list(package, version)
+        let package_meta = self.read_repo_package(repository_id, package)?;
+        self.get_metadata_provider(repository_id)?.read_prebuilds_list(package, version, &package_meta)
     }
 
     /// Reads a file of the given package from the given repository.

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -9,7 +9,7 @@ use crate::{
     repositories::{
         error::Result,
         provider::MetadataProvider,
-        types::{IndexMeta, PackageMeta, PackageVersionMeta, RepositoryMeta},
+        types::{IndexMeta, PackageMeta, PackageVersionMeta, PrebuildsList, RepositoryMeta},
     },
     utils::ioerror::IOResultExt,
 };
@@ -44,6 +44,16 @@ impl MetadataProvider for FileSystemMetadataProvider {
         let path = self.path.join("packages").join(package.to_string()).join(version.to_string()).join("targets.toml");
         let data = Self::read_file_string(path)?;
 
+        Ok(toml::de::from_str(&data)?)
+    }
+
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
+        let path = self.path.join("packages").join(package.to_string()).join(version.to_string()).join("prebuilds.toml");
+        if !path.exists() {
+            return Ok(PrebuildsList::default());
+        }
+
+        let data = Self::read_file_string(path)?;
         Ok(toml::de::from_str(&data)?)
     }
 

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -47,10 +47,10 @@ impl MetadataProvider for FileSystemMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList> {
         let path = self.path.join("packages").join(package.to_string()).join(version.to_string()).join("prebuilds.toml");
         if !path.exists() {
-            return Ok(PrebuildsList::default());
+            return Ok(PrebuildsList::default(package_meta.supported_versions.keys()));
         }
 
         let data = Self::read_file_string(path)?;

--- a/src/repositories/metadata/web.rs
+++ b/src/repositories/metadata/web.rs
@@ -8,7 +8,7 @@ use crate::{
     repositories::{
         error::{RepositoryError, Result},
         provider::MetadataProvider,
-        types::{IndexMeta, PackageMeta, PackageVersionMeta, RepositoryMeta},
+        types::{IndexMeta, PackageMeta, PackageVersionMeta, PrebuildsList, RepositoryMeta},
     },
     utils::requests,
 };
@@ -43,6 +43,21 @@ impl MetadataProvider for WebMetadataProvider {
         let data = self.request_metadata(format!("{}/packages/{package}/{version}/targets.toml", self.url))?;
 
         Ok(toml::de::from_str(&data)?)
+    }
+
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
+        let response = requests::get(format!("{}/packages/{package}/{version}/prebuilds.toml", self.url))?;
+
+        if response.status() == StatusCode::NOT_FOUND {
+            return Ok(PrebuildsList::default());
+        }
+
+        // Return an error if something went wrong with the request (apart from not found error)
+        if !response.status().is_success() {
+            return Err(RepositoryError::UnsuccessfulRequest(response.status()));
+        }
+
+        Ok(toml::de::from_str(&response.text()?)?)
     }
 
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {

--- a/src/repositories/metadata/web.rs
+++ b/src/repositories/metadata/web.rs
@@ -45,11 +45,11 @@ impl MetadataProvider for WebMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList> {
         let response = requests::get(format!("{}/packages/{package}/{version}/prebuilds.toml", self.url))?;
 
         if response.status() == StatusCode::NOT_FOUND {
-            return Ok(PrebuildsList::default());
+            return Ok(PrebuildsList::default(package_meta.supported_versions.keys()));
         }
 
         // Return an error if something went wrong with the request (apart from not found error)

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -304,7 +304,7 @@ impl<'a> PortableRepoCreator<'a> {
             Ok(prebuild_meta) => prebuild_meta,
             // Only try to package locally if the current target is the target we generate a portable repo for
             Err(RepositoryError::PrebuildNotFound { .. }) if self.target == Target::current() => {
-                packager::package(self.config, package_id, &destination, revision)?;
+                packager::package(self.config, package_id, &destination, revision, &prebuild_id)?;
                 return Ok(());
             },
             Err(e) => return Err(e.into()),

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -50,9 +50,6 @@ pub enum PortableRepoError {
     #[error("The destination does already exist and is not an empty directory")]
     DestinationNotEmpty,
 
-    #[error("The given package name is empty")]
-    EmptyPackageName,
-
     #[error("Cannot fetch package metadata from repository")]
     RepositoryError(#[from] RepositoryError),
 
@@ -164,17 +161,17 @@ impl<'a> PortableRepoCreator<'a> {
     /// Returns `true` if a prebuild is available, false otherwise.
     fn is_prebuild_available(&self, repository_id: &str, package_id: &PackageId, revision: u64) -> Result<bool> {
         // Get id of the prebuild
-        let prebuilds_list = self.repository_manager.read_prebuilds_list(&repository_id, &package_id.name, &package_id.version)?;
+        let prebuilds_list = self.repository_manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
         let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
             return Ok(false);
         };
 
         // Check if the package has a prebuild
-        let prebuild_meta = self.repository_manager.get_prebuild_meta(&repository_id, &package_id, revision, prebuild_id);
+        let prebuild_meta = self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, prebuild_id);
         match prebuild_meta {
             Ok(_) => Ok(true),
             Err(RepositoryError::PrebuildNotFound { .. }) => Ok(false),
-            Err(e) => return Err(e.into()),
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -304,7 +301,7 @@ impl<'a> PortableRepoCreator<'a> {
         package_version: &PackageVersionMeta,
         destination: &Path,
     ) -> Result<()> {
-        let prefix = package_id.name.chars().next().ok_or(PortableRepoError::EmptyPackageName)?.to_string();
+        let prefix = package_id.name.get_prefix().to_string();
         let prebuilds_dir = destination.join("prebuilds");
         let destination = prebuilds_dir.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string());
         fs::create_dir_all(&destination).err_with_path("create dirs", &destination)?;

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -258,6 +258,11 @@ impl<'a> PortableRepoCreator<'a> {
         let targets_path = package_path.join(package_id.version.to_string()).join("targets.toml");
         self.write_metadata(version_meta, targets_path, false)?;
 
+        // Download prebuilds.toml
+        let prebuilds_list = self.repository_manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
+        let prebuilds_path = package_path.join(package_id.version.to_string()).join("prebuilds.toml");
+        self.write_metadata(prebuilds_list, prebuilds_path, false)?;
+
         let target_bounds = package_version.get_best_target(&self.target)?;
 
         // Download scripts
@@ -297,20 +302,25 @@ impl<'a> PortableRepoCreator<'a> {
         let destination = destination.join("prebuilds").join(&target).join(&prefix).join(&package_id.name);
         fs::create_dir_all(&destination).err_with_path("create dirs", &destination)?;
 
+        // Get id of the prebuild
+        let prebuilds_list = self.repository_manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
+        let (prebuild_id, _) = prebuilds_list.get_best_prebuild(&Target::current()).ok_or(PortableRepoError::PrebuildNotFound {
+            package_id: package_id.clone(),
+        })?;
+
         // Get checksum
         let revision = package_version.get_revision_count();
-        let prebuild_id = self.target.architecture.to_string();
-        let prebuild_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, &prebuild_id) {
+        let prebuild_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, prebuild_id) {
             Ok(prebuild_meta) => prebuild_meta,
             // Only try to package locally if the current target is the target we generate a portable repo for
             Err(RepositoryError::PrebuildNotFound { .. }) if self.target == Target::current() => {
-                packager::package(self.config, package_id, &destination, revision, &prebuild_id)?;
+                packager::package(self.config, package_id, &destination, revision, prebuild_id)?;
                 return Ok(());
             },
             Err(e) => return Err(e.into()),
         };
 
-        let (_, prebuild) = self.repository_manager.read_prebuild(repository_id, package_id, revision, &prebuild_id)?;
+        let (_, prebuild) = self.repository_manager.read_prebuild(repository_id, package_id, revision, prebuild_id)?;
 
         // Write to file
         let prebuild_name = format!("{package_id}-{revision}-{target}.tar.gz");

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -114,18 +114,7 @@ impl<'a> PortableRepoCreator<'a> {
                 self.repository_manager.read_package_and_version(&package_id.clone().into(), &self.target)?;
 
             if !self.exclude_prebuilds {
-                // Check if the package has a prebuild
-                let prebuild_meta = self.repository_manager.get_prebuild_meta(
-                    &repository_id,
-                    &package_id,
-                    package_version.get_revision_count(),
-                    &self.target.architecture.to_string(),
-                );
-                let found_prebuild = match prebuild_meta {
-                    Ok(_) => true,
-                    Err(RepositoryError::PrebuildNotFound { .. }) => false,
-                    Err(e) => return Err(e.into()),
-                };
+                let found_prebuild = self.is_prebuild_available(&repository_id, &package_id, package_version.get_revision_count())?;
 
                 // Check if prebuild is downloadable, or if package is installed
                 if !found_prebuild && (self.target != Target::current() || self.register.get_package_version(&package_id).is_none()) {
@@ -169,6 +158,24 @@ impl<'a> PortableRepoCreator<'a> {
         self.write_metadata(index_meta, destination.join("index.toml"), true)?;
 
         Ok(())
+    }
+
+    /// Checks if a prebuild is available for the given package and revision in the given repository.
+    /// Returns `true` if a prebuild is available, false otherwise.
+    fn is_prebuild_available(&self, repository_id: &str, package_id: &PackageId, revision: u64) -> Result<bool> {
+        // Get id of the prebuild
+        let prebuilds_list = self.repository_manager.read_prebuilds_list(&repository_id, &package_id.name, &package_id.version)?;
+        let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+            return Ok(false);
+        };
+
+        // Check if the package has a prebuild
+        let prebuild_meta = self.repository_manager.get_prebuild_meta(&repository_id, &package_id, revision, prebuild_id);
+        match prebuild_meta {
+            Ok(_) => Ok(true),
+            Err(RepositoryError::PrebuildNotFound { .. }) => Ok(false),
+            Err(e) => return Err(e.into()),
+        }
     }
 
     /// Creates a set of all packages that are in the dependency trees of the included packages.
@@ -298,8 +305,8 @@ impl<'a> PortableRepoCreator<'a> {
         destination: &Path,
     ) -> Result<()> {
         let prefix = package_id.name.chars().next().ok_or(PortableRepoError::EmptyPackageName)?.to_string();
-        let target = self.target.architecture.to_string();
-        let destination = destination.join("prebuilds").join(&target).join(&prefix).join(&package_id.name);
+        let prebuilds_dir = destination.join("prebuilds");
+        let destination = prebuilds_dir.join("packages").join(prefix).join(&package_id.name).join(package_id.version.to_string());
         fs::create_dir_all(&destination).err_with_path("create dirs", &destination)?;
 
         // Get id of the prebuild
@@ -323,9 +330,9 @@ impl<'a> PortableRepoCreator<'a> {
         let (_, prebuild) = self.repository_manager.read_prebuild(repository_id, package_id, revision, prebuild_id)?;
 
         // Write to file
-        let prebuild_name = format!("{package_id}-{revision}-{target}.tar.gz");
+        let prebuild_name = format!("{package_id}-{revision}-{prebuild_id}.tar.gz");
         let prebuild_path = destination.join(prebuild_name);
-        let prebuild_meta_name = format!("{package_id}-{revision}-{target}.toml");
+        let prebuild_meta_name = format!("{package_id}-{revision}-{prebuild_id}.toml");
         let prebuild_meta_path = destination.join(prebuild_meta_name);
         fs::write(&prebuild_path, &prebuild).err_with_path("write", prebuild_path)?;
         self.write_metadata(prebuild_meta, prebuild_meta_path, false)?;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -14,7 +14,7 @@ use crate::{
             DEFAULT_PREBUILD_PROVIDER_ID, FILESYSTEM_PREBUILD_PROVIDER_ID, FileSystemPrebuildProvider, WEB_PREBUILD_PROVIDER_ID,
             WebPrebuildProvider,
         },
-        types::{IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, RepositoryMeta},
+        types::{IndexMeta, PackageMeta, PackageVersionMeta, PrebuildFileMeta, PrebuildsList, RepositoryMeta},
     },
 };
 
@@ -31,6 +31,9 @@ pub trait MetadataProvider {
 
     /// Reads the metadata of a certain version of a package, containing dependencies and targets.
     fn read_package_version(&self, package: &PackageName, version: &Version) -> Result<PackageVersionMeta>;
+
+    /// Reads the list of prebuilds that can be generated for the given version of the package.
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList>;
 
     /// Reads the requested file from the repository as bytes.
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>>;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -33,7 +33,7 @@ pub trait MetadataProvider {
     fn read_package_version(&self, package: &PackageName, version: &Version) -> Result<PackageVersionMeta>;
 
     /// Reads the list of prebuilds that can be generated for the given version of the package.
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<PrebuildsList>;
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList>;
 
     /// Reads the requested file from the repository as bytes.
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>>;

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -19,6 +19,8 @@ pub use self::package_target::PackageTarget;
 pub use self::package_version::PackageVersionMeta;
 
 pub use self::prebuilds::PrebuildFileMeta;
+pub use self::prebuilds::PrebuildMeta;
+pub use self::prebuilds::PrebuildsList;
 
 pub use self::checksum::Checksum;
 pub use self::common::Script;

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -19,6 +19,7 @@ pub use self::package_target::PackageTarget;
 pub use self::package_version::PackageVersionMeta;
 
 pub use self::prebuilds::PrebuildFileMeta;
+#[expect(unused_imports)]
 pub use self::prebuilds::PrebuildMeta;
 pub use self::prebuilds::PrebuildsList;
 

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -1,10 +1,55 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
-use crate::repositories::types::{Checksum, FileSize};
+use crate::{
+    installer::types::VersionIntervals,
+    platforms::{Target, TargetArchitecture},
+    repositories::types::{Checksum, FileSize, TargetBounds, target_bounds::TargetName},
+};
 
 /// Represents the metadata file that comes with a prebuild.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PrebuildFileMeta {
     pub checksum: Checksum,
     pub size: FileSize,
+}
+
+/// Represents the prebuilds.toml file, containing a list of all prebuilds that can be generated.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrebuildsList {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    prebuilds: HashMap<String, PrebuildMeta>,
+}
+
+/// Represents the information about a prebuild in the prebuilds.toml file.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct PrebuildMeta {
+    targets: Vec<TargetBounds>,
+}
+
+impl PrebuildsList {
+    /// Gets the prebuild that satisfies the given target the best.
+    /// Returns the prebuild id and the `PrebuildMeta`
+    pub fn get_best_prebuild(&self, target: Target) -> (&String, &PrebuildMeta) {
+        todo!()
+    }
+}
+
+// TODO: refactor: also targets that are not supported are in this list by default now.
+impl Default for PrebuildsList {
+    /// Creates a default `PrebuildsList`, containing a prebuild for all available targets.
+    fn default() -> Self {
+        let mut prebuilds = HashMap::new();
+        for architecture in TargetArchitecture::values() {
+            let target = TargetBounds {
+                name: TargetName::Architecture(architecture.clone()),
+                addition: None,
+                version_intervals: VersionIntervals::default(),
+            };
+            prebuilds.insert(architecture.to_string(), PrebuildMeta { targets: vec![target] });
+        }
+
+        Self { prebuilds }
+    }
 }

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
 
 use crate::{
+    cli::display::logging::warning,
     installer::types::VersionIntervals,
     platforms::{Target, TargetArchitecture},
     repositories::types::{Checksum, FileSize, TargetBounds, target_bounds::TargetName},
@@ -30,9 +31,34 @@ pub struct PrebuildMeta {
 
 impl PrebuildsList {
     /// Gets the prebuild that satisfies the given target the best.
-    /// Returns the prebuild id and the `PrebuildMeta`
-    pub fn get_best_prebuild(&self, target: Target) -> (&String, &PrebuildMeta) {
-        todo!()
+    /// Returns the prebuild id and the `PrebuildMeta`, or `None` if no matching prebuild can be found.
+    pub fn get_best_prebuild(&self, target: &Target) -> Option<(&String, &PrebuildMeta)> {
+        let mut best_prebuild_id = None;
+        let mut best_prebuild_meta = None;
+        let mut best_priority = 0;
+
+        for (id, meta) in &self.prebuilds {
+            let Some((priority, _)) = TargetBounds::get_best_target_priority(target, meta.targets.iter().collect()) else {
+                continue;
+            };
+
+            if priority < best_priority {
+                continue;
+            }
+
+            if priority == best_priority {
+                warning!("Found two targets that satisfy and have the same priority!");
+            }
+
+            best_prebuild_id = Some(id);
+            best_prebuild_meta = Some(meta);
+            best_priority = priority;
+        }
+
+        match (best_prebuild_id, best_prebuild_meta) {
+            (Some(best_prebuild_id), Some(best_prebuild_meta)) => Some((best_prebuild_id, best_prebuild_meta)),
+            _ => None,
+        }
     }
 }
 

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -60,14 +60,23 @@ impl PrebuildsList {
             _ => None,
         }
     }
-}
 
-// TODO: refactor: also targets that are not supported are in this list by default now.
-impl Default for PrebuildsList {
-    /// Creates a default `PrebuildsList`, containing a prebuild for all available targets.
-    fn default() -> Self {
+    /// Creates a default `PrebuildsList`, containing a prebuild for all supported targets.
+    pub fn default<'a>(supported_targets: impl Iterator<Item = &'a TargetBounds>) -> Self {
+        // Extract only supported targets from the given target bounds
+        let mut targets = HashSet::new();
+        for supported_target in supported_targets {
+            match &supported_target.name {
+                TargetName::Architecture(architecture) => {
+                    targets.insert(architecture);
+                },
+                TargetName::Os(os) => targets.extend(TargetArchitecture::values().iter().filter(|x| x.get_os() == *os)),
+                TargetName::Unix => targets.extend(TargetArchitecture::values().iter().filter(|x| x.get_os().is_unix())),
+            }
+        }
+
         let mut prebuilds = HashMap::new();
-        for architecture in TargetArchitecture::values() {
+        for architecture in targets {
             let target = TargetBounds {
                 name: TargetName::Architecture(architecture.clone()),
                 addition: None,

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -16,14 +16,15 @@ pub struct PrebuildFileMeta {
     pub size: FileSize,
 }
 
-/// Represents the prebuilds.toml file, containing a list of all prebuilds that can be generated.
+/// Represents the `prebuilds.toml` file, containing a list of all prebuilds that can be generated.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PrebuildsList {
+    // A mapping from prebuild id to prebuild metadata
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     prebuilds: HashMap<String, PrebuildMeta>,
 }
 
-/// Represents the information about a prebuild in the prebuilds.toml file.
+/// Represents the information about a prebuild in the `prebuilds.toml` file.
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PrebuildMeta {
     targets: Vec<TargetBounds>,
@@ -33,8 +34,7 @@ impl PrebuildsList {
     /// Gets the prebuild that satisfies the given target the best.
     /// Returns the prebuild id and the `PrebuildMeta`, or `None` if no matching prebuild can be found.
     pub fn get_best_prebuild(&self, target: &Target) -> Option<(&String, &PrebuildMeta)> {
-        let mut best_prebuild_id = None;
-        let mut best_prebuild_meta = None;
+        let mut best_prebuild = None;
         let mut best_priority = 0;
 
         for (id, meta) in &self.prebuilds {
@@ -50,15 +50,11 @@ impl PrebuildsList {
                 warning!("Found two targets that satisfy and have the same priority!");
             }
 
-            best_prebuild_id = Some(id);
-            best_prebuild_meta = Some(meta);
+            best_prebuild = Some((id, meta));
             best_priority = priority;
         }
 
-        match (best_prebuild_id, best_prebuild_meta) {
-            (Some(best_prebuild_id), Some(best_prebuild_meta)) => Some((best_prebuild_id, best_prebuild_meta)),
-            _ => None,
-        }
+        best_prebuild
     }
 
     /// Creates a default `PrebuildsList`, containing a prebuild for all supported targets.

--- a/src/repositories/types/target_bounds.rs
+++ b/src/repositories/types/target_bounds.rs
@@ -239,6 +239,12 @@ impl TargetBounds {
     /// Gets the best satisfying target bound. The best meaning the bound with the highest priority.
     /// `None` will be returned if no satisfying target bounds can be found.
     pub fn get_best_target<'a>(specific_target: &Target, targets: Vec<&'a TargetBounds>) -> Option<&'a TargetBounds> {
+        Self::get_best_target_priority(specific_target, targets).map(|(_, x)| x)
+    }
+
+    /// Gets the best satisfying target bound and its priority. A higher priority means a more specific target.
+    /// `None` will be returned if no satisfying target bounds can be found.
+    pub fn get_best_target_priority<'a>(specific_target: &Target, targets: Vec<&'a TargetBounds>) -> Option<(u32, &'a TargetBounds)> {
         let mut current_best = None;
         let mut current_best_priority = 0;
 
@@ -260,6 +266,6 @@ impl TargetBounds {
             current_best_priority = priority;
         }
 
-        current_best
+        current_best.map(|x| (current_best_priority, x))
     }
 }


### PR DESCRIPTION
This PR introduces the new `prebuilds.toml` file on package versions in metadata repositories. This file can be used to describe which prebuilds are available and which targets are supported by a prebuild. 
The `prebuilds.toml` file is optional, when it is not available, the previous behaviour of a prebuild for each target is assumed.

Because of this change, `ca-certificates` for example can have only a single prebuild, for all targets.