### PR TITLE
Small refactors for prebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Change display of true and false values in the `info` and `search` commands.
 - Prebuilds now have a toml metadata file instead of the checksum file, containing the checksum and size of the prebuild.
 - The license field in the metadata now allows nesting and specifying exceptions.
+- The `prebuild_url` and `prebuild_provider` fields in the `repository.toml` file now represent a suggestion that needs to be added to the config in order to be used.
+- The `Alterations` verifier check is now enabled for packages that were installed from a prebuild.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -3,15 +3,15 @@
 ### `repository.toml`
 This file should be present in every Packit repository, it quickly describes what the repository is for.
 
-| Field                     | Explanation                                                         |
-| ------------------------- | ------------------------------------------------------------------- |
-| `name`                    | The name of the repository. (required)                              |
-| `description`             | A small description of the repository. (required)                   |
-| `license`                 | The license of the repository.                                      |
-| `maintainers`             | A list of maintainers of the repository. (required)                 |
-| `required_packit_version` | The minimum required Packit version to use the repository.          |
-| `prebuilds_url`           | Defines the url of the prebuilds repository for this repository.    |
-| `prebuilds_provider`      | Defines the provider of the prebuilds repository, defaults to `fs`. |
+| Field                     | Explanation                                                                   |
+| ------------------------- | ----------------------------------------------------------------------------- |
+| `name`                    | The name of the repository. (required)                                        |
+| `description`             | A small description of the repository. (required)                             |
+| `license`                 | The license of the repository.                                                |
+| `maintainers`             | A list of maintainers of the repository. (required)                           |
+| `required_packit_version` | The minimum required Packit version to use the repository.                    |
+| `prebuilds_url`           | Defines the url of the suggested prebuilds repository for this repository.    |
+| `prebuilds_provider`      | Defines the provider of the suggested prebuilds repository, defaults to `fs`. |
 
 
 ### `index.toml`

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -12,6 +12,7 @@ use crate::{
             aligned_print::PairAligner,
             ask_user,
             logging::{error, warning},
+            standard_print::DisplayOption,
             styled::Styled,
         },
     },
@@ -240,7 +241,7 @@ impl ConfigArgs {
             Some(provider) => provider,
             None => DEFAULT_METADATA_PROVIDER_ID,
         };
-        let repository = Repository::new(url, provider);
+        let mut repository = Repository::new(url, provider);
 
         // Try to connect to the repository
         let provider = provider::create_metadata_provider(&repository).unwrap_or_exit_msg("Unable to connect to repository", 1);
@@ -257,6 +258,21 @@ impl ConfigArgs {
             if ask_user("Are you sure you want to add this repository?", QuestionResponse::No).unwrap_or_exit(1).is_no_or_invalid() {
                 println!("Cancelling adding of repository.");
                 return;
+            }
+        }
+
+        // Check if repository suggests a prebuild url
+        if let Some(prebuilds_url) = &repo_meta.prebuilds_url {
+            println!("This repository suggests using the following prebuilds repository:");
+            let mut pair_aligner = PairAligner::new();
+            pair_aligner.add("Url", prebuilds_url);
+            pair_aligner.add("Provider", repo_meta.prebuilds_provider.display());
+            pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+
+            if ask_user("Do you want to add this prebuild repository too?", QuestionResponse::Yes).unwrap_or_exit(1).is_yes() {
+                println!("Adding prebuild repository to config.");
+                repository.prebuilds_url = Some(prebuilds_url.clone());
+                repository.prebuilds_provider = repo_meta.prebuilds_provider;
             }
         }
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -269,7 +269,7 @@ impl ConfigArgs {
             pair_aligner.add("Provider", repo_meta.prebuilds_provider.display());
             pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
 
-            if ask_user("Do you want to add this prebuild repository too?", QuestionResponse::Yes).unwrap_or_exit(1).is_yes() {
+            if ask_user("Do you want to add this prebuild repository?", QuestionResponse::Yes).unwrap_or_exit(1).is_yes() {
                 println!("Adding prebuild repository to config.");
                 repository.prebuilds_url = Some(prebuilds_url.clone());
                 repository.prebuilds_provider = repo_meta.prebuilds_provider;

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -12,7 +12,7 @@ use crate::{
     packager,
     platforms::Target,
     register::package_register::PackageRegister,
-    repositories::provider,
+    repositories::{provider, types::PrebuildsList},
     utils::unwrap_or_exit::UnwrapOrExit,
 };
 
@@ -92,8 +92,9 @@ impl PackageArgs {
         };
 
         // Request prebuilds list
-        let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version, &package_meta) {
-            Ok(prebuilds_list) => prebuilds_list,
+        let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+            Ok(Some(prebuilds_list)) => prebuilds_list,
+            Ok(None) => PrebuildsList::default(package_meta.supported_versions.keys()),
             Err(e) => {
                 error!(e, "Cannot read prebuild list for {}, skipping packaging.", package_id.style());
                 return;

--- a/src/config.rs
+++ b/src/config.rs
@@ -159,8 +159,8 @@ impl Config {
             let mut pair_aligner = PairAligner::new();
             pair_aligner.add("Url", &repo.url);
             pair_aligner.add("Provider", &repo.provider);
-            pair_aligner.add("Prebuilds provider", repo.prebuilds_provider.display());
             pair_aligner.add("Prebuilds url", repo.prebuilds_url.display());
+            pair_aligner.add("Prebuilds provider", repo.prebuilds_provider.display());
             pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         }
     }

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -22,7 +22,7 @@ use crate::{
     register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
     repositories::{
         provider::{self, create_metadata_provider},
-        types::{Checksum, PackageVersionMeta},
+        types::{Checksum, PackageVersionMeta, PrebuildsList},
     },
     utils::{io::directory_is_empty, ioerror::IOResultExt},
 };
@@ -119,8 +119,9 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
     };
 
     // Request prebuilds list
-    let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version, &package_meta) {
-        Ok(prebuilds_list) => prebuilds_list,
+    let prebuilds_list = match provider.read_prebuilds_list(&package_id.name, &package_id.version) {
+        Ok(Some(prebuilds_list)) => prebuilds_list,
+        Ok(None) => PrebuildsList::default(package_meta.supported_versions.keys()),
         Err(e) => {
             warning!("Cannot read prebuild list for {}, skipping check.", package_id.style());
             debug!(err: e, "Retrieving prebuilds list failed");

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -29,12 +29,7 @@ use crate::{
 
 /// Checks for alterations in the given packages using a checksum which is compared to the checksum from the prebuild.
 /// Returns an alteration issue or `None` if no packages can be found that are altered.
-#[expect(unused_variables, unreachable_code)]
 pub fn check_alterations(packages: &Vec<PackageId>, register: &PackageRegister, config: &Config) -> Result<Option<Issue>> {
-    // TODO: For now skip this check, because it will never work (yet)
-    return Ok(None);
-    warning!("This is an experimental check, issues from this check could be inaccurate.");
-
     let mut altered = Vec::new();
     for package_id in packages {
         if check_package_alterations(package_id, register, config)? {
@@ -51,11 +46,7 @@ pub fn check_alterations(packages: &Vec<PackageId>, register: &PackageRegister, 
 
 /// Checks for alterations in a single package using a checksum which is compared to the checksum from the prebuild.
 /// Returns true if the package was altered, false if not.
-#[expect(unused_variables, unreachable_code)]
 fn check_package_alterations(package_id: &PackageId, register: &PackageRegister, config: &Config) -> Result<bool> {
-    // TODO: For now skip this check, because it will never work (yet)
-    return Ok(false);
-
     // Get the installed package from the register
     let Some(package_version) = register.get_package_version(package_id) else {
         warning!(
@@ -65,11 +56,20 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         return Ok(false);
     };
 
+    // Skip check if package was not installed from a prebuild
+    if package_version.prebuilds_repository_url.is_none() {
+        debug!(
+            "Package {} was not installed from a prebuild, skipping alterations check",
+            package_id.style()
+        );
+        return Ok(false);
+    }
+
     let repository = Repository {
-        url: package_version.metadata_repository_url,
-        provider: package_version.metadata_repository_provider,
-        prebuilds_url: package_version.prebuilds_repository_url,
-        prebuilds_provider: package_version.prebuilds_repository_provider,
+        url: package_version.metadata_repository_url.clone(),
+        provider: package_version.metadata_repository_provider.clone(),
+        prebuilds_url: package_version.prebuilds_repository_url.clone(),
+        prebuilds_provider: package_version.prebuilds_repository_provider.clone(),
         disable_prebuilds: false,
     };
 

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -65,47 +65,22 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         return Ok(false);
     };
 
-    let repository = Repository::new(
-        &package_version.metadata_repository_url,
-        &package_version.metadata_repository_provider,
-    );
+    let repository = Repository {
+        url: package_version.metadata_repository_url,
+        provider: package_version.metadata_repository_provider,
+        prebuilds_url: package_version.prebuilds_repository_url,
+        prebuilds_provider: package_version.prebuilds_repository_provider,
+        disable_prebuilds: false,
+    };
 
+    // Create providers
     let Some(provider) = provider::create_metadata_provider(&repository) else {
         warning!("Cannot create metadata provider for {}, skipping check", package_id.style());
         return Ok(false);
     };
-
-    let mut prebuilds_url = package_version.prebuilds_repository_url.clone();
-    let mut prebuilds_provider = package_version.prebuilds_repository_provider.clone();
-
-    if prebuilds_url.is_none() {
-        let repo_metadata = match provider.read_repository_metadata() {
-            Ok(meta) => meta,
-            Err(e) => {
-                warning!("Cannot retrieve repository metadata for {}, skipping check", package_id.style());
-                debug!(err: e, "Retrieving repository metadata failed");
-                return Ok(false);
-            },
-        };
-
-        prebuilds_url = repo_metadata.prebuilds_url;
-        prebuilds_provider = repo_metadata.prebuilds_provider;
-    }
-
-    let Some(prebuilds_url) = &prebuilds_url else {
-        warning!(
-            "Cannot perform alterations check for package {}, because no prebuild repository for the package can be found, skipping check",
-            package_id.style()
-        );
+    let Some(prebuild_provider) = provider::create_prebuild_provider(&repository) else {
+        warning!("Cannot create prebuild provider for {}, skipping check", package_id.style());
         return Ok(false);
-    };
-
-    let prebuild_provider = match provider::create_prebuild_provider_from_url(prebuilds_url, prebuilds_provider) {
-        Some(provider) => provider,
-        None => {
-            warning!("Cannot create prebuild provider for {}, skipping check", package_id.style());
-            return Ok(false);
-        },
     };
 
     // Request package metadata

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -324,8 +324,13 @@ impl<'a> RepositoryManager<'a> {
 
     /// Reads the list of prebuilds that can be generated for the given version of the package.
     pub fn read_prebuilds_list(&self, repository_id: &str, package: &PackageName, version: &Version) -> Result<PrebuildsList> {
-        let package_meta = self.read_repo_package(repository_id, package)?;
-        self.get_metadata_provider(repository_id)?.read_prebuilds_list(package, version, &package_meta)
+        match self.get_metadata_provider(repository_id)?.read_prebuilds_list(package, version)? {
+            Some(list) => Ok(list),
+            None => {
+                let package_meta = self.read_repo_package(repository_id, package)?;
+                Ok(PrebuildsList::default(package_meta.supported_versions.keys()))
+            },
+        }
     }
 
     /// Reads a file of the given package from the given repository.

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -75,7 +75,7 @@ impl<'a> RepositoryManager<'a> {
             }
 
             // Try to create the prebuild provider
-            let prebuild_provider = provider::create_prebuild_provider(repository, &repository_meta);
+            let prebuild_provider = provider::create_prebuild_provider(repository);
             let Some(prebuild_provider) = prebuild_provider else {
                 warning!("Cannot create prebuild provider for repository '{id}'.");
                 continue;

--- a/src/repositories/metadata/filesystem.rs
+++ b/src/repositories/metadata/filesystem.rs
@@ -47,14 +47,14 @@ impl MetadataProvider for FileSystemMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList> {
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<Option<PrebuildsList>> {
         let path = self.path.join("packages").join(package.to_string()).join(version.to_string()).join("prebuilds.toml");
         if !path.exists() {
-            return Ok(PrebuildsList::default(package_meta.supported_versions.keys()));
+            return Ok(None);
         }
 
         let data = Self::read_file_string(path)?;
-        Ok(toml::de::from_str(&data)?)
+        Ok(Some(toml::de::from_str(&data)?))
     }
 
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {

--- a/src/repositories/metadata/web.rs
+++ b/src/repositories/metadata/web.rs
@@ -45,11 +45,11 @@ impl MetadataProvider for WebMetadataProvider {
         Ok(toml::de::from_str(&data)?)
     }
 
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList> {
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<Option<PrebuildsList>> {
         let response = requests::get(format!("{}/packages/{package}/{version}/prebuilds.toml", self.url))?;
 
         if response.status() == StatusCode::NOT_FOUND {
-            return Ok(PrebuildsList::default(package_meta.supported_versions.keys()));
+            return Ok(None);
         }
 
         // Return an error if something went wrong with the request (apart from not found error)
@@ -57,7 +57,7 @@ impl MetadataProvider for WebMetadataProvider {
             return Err(RepositoryError::UnsuccessfulRequest(response.status()));
         }
 
-        Ok(toml::de::from_str(&response.text()?)?)
+        Ok(Some(toml::de::from_str(&response.text()?)?))
     }
 
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>> {

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -143,8 +143,8 @@ impl<'a> PortableRepoCreator<'a> {
             required_packit_version: current_packit_version(),
             maintainers: vec![PORTABLE_REPO_MAINTAINER.into()],
             license: Licenses::Unknown,
-            // prebuilds_url: None,
-            // prebuilds_provider: None,
+            prebuilds_url: None,
+            prebuilds_provider: None,
         };
         self.write_metadata(repository_meta, destination.join("repository.toml"), false)?;
 

--- a/src/repositories/portable_repo.rs
+++ b/src/repositories/portable_repo.rs
@@ -143,8 +143,8 @@ impl<'a> PortableRepoCreator<'a> {
             required_packit_version: current_packit_version(),
             maintainers: vec![PORTABLE_REPO_MAINTAINER.into()],
             license: Licenses::Unknown,
-            prebuilds_url: None,
-            prebuilds_provider: None,
+            // prebuilds_url: None,
+            // prebuilds_provider: None,
         };
         self.write_metadata(repository_meta, destination.join("repository.toml"), false)?;
 

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -33,7 +33,8 @@ pub trait MetadataProvider {
     fn read_package_version(&self, package: &PackageName, version: &Version) -> Result<PackageVersionMeta>;
 
     /// Reads the list of prebuilds that can be generated for the given version of the package.
-    fn read_prebuilds_list(&self, package: &PackageName, version: &Version, package_meta: &PackageMeta) -> Result<PrebuildsList>;
+    /// Returns `None` if the prebuilds list does not exist.
+    fn read_prebuilds_list(&self, package: &PackageName, version: &Version) -> Result<Option<PrebuildsList>>;
 
     /// Reads the requested file from the repository as bytes.
     fn read_file_bytes(&self, package: &PackageName, file_path: &str) -> Result<Option<Bytes>>;

--- a/src/repositories/provider.rs
+++ b/src/repositories/provider.rs
@@ -61,39 +61,19 @@ pub fn create_metadata_provider(repository: &Repository) -> Option<Box<dyn Metad
     }
 }
 
-/// Creates a prebuild repository provider for the given repository from its url and provider.
-pub fn create_prebuild_provider_from_url(url: &str, provider: Option<String>) -> Option<Box<dyn PrebuildProvider>> {
-    let provider = provider.unwrap_or(DEFAULT_PREBUILD_PROVIDER_ID.into());
+/// Creates a prebuild repository provider for the given repository.
+pub fn create_prebuild_provider(repository: &Repository) -> Option<Box<dyn PrebuildProvider>> {
+    let Some(url) = &repository.prebuilds_url else {
+        return None;
+    };
 
-    match provider.as_str() {
+    let provider = repository.prebuilds_provider.as_deref().unwrap_or(DEFAULT_PREBUILD_PROVIDER_ID);
+
+    match provider {
         FILESYSTEM_PREBUILD_PROVIDER_ID => boxed_prebuild(FileSystemPrebuildProvider::from_url(url)),
         WEB_PREBUILD_PROVIDER_ID => boxed_prebuild(WebPrebuildProvider::from_url(url)),
         _ => None,
     }
-}
-
-/// Creates a prebuild repository provider for the given repository.
-pub fn create_prebuild_provider(repository: &Repository, repo_metadata: &RepositoryMeta) -> Option<Box<dyn PrebuildProvider>> {
-    let (url, provider) = get_prebuild_repository_info(repository, repo_metadata)?;
-
-    create_prebuild_provider_from_url(&url, Some(provider))
-}
-
-/// Gets pre-build info from a repositiry. Returns a tuple with the pre-build url and the pre-build provider.
-fn get_prebuild_repository_info(repository: &Repository, repo_metadata: &RepositoryMeta) -> Option<(String, String)> {
-    if let Some(url) = &repository.prebuilds_url {
-        let provider = repository.prebuilds_provider.clone().unwrap_or(DEFAULT_PREBUILD_PROVIDER_ID.into());
-
-        return Some((url.clone(), provider));
-    }
-
-    if let Some(url) = &repo_metadata.prebuilds_url {
-        let provider = repo_metadata.prebuilds_provider.clone().unwrap_or(DEFAULT_PREBUILD_PROVIDER_ID.into());
-
-        return Some((url.clone(), provider));
-    }
-
-    None
 }
 
 /// Maps an `Option<MetadataProvider>` to `Option<Box<MetadataProvider>>`.

--- a/src/repositories/types/repository.rs
+++ b/src/repositories/types/repository.rs
@@ -13,10 +13,12 @@ pub struct RepositoryMeta {
 
     #[serde(skip_serializing_if = "Licenses::is_unknown", default)]
     pub license: Licenses,
-    // TODO: reintroduce as suggestions
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub prebuilds_url: Option<String>,
 
-    // #[serde(skip_serializing_if = "Option::is_none")]
-    // pub prebuilds_provider: Option<String>,
+    /// Specifies a suggestion of a prebuild repository to use with this metadata repository.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prebuilds_url: Option<String>,
+
+    /// Specifies a suggestion of a prebuild repository to use with this metadata repository.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prebuilds_provider: Option<String>,
 }

--- a/src/repositories/types/repository.rs
+++ b/src/repositories/types/repository.rs
@@ -13,10 +13,10 @@ pub struct RepositoryMeta {
 
     #[serde(skip_serializing_if = "Licenses::is_unknown", default)]
     pub license: Licenses,
+    // TODO: reintroduce as suggestions
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub prebuilds_url: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prebuilds_url: Option<String>,
-
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prebuilds_provider: Option<String>,
+    // #[serde(skip_serializing_if = "Option::is_none")]
+    // pub prebuilds_provider: Option<String>,
 }


### PR DESCRIPTION
This PR refactors several small things that use prebuilds:
- The `read_prebuilds_list` method now does not require PackageMeta anymore, it returns an Option and the caller needs to call `PrebuildsList::default`.
- The `prebuilds_url` and `prebuilds_provider` fields in the `repository.toml` file now are used as a suggestion, when adding a repository the user is prompted for using this prebuilds repository.
- The package alteration check is now enabled for packages that were installed from a prebuild.