### PR TITLE
Fix MSVC detection to also find VS Build Tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - Fix error messages not representing the error correctly.
+- Fix MSVC detection not finding VS Build Tools.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/src/platforms/tool_detection/windows.rs
+++ b/src/platforms/tool_detection/windows.rs
@@ -2,9 +2,12 @@
 use std::{fs, path::PathBuf, process::Command, str::FromStr};
 
 use crate::{
-    cli::display::logging::debug,
+    cli::display::logging::{debug, error},
     installer::types::Version,
-    platforms::tool_detection::{error::Result, tools::Msvc},
+    platforms::{
+        TargetArchitecture,
+        tool_detection::{error::Result, tools::Msvc},
+    },
     utils::ioerror::IOResultExt,
 };
 
@@ -18,9 +21,21 @@ pub fn detect_msvc() -> Result<Option<Msvc>> {
         return Ok(None);
     }
 
+    // Create vswhere requirement based on target architecture
+    let target = match TargetArchitecture::current() {
+        TargetArchitecture::WindowsX86_64Msvc => "x86.x64",
+        TargetArchitecture::WindowsAarch64Msvc => "ARM64",
+        _ => {
+            error!(msg: "Reached Windows specific code on non-Windows target");
+            return Ok(None);
+        },
+    };
+    let requirement = format!("Microsoft.VisualStudio.Component.VC.Tools.{target}");
+
     // Read Visual Studio install path from `vswhere`
     let mut command = Command::new(vswhere);
     command.args(["-latest", "-property", "installationPath"]);
+    command.args(["-products", "*", "-requires", &requirement]);
     let output = command.output().err_operation("run vswhere command")?;
     let vs_path = str::from_utf8(&output.stdout)?;
     let vs_path = PathBuf::from(vs_path.trim());


### PR DESCRIPTION
This PR fixes the MSVC detection not finding VS Build Tools, as noted in #126. The detection now checks for all products and specifically for `VC.Tools`.