### PR TITLE
Extend Licenses to allow nesting and specifying exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.
 - Prebuilds now have a toml metadata file instead of the checksum file, containing the checksum and size of the prebuild.
+- The license field in the metadata now allows nesting and specifying exceptions.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -183,6 +183,20 @@ The following operators are available:
 | `\|`        | Can be used to chain multiple bounds, works as an or operator, for example `3\|5-7`. |
 
 
+### Licenses
+
+The licenses can be specified in a structured format, that is easy to parse. A license field can have the following values:
+- `"<license-name>"`
+- `{ name = "<license-name>", with = ["<exception>"] }`
+- `{ any = [ <license-value> ] }`
+- `{ all = [ <license-value> ] }`
+
+The `any` and `all` fields allow nesting another license value. For example, the following complex license is valid: <br>
+`{ all = [ "License-1", { any = [ { name = "License-2", with = ["Exception-1", "Exception-2"] }, "License-3" ] } ] }`
+
+Note that the `<license-name>` and `<exception>` should be a SPDX Identifier if it is available. See https://spdx.org/licenses/.
+
+
 ### Scripts
 
 The scripts define the specific behaviour to install, uninstall or test a specific package. They can be defined globally for a package, per version or per target. On unix systems the script are written in `sh` and have the `.sh` extension. On Windows the scripts are written in `batch` and have the `.bat` extension.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -194,7 +194,7 @@ The licenses can be specified in a structured format, that is easy to parse. A l
 The `any` and `all` fields allow nesting another license value. For example, the following complex license is valid: <br>
 `{ all = [ "License-1", { any = [ { name = "License-2", with = ["Exception-1", "Exception-2"] }, "License-3" ] } ] }`
 
-Note that the `<license-name>` and `<exception>` should be a SPDX Identifier if it is available. See https://spdx.org/licenses/.
+Note that the `<license-name>` and `<exception>` should be an SPDX Identifier if it is available. See https://spdx.org/licenses/.
 
 
 ### Scripts

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -476,22 +476,51 @@ impl MetaCheck {
 
     /// Checks the licenses of a package.
     fn check_license(&mut self, license: &Licenses, package_id: &PackageId) {
-        let licenses = match &license {
+        let (license, exceptions) = match &license {
             Licenses::Unknown => return,
-            Licenses::Single(license) => &vec![license.clone()],
-            Licenses::Any { any } => any,
-            Licenses::All { all } => all,
+            Licenses::Single(license) => (license, None),
+            Licenses::SingleWithExceptions { name, exceptions } => (name, Some(exceptions)),
+            Licenses::Any { any: licenses } | Licenses::All { all: licenses } => {
+                // Check if the list of licenses is empty
+                if licenses.is_empty() {
+                    let description = format!("List of licenses from {} is empty", package_id.style());
+                    self.issues.push(MetaIssue::default(description));
+                }
+
+                // Check if list contains only a single license
+                if licenses.len() == 1 {
+                    let description = format!("List of licenses from {} contains only a single license", package_id.style());
+                    self.issues.push(MetaIssue::default(description));
+                }
+
+                // Check each license in the list
+                for license in licenses {
+                    self.check_license(license, package_id);
+                }
+                return;
+            },
         };
 
-        if licenses.is_empty() {
-            let description = format!("List of licenses from {} is empty", package_id.style());
+        // Check if the license is an empty string
+        if license.is_empty() {
+            let description = format!("Package {} has an empty license", package_id.style());
             self.issues.push(MetaIssue::default(description));
         }
 
-        for license in licenses {
-            if license.is_empty() {
-                let description = format!("Package {} has an empty license", package_id.style());
+        // Check exceptions if specified
+        if let Some(exceptions) = exceptions {
+            // Check if the list of exceptions is empty
+            if exceptions.is_empty() {
+                let description = format!("List of license exceptions from {} is empty", package_id.style());
                 self.issues.push(MetaIssue::default(description));
+            }
+
+            // Check if one of the excptions is an empty string
+            for exception in exceptions {
+                if exception.is_empty() {
+                    let description = format!("Package {} has an empty license exception", package_id.style());
+                    self.issues.push(MetaIssue::default(description));
+                }
             }
         }
     }

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -493,10 +493,11 @@ impl MetaCheck {
                     self.issues.push(MetaIssue::default(description));
                 }
 
-                // Check each license in the list
+                // Recursively check each license in the list
                 for license in licenses {
                     self.check_license(license, package_id);
                 }
+
                 return;
             },
         };

--- a/src/repositories/types/license.rs
+++ b/src/repositories/types/license.rs
@@ -9,28 +9,72 @@ pub enum Licenses {
     #[default]
     Unknown,
     Single(String),
+    SingleWithExceptions {
+        name: String,
+
+        #[serde(rename = "with")]
+        exceptions: Vec<String>,
+    },
     Any {
-        any: Vec<String>,
+        any: Vec<Licenses>,
     },
     All {
-        all: Vec<String>,
+        all: Vec<Licenses>,
     },
 }
 
 impl Licenses {
-    /// Returns true if the License is `Unknown`.
+    /// Returns true if the license is `Unknown`.
     pub fn is_unknown(&self) -> bool {
         matches!(self, Self::Unknown)
+    }
+
+    /// Implementation of license display.
+    /// Only includes parentheses for `All` and `Any` options when `include_parentheses` is true.
+    fn display_impl(&self, f: &mut std::fmt::Formatter<'_>, include_parentheses: bool) -> std::fmt::Result {
+        if include_parentheses && matches!(self, Licenses::All { .. } | Licenses::Any { .. }) {
+            write!(f, "(")?;
+        }
+
+        match self {
+            Licenses::Unknown => write!(f, "Unknown")?,
+            Licenses::Single(license) => write!(f, "{license}")?,
+            Licenses::SingleWithExceptions { name, exceptions } => {
+                write!(f, "{name} WITH ",)?;
+                let exceptions_str = exceptions.join(", ");
+                match exceptions.len() {
+                    1 => write!(f, "{}", exceptions_str)?,
+                    _ => write!(f, "({})", exceptions_str)?,
+                }
+            },
+            Licenses::Any { any } => {
+                for (i, license) in any.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " OR ")?;
+                    }
+                    license.display_impl(f, true)?;
+                }
+            },
+            Licenses::All { all } => {
+                for (i, license) in all.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " AND ")?;
+                    }
+                    license.display_impl(f, true)?;
+                }
+            },
+        }
+
+        if include_parentheses && matches!(self, Licenses::All { .. } | Licenses::Any { .. }) {
+            write!(f, ")")?;
+        }
+
+        Ok(())
     }
 }
 
 impl Display for Licenses {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Licenses::Unknown => write!(f, "Unknown"),
-            Licenses::Single(license) => write!(f, "{license}"),
-            Licenses::Any { any } => write!(f, "any of: {}", any.join(", ")),
-            Licenses::All { all } => write!(f, "all of: {}", all.join(", ")),
-        }
+        self.display_impl(f, false)
     }
 }

--- a/src/repositories/types/license.rs
+++ b/src/repositories/types/license.rs
@@ -40,11 +40,11 @@ impl Licenses {
             Licenses::Unknown => write!(f, "Unknown")?,
             Licenses::Single(license) => write!(f, "{license}")?,
             Licenses::SingleWithExceptions { name, exceptions } => {
-                write!(f, "{name} WITH ",)?;
+                write!(f, "{name} WITH ")?;
                 let exceptions_str = exceptions.join(", ");
                 match exceptions.len() {
-                    1 => write!(f, "{}", exceptions_str)?,
-                    _ => write!(f, "({})", exceptions_str)?,
+                    1 => write!(f, "{exceptions_str}")?,
+                    _ => write!(f, "({exceptions_str})")?,
                 }
             },
             Licenses::Any { any } => {


### PR DESCRIPTION
This PR extends the license fields to allow specifying more complex licensing. It now allows nesting of values and specifying exceptions. The display of `Licenses` is changed to be in SPDX format and the metacheck command is updated to include checks for the new format.