### PR TITLE
Remove readonly check from the is_writable method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix MSVC detection not finding VS Build Tools.
 - Fix "check length methods" from the verifier returning wrong length in case of an incomplete check list.
 - Fix portable repositories generating an invalid prebuild repository structure.
-- Fix the writable check using the `readonly` method to check write permissions.
+- Fix writable checks by ignoring the readonly attribute on Windows.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix MSVC detection not finding VS Build Tools.
 - Fix "check length methods" from the verifier returning wrong length in case of an incomplete check list.
 - Fix portable repositories generating an invalid prebuild repository structure.
+- Fix the writable check using the `readonly` method to check write permissions.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/install.bat
+++ b/install.bat
@@ -220,6 +220,9 @@ echo Initializing Packit
 if ERRORLEVEL 1 goto cleanup
 echo Initializing Packit successful
 
+REM Remove readonly attributes on Packit directories
+attrib -R /S /D "*"
+
 REM Make sure that packit words
 echo Testing Packit install
 "%PREFIX_DIR%\bin\pit.exe" --version 2>nul >nul

--- a/src/platforms/permissions.rs
+++ b/src/platforms/permissions.rs
@@ -26,15 +26,8 @@ pub fn is_writable(path: &PathBuf) -> Result<bool> {
         return Ok(false);
     }
 
-    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
-    let permissions = metadata.permissions();
-
-    // Check if path is read only
-    if permissions.readonly() {
-        return Ok(false);
-    }
-
     // Use platform specific writable checks
+    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
     platform::is_writable(path, metadata)
 }
 

--- a/src/platforms/permissions.rs
+++ b/src/platforms/permissions.rs
@@ -27,8 +27,7 @@ pub fn is_writable(path: &PathBuf) -> Result<bool> {
     }
 
     // Use platform specific writable checks
-    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
-    platform::is_writable(path, metadata)
+    platform::is_writable(path)
 }
 
 /// Sets the permissions of packit files.

--- a/src/platforms/permissions/unix.rs
+++ b/src/platforms/permissions/unix.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{
     ffi::CString,
-    fs::{self, Metadata, Permissions},
+    fs::{self, Permissions},
     os::unix::{
         self,
         fs::{MetadataExt, PermissionsExt},
@@ -27,7 +27,8 @@ pub enum PlatformError {
 }
 
 /// Checks if a directory is writeable. Returns true if it is, false otherwise.
-pub(super) fn is_writable(_path: &PathBuf, metadata: Metadata) -> Result<bool> {
+pub(super) fn is_writable(path: &PathBuf) -> Result<bool> {
+    let metadata = fs::metadata(path).err_with_path("read metadata of", path)?;
     let mode = metadata.mode();
 
     // Check if path is writable for everyone

--- a/src/platforms/permissions/windows.rs
+++ b/src/platforms/permissions/windows.rs
@@ -112,7 +112,7 @@ pub enum PlatformError {
 
 /// Checks if the given directory is writable by the current user. Returns true if it is, false if not.
 /// Could return a `PlatformError::SecurityInfoError` or a `PlatformError::WindowsAPIError` error.
-pub fn is_writable(path: &PathBuf, _metadata: Metadata) -> Result<bool> {
+pub fn is_writable(path: &PathBuf) -> Result<bool> {
     let wide_path_buffer = path_to_pcwstr(path);
     let wide_path = PCWSTR(wide_path_buffer.as_ptr());
     let (_, security_descriptor) = get_security_info(wide_path)?;


### PR DESCRIPTION
This PR removed the `readonly` check from the `is_writable` method, because it checks writability based on file attributes instead of ACL's on windows. And on Unix systems it doesn't check if the current user is in a group which has write access.
The `install.bat` now also makes sure not to have any Packit files with the readonly attribute.