### PR TITLE
Remove readonly check from the is_writable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix MSVC detection not finding VS Build Tools.
 - Fix "check length methods" from the verifier returning wrong length in case of an incomplete check list.
 - Fix portable repositories generating an invalid prebuild repository structure.
+- Fix the writable check using the `readonly` method to check write permissions.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/install.bat
+++ b/install.bat
@@ -220,6 +220,9 @@ echo Initializing Packit
 if ERRORLEVEL 1 goto cleanup
 echo Initializing Packit successful
 
+REM Remove readonly attributes on Packit directories
+attrib -R /S /D "*"
+
 REM Make sure that packit words
 echo Testing Packit install
 "%PREFIX_DIR%\bin\pit.exe" --version 2>nul >nul

--- a/src/platforms/permissions.rs
+++ b/src/platforms/permissions.rs
@@ -26,15 +26,8 @@ pub fn is_writable(path: &PathBuf) -> Result<bool> {
         return Ok(false);
     }
 
-    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
-    let permissions = metadata.permissions();
-
-    // Check if path is read only
-    if permissions.readonly() {
-        return Ok(false);
-    }
-
     // Use platform specific writable checks
+    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
     platform::is_writable(path, metadata)
 }
 


### PR DESCRIPTION
This PR removed the readonly check from the `is_writable` method, because it checks writability based on file attributes instead of ACL's on windows. And on Unix systems it doesn't check if the current user is in a group which has write access.
The `install.bat` now also makes sure not to have any Packit files with the `readonly` attribute.