### PR TITLE
Add exclude_paths field to PrebuildMeta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `meta-check` utility command, which checks the metadata of a given repository.
 - The `InvalidFiles` check in the verifier, which check directories for invalid files.
 - The `MissingDependencySymlinks` check in the verifier, which checks for missing or incorrect symlinks in the dependencies directory of a certain package.
-- The `prebuilds.toml` file in the metadata, to support more advanced specification of prebuilds for a package.
+- The `prebuilds.toml` file in the metadata, to support more advanced specification of prebuilds for a package:
+    - Prebuilds can now be shared by multiple targets.
+    - Prebuilds can now exclude certain paths of a package.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -120,9 +120,10 @@ The package version directory can contain an optional `prebuilds.toml` file. Thi
 #### Prebuild fields
 A prebuild is specified by using `[prebuild.<prebuild-id>]`. Each prebuild can have the fields listed below.
 
-| Field     | Explanation                                                                                     |
-| --------- | ----------------------------------------------------------------------------------------------- |
-| `targets` | Defines a list of [target bounds](#target-bounds) that the prebuild can be used for. (required) |
+| Field           | Explanation                                                                                     |
+| --------------- | ----------------------------------------------------------------------------------------------- |
+| `targets`       | Defines a list of [target bounds](#target-bounds) that the prebuild can be used for. (required) |
+| `exclude_paths` | Defines a list of paths that should not be included in the prebuild.                            |
 
 
 ### Target bounds

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -101,7 +101,7 @@ impl PackageArgs {
         };
 
         // Retrieve `prebuild_id` to use
-        let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+        let Some((prebuild_id, prebuild_meta)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
             error!(msg: "Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
             return;
         };
@@ -113,7 +113,8 @@ impl PackageArgs {
         let spinner_message = format!("Packaging {} to '{}'", package_id.style(), destination.display());
         let spinner = Spinner::new(spinner_message);
         spinner.show();
-        packager::package(config, package_id, destination, package_version.revisions.len() as u64, prebuild_id).unwrap_or_exit(1);
+        let revisions = package_version.revisions.len() as u64;
+        packager::package(config, package_id, destination, revisions, prebuild_id, prebuild_meta).unwrap_or_exit(1);
         spinner.finish();
     }
 }

--- a/src/integrity/repairer/package.rs
+++ b/src/integrity/repairer/package.rs
@@ -167,16 +167,16 @@ fn used_prebuild(
 ) -> Result<bool> {
     let prebuilds_list = manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
 
-    let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+    let Some((prebuild_id, prebuild_meta)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
         return Ok(false);
     };
 
     let revisions = package_version_meta.get_revision_count();
     match manager.get_prebuild_meta(repository_id, package_id, revisions, prebuild_id) {
-        Ok(prebuild_meta) => {
-            let compressed = packager::compress(install_path)?;
+        Ok(prebuild_file_meta) => {
+            let compressed = packager::compress(install_path, prebuild_meta)?;
             let checksum = Checksum::from_bytes(&compressed);
-            Ok(prebuild_meta.checksum == checksum)
+            Ok(prebuild_file_meta.checksum == checksum)
         },
         Err(RepositoryError::PrebuildNotFound { .. }) | Err(RepositoryError::RepositoryNotFoundError { .. }) => Ok(false),
         Err(e) => Err(e.into()),

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -129,14 +129,14 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     };
 
     // Retrieve `prebuild_id` to use
-    let Some((prebuild_id, _)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
+    let Some((prebuild_id, prebuild_meta)) = prebuilds_list.get_best_prebuild(&Target::current()) else {
         warning!("Cannot find prebuild to create for {}, skipping packaging.", package_id.style());
         return Ok(false);
     };
 
     let revision = package_version.revisions.len() as u64;
-    let prebuild_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, prebuild_id) {
-        Ok(prebuild_meta) => prebuild_meta,
+    let prebuild_file_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, prebuild_id) {
+        Ok(prebuild_file_meta) => prebuild_file_meta,
         Err(e) => {
             warning!(
                 "Cannot perform alterations check for package {}, because prebuild metadata cannot be read, skipping check",
@@ -148,10 +148,10 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     };
 
     let install_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
-    let compressed = packager::compress(&install_directory)?;
+    let compressed = packager::compress(&install_directory, prebuild_meta)?;
     let checksum = Checksum::from_bytes(&compressed);
 
-    Ok(checksum != prebuild_meta.checksum)
+    Ok(checksum != prebuild_file_meta.checksum)
 }
 
 /// Checks if the given packages in the register also exist in the package storage in the prefix directory.

--- a/src/packager.rs
+++ b/src/packager.rs
@@ -3,7 +3,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::{
     fs::{self, File},
-    io::{self, Write},
+    io::Write,
     path::{Path, PathBuf},
 };
 
@@ -12,10 +12,14 @@ use tar::{Builder, EntryType, Header};
 use thiserror::Error;
 
 use crate::{
+    cli::display::logging::debug,
     config::Config,
     installer::types::PackageId,
-    repositories::types::{Checksum, FileSize, PrebuildFileMeta},
-    utils::ioerror::{self, IOResultExt},
+    repositories::types::{Checksum, FileSize, PrebuildFileMeta, PrebuildMeta},
+    utils::{
+        io,
+        ioerror::{self, IOResultExt},
+    },
 };
 
 /// The errors that occur while packaging a package.
@@ -44,9 +48,19 @@ pub enum PackagerError {
 
 pub type Result<T> = core::result::Result<T, PackagerError>;
 
+/// Type alias for tar builder.
+type TarBuilder = Builder<GzEncoder<Vec<u8>>>;
+
 /// Packages a package to a given destination. If the destination doesn't exist, a `PackagerError::InvalidDestination` error is returned.
 /// The revision is used to create a unique filename for different package revisions.
-pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revisions: u64, prebuild_id: &str) -> Result<()> {
+pub fn package(
+    config: &Config,
+    package_id: &PackageId,
+    destination: &Path,
+    revisions: u64,
+    prebuild_id: &str,
+    prebuild_meta: &PrebuildMeta,
+) -> Result<()> {
     let install_directory = config.prefix_directory.join("packages").join(&package_id.name).join(package_id.version.to_string());
 
     // Return an error if the destination is not a directory
@@ -57,7 +71,7 @@ pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revi
     }
 
     // Compress the package
-    let compressed = compress(&install_directory)?;
+    let compressed = compress(&install_directory, prebuild_meta)?;
 
     // Calculate checksum and size for the compressed package
     let checksum = Checksum::from_bytes(&compressed);
@@ -83,13 +97,14 @@ pub fn package(config: &Config, package_id: &PackageId, destination: &Path, revi
 }
 
 /// Compresses a given directory using a normalized tar and returns the compressed bytes.
-pub fn compress(source_directory: &PathBuf) -> Result<Vec<u8>> {
+/// Uses `prebuild_meta` to determine directories to exclude.
+pub fn compress(source_directory: &PathBuf, prebuild_meta: &PrebuildMeta) -> Result<Vec<u8>> {
     let buffer = Vec::new();
     let encoder = GzBuilder::new().mtime(0).write(buffer, Compression::default());
 
     // Add the whole directory recursively
     let mut tar_builder = Builder::new(encoder);
-    create_normalized_tar(&mut tar_builder, &PathBuf::from("."), source_directory)?;
+    create_normalized_tar(&mut tar_builder, &PathBuf::from("."), source_directory, prebuild_meta)?;
     tar_builder.finish().map_err(PackagerError::TarFinishError)?;
 
     // Build tar into bytes vec
@@ -100,7 +115,8 @@ pub fn compress(source_directory: &PathBuf) -> Result<Vec<u8>> {
 }
 
 /// Creates a normalized tar by recursively adding files to the tar from a given directory while maintaining the directory structure.
-fn create_normalized_tar(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
+/// Uses `prebuild_meta` to determine directories to exclude.
+fn create_normalized_tar(builder: &mut TarBuilder, tar_path: &PathBuf, file_path: &PathBuf, prebuild_meta: &PrebuildMeta) -> Result<()> {
     add_directory(builder, tar_path, file_path)?;
 
     // Get directory entries
@@ -118,21 +134,28 @@ fn create_normalized_tar(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &P
         let filename = entry.file_name().expect("Expected a valid path termination");
         let filename = filename.to_str().ok_or(PackagerError::InvalidUnicodeError)?;
 
+        // If the path should be skipped, skipping adding entry.
+        let new_tar_path = tar_path.join(filename);
+        if prebuild_meta.exclude_paths.contains(&io::normalize_path(&new_tar_path)) {
+            debug!("Skipping adding {} to package tar", new_tar_path.display());
+            continue;
+        }
+
         // Add symlink to tar
         if entry.is_symlink() {
-            add_symlink(builder, &tar_path.join(filename), &entry)?;
+            add_symlink(builder, &new_tar_path, &entry)?;
             continue;
         }
 
         // Add directory to tar
         if entry.is_dir() {
-            create_normalized_tar(builder, &tar_path.join(filename), &entry)?;
+            create_normalized_tar(builder, &new_tar_path, &entry, prebuild_meta)?;
             continue;
         }
 
         // Add file to tar
         if entry.is_file() {
-            add_file(builder, &tar_path.join(filename), &entry)?;
+            add_file(builder, &new_tar_path, &entry)?;
             continue;
         }
     }
@@ -141,20 +164,20 @@ fn create_normalized_tar(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &P
 }
 
 /// Adds a normalized directory to a tar file.
-fn add_directory(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
+fn add_directory(builder: &mut TarBuilder, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
     // Create directory header
     let mut header = Header::new_ustar();
     header.set_entry_type(EntryType::Directory);
     normalize_header(&mut header, 0, tar_path, file_path)?;
 
     // Add directory to builder
-    builder.append_data(&mut header, tar_path, io::empty()).err_with_path("append dir to tar", file_path)?;
+    builder.append_data(&mut header, tar_path, std::io::empty()).err_with_path("append dir to tar", file_path)?;
 
     Ok(())
 }
 
 /// Adds a normalized file to a tar file.
-fn add_file(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
+fn add_file(builder: &mut TarBuilder, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
     let file = File::open(file_path).err_with_path("open", file_path)?;
     let metadata = file.metadata().err_with_path("read metadata of", file_path)?;
 
@@ -170,7 +193,7 @@ fn add_file(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_
 }
 
 /// Adds a normalized symlink to a tar file.
-fn add_symlink(builder: &mut Builder<GzEncoder<Vec<u8>>>, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
+fn add_symlink(builder: &mut TarBuilder, tar_path: &PathBuf, file_path: &PathBuf) -> Result<()> {
     let target = fs::read_link(file_path).err_with_path("read link", file_path)?;
 
     // Create symlink header

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -308,17 +308,18 @@ impl<'a> PortableRepoCreator<'a> {
 
         // Get id of the prebuild
         let prebuilds_list = self.repository_manager.read_prebuilds_list(repository_id, &package_id.name, &package_id.version)?;
-        let (prebuild_id, _) = prebuilds_list.get_best_prebuild(&Target::current()).ok_or(PortableRepoError::PrebuildNotFound {
-            package_id: package_id.clone(),
-        })?;
+        let (prebuild_id, prebuild_meta) =
+            prebuilds_list.get_best_prebuild(&Target::current()).ok_or(PortableRepoError::PrebuildNotFound {
+                package_id: package_id.clone(),
+            })?;
 
         // Get checksum
         let revision = package_version.get_revision_count();
-        let prebuild_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, prebuild_id) {
-            Ok(prebuild_meta) => prebuild_meta,
+        let prebuild_file_meta = match self.repository_manager.get_prebuild_meta(repository_id, package_id, revision, prebuild_id) {
+            Ok(prebuild_file_meta) => prebuild_file_meta,
             // Only try to package locally if the current target is the target we generate a portable repo for
             Err(RepositoryError::PrebuildNotFound { .. }) if self.target == Target::current() => {
-                packager::package(self.config, package_id, &destination, revision, prebuild_id)?;
+                packager::package(self.config, package_id, &destination, revision, prebuild_id, prebuild_meta)?;
                 return Ok(());
             },
             Err(e) => return Err(e.into()),
@@ -332,7 +333,7 @@ impl<'a> PortableRepoCreator<'a> {
         let prebuild_meta_name = format!("{package_id}-{revision}-{prebuild_id}.toml");
         let prebuild_meta_path = destination.join(prebuild_meta_name);
         fs::write(&prebuild_path, &prebuild).err_with_path("write", prebuild_path)?;
-        self.write_metadata(prebuild_meta, prebuild_meta_path, false)?;
+        self.write_metadata(prebuild_file_meta, prebuild_meta_path, false)?;
 
         Ok(())
     }

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -19,7 +19,6 @@ pub use self::package_target::PackageTarget;
 pub use self::package_version::PackageVersionMeta;
 
 pub use self::prebuilds::PrebuildFileMeta;
-#[expect(unused_imports)]
 pub use self::prebuilds::PrebuildMeta;
 pub use self::prebuilds::PrebuildsList;
 

--- a/src/repositories/types/prebuilds.rs
+++ b/src/repositories/types/prebuilds.rs
@@ -1,4 +1,7 @@
-use std::collections::{HashMap, HashSet};
+use std::{
+    collections::{HashMap, HashSet},
+    path::PathBuf,
+};
 
 use serde::{Deserialize, Serialize};
 
@@ -28,6 +31,9 @@ pub struct PrebuildsList {
 #[derive(Serialize, Deserialize, Debug)]
 pub struct PrebuildMeta {
     targets: Vec<TargetBounds>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub exclude_paths: Vec<PathBuf>,
 }
 
 impl PrebuildsList {
@@ -78,7 +84,13 @@ impl PrebuildsList {
                 addition: None,
                 version_intervals: VersionIntervals::default(),
             };
-            prebuilds.insert(architecture.to_string(), PrebuildMeta { targets: vec![target] });
+            prebuilds.insert(
+                architecture.to_string(),
+                PrebuildMeta {
+                    targets: vec![target],
+                    exclude_paths: Vec::new(),
+                },
+            );
         }
 
         Self { prebuilds }


### PR DESCRIPTION
This PR adds the `exclude_paths` field to the `prebuilds.toml` file. This field allows the exclude certain paths from packaging of a prebuild.

This is for example useful for `ca-certificates`, the generated `cert.pem` file can now be excluded in the prebuild.