### PR TITLE
Add skip test flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `prebuilds.toml` file in the metadata, to support more advanced specification of prebuilds for a package:
     - Prebuilds can now be shared by multiple targets.
     - Prebuilds can now exclude certain paths of a package.
+- The `skip-test` and `skip-build-test` flags in the `install` command, to skip Packit tests or skip build tests.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Packit repository is licensed under the GNU General Public License v3.0. See
 ## Usage
 The general usage of Packit is: `pit <COMMAND>`.
 
-#### `pit install <PACKAGE-NAME>[@<VERSION>] ... [--build] [--build-all] [--keep-build] [--skip-symlinking] [--skip-active] [--verbose]`
+#### `pit install <PACKAGE-NAME>[@<VERSION>] ... [--build] [--build-all] [--keep-build] [--skip-symlinking] [--skip-active] [--verbose] [--skip-test] [--skip-build-test]`
 Installs the specified packages, if a version is given that version will be installed, if not the latest available version will be installed. Multiple packages can be specified by entering multiple names, split by a space.
 <br>
 If the `--build` option is given, the package is build from source, instead of installing a prebuild version.
@@ -57,6 +57,8 @@ If the `--build-all` option is given, the package and all its dependencies are b
 If the `--keep-build` option is given, the build dependencies will not be deleted after building.
 If the `--skip-symlinking` option is enabled, the package is not symlinked into the /bin, /lib, /share, etc. directories.
 If the `--skip-active` option is enabled, the package is not set to active and the current active version is kept. If there is no current active version, this flag is ignored and the package is set to active.
+If the `--skip-test` option is enabled, Packit tests are skipped.
+If the `--skip-build-test` option is enabled, build tests are skipped.
 If the `--verbose` option is given, extra verbose output is shown, like build output.
 
 #### `pit uninstall <PACKAGE-NAME>[@<VERSION>] ...`

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -225,6 +225,7 @@ Scripts get certain environment variables from Packit:
 | `PACKIT_PACKAGE_VERSION`           | The version of the package the script belongs to.                                          |
 | `PACKIT_PACKAGE_DEPENDENCIES_PATH` | The path containing symlinks to all dependencies of the package.                           |
 | `PACKIT_VERBOSE`                   | True (1) if verbose output is enabled, false (0) otherwise.                                |
+| `PACKIT_SKIP_BUILD_TEST`           | True (1) if the build tests should be skipped, false (0) otherwise.                        |
 
 Please note that the build script output is only shown to the user when the verbose mode is turned on. All other scripts always show their output, the output of these scripts should thus be clean. Optional verbose output can be printed when the `PACKIT_VERBOSE` is `1`.
 

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -35,16 +35,24 @@ pub struct Builder<'a> {
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     verbose: bool,
+    skip_build_test: bool,
 }
 
 impl<'a> Builder<'a> {
     /// Creates new builder
-    pub fn new(config: &'a Config, register: &'a mut PackageRegister, repository_manager: &'a RepositoryManager, verbose: bool) -> Self {
+    pub fn new(
+        config: &'a Config,
+        register: &'a mut PackageRegister,
+        repository_manager: &'a RepositoryManager,
+        verbose: bool,
+        skip_build_test: bool,
+    ) -> Self {
         Self {
             config,
             register,
             repository_manager,
             verbose,
+            skip_build_test,
         }
     }
 
@@ -162,7 +170,15 @@ impl<'a> Builder<'a> {
         let script_path = install_meta.version_metadata.get_build_script_path(&install_meta.target_bounds)?;
         let script_path = scripts::download_script(self.repository_manager, &script_path, package_name, &install_meta.repository_id)?
             .ok_or(ScriptError::ScriptNotFound("build".into()))?;
-        let script_data = ScriptData::new(&script_path, &destination_dir, &package_id, self.config, &script_args, self.verbose);
+        let script_data = ScriptData::new(
+            &script_path,
+            &destination_dir,
+            &package_id,
+            self.config,
+            &script_args,
+            self.verbose,
+            self.skip_build_test,
+        );
 
         // Show build spinner
         if !self.verbose {

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -170,15 +170,7 @@ impl<'a> Builder<'a> {
         let script_path = install_meta.version_metadata.get_build_script_path(&install_meta.target_bounds)?;
         let script_path = scripts::download_script(self.repository_manager, &script_path, package_name, &install_meta.repository_id)?
             .ok_or(ScriptError::ScriptNotFound("build".into()))?;
-        let script_data = ScriptData::new(
-            &script_path,
-            &destination_dir,
-            &package_id,
-            self.config,
-            &script_args,
-            self.verbose,
-            self.skip_build_test,
-        );
+        let script_data = ScriptData::new(&script_path, &destination_dir, &package_id, self.config, &script_args, self.verbose);
 
         // Show build spinner
         if !self.verbose {
@@ -188,7 +180,7 @@ impl<'a> Builder<'a> {
             spinner.show();
 
             // Run build script
-            scripts::run_build_script(&script_data, &build_directory, env)?;
+            scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test)?;
 
             // Finish build spinner
             spinner.finish();
@@ -196,7 +188,7 @@ impl<'a> Builder<'a> {
             println!("Executing build script of {}", package_id.style());
 
             // Run build script
-            scripts::run_build_script(&script_data, &build_directory, env)?;
+            scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test)?;
         }
 
         // Patch binaries

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -6,7 +6,12 @@ use std::process::exit;
 use crate::{
     cli::{
         commands::HandleCommand,
-        display::{deprecation, logging::error, not_found, standard_print, styled::Styled},
+        display::{
+            deprecation,
+            logging::{error, warning},
+            not_found, standard_print,
+            styled::Styled,
+        },
         parameter_checks,
     },
     config::Config,
@@ -50,7 +55,11 @@ pub struct InstallArgs {
     #[arg(short, long, default_value = "false")]
     verbose: bool,
 
-    /// True to skip the build tests (note that these are not the same as the tests done after installation)
+    /// True to skip the Packit tests
+    #[arg(long, default_value = "false")]
+    skip_test: bool,
+
+    /// True to skip the build tests (note that these are not the same as the Packit tests)
     #[arg(long, default_value = "false")]
     skip_build_test: bool,
 }
@@ -97,13 +106,18 @@ impl HandleCommand for InstallArgs {
             InstallType::Prebuild
         };
 
+        if self.skip_test {
+            warning!("Packit tests are skipped, because the `--skip-test` flag is enabled");
+        }
+
         let installer_options = InstallerOptions::default()
             .install_type(install_type)
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
             .keep_build(self.keep_build)
             .verbose(self.verbose)
-            .skip_build_test(self.skip_build_test);
+            .skip_build_test(self.skip_build_test)
+            .skip_test(self.skip_test);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -49,6 +49,10 @@ pub struct InstallArgs {
     /// True if verbose information should be shown
     #[arg(short, long, default_value = "false")]
     verbose: bool,
+
+    /// True to skip the build tests (note that these are not the same as the tests done after installation)
+    #[arg(long, default_value = "false")]
+    skip_build_test: bool,
 }
 
 impl HandleCommand for InstallArgs {
@@ -98,7 +102,8 @@ impl HandleCommand for InstallArgs {
             .skip_symlinking(self.skip_symlinking)
             .skip_active(self.skip_active)
             .keep_build(self.keep_build)
-            .verbose(self.verbose);
+            .verbose(self.verbose)
+            .skip_build_test(self.skip_build_test);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -238,7 +238,7 @@ impl<'a> Installer<'a> {
 
         self.determine_active(install_meta, &package_id, target)?;
 
-        // Skip the test if the skip test option is true
+        // Only run the test if the skip test option is false
         if !self.options.skip_test {
             self.execute_test(&package_id, install_meta, &install_directory, &script_args, target)?;
         }
@@ -267,7 +267,6 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
-            self.options.skip_build_test,
         );
 
         // Only show a spinner when not verbose
@@ -364,7 +363,6 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
-            self.options.skip_build_test,
         );
 
         // Only show a spinner when not verbose
@@ -470,7 +468,6 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
-            self.options.skip_build_test,
         );
 
         // Download external files necessary for testing
@@ -783,7 +780,6 @@ impl<'a> Installer<'a> {
             self.config,
             &script_args,
             self.options.verbose,
-            self.options.skip_build_test,
         );
 
         // Only show spinner when not verbose

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -238,7 +238,10 @@ impl<'a> Installer<'a> {
 
         self.determine_active(install_meta, &package_id, target)?;
 
-        self.execute_test(&package_id, install_meta, &install_directory, &script_args, target)?;
+        // Skip the test if the skip test option is true
+        if !self.options.skip_test {
+            self.execute_test(&package_id, install_meta, &install_directory, &script_args, target)?;
+        }
 
         Ok(())
     }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -205,8 +205,14 @@ impl<'a> Installer<'a> {
                 let revision = install_meta.version_metadata.get_revision_count();
                 self.download_prebuild(&install_meta.repository_id, &package_id, revision, &install_directory)?
             },
-            false => Builder::new(self.config, self.register, self.repository_manager, self.options.verbose)
-                .build(install_meta, &install_directory)?,
+            false => Builder::new(
+                self.config,
+                self.register,
+                self.repository_manager,
+                self.options.verbose,
+                self.options.skip_build_test,
+            )
+            .build(install_meta, &install_directory)?,
         }
 
         // Set correct permissions for the installed package
@@ -258,6 +264,7 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
+            self.options.skip_build_test,
         );
 
         // Only show a spinner when not verbose
@@ -354,6 +361,7 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
+            self.options.skip_build_test,
         );
 
         // Only show a spinner when not verbose
@@ -459,6 +467,7 @@ impl<'a> Installer<'a> {
             self.config,
             script_args,
             self.options.verbose,
+            self.options.skip_build_test,
         );
 
         // Download external files necessary for testing
@@ -771,6 +780,7 @@ impl<'a> Installer<'a> {
             self.config,
             &script_args,
             self.options.verbose,
+            self.options.skip_build_test,
         );
 
         // Only show spinner when not verbose

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -8,6 +8,7 @@ pub struct InstallerOptions {
     pub skip_active: bool,
     pub keep_build: bool,
     pub verbose: bool,
+    pub skip_test: bool,
     pub skip_build_test: bool,
 }
 
@@ -20,6 +21,7 @@ impl Default for InstallerOptions {
             skip_active: false,
             keep_build: false,
             verbose: false,
+            skip_test: false,
             skip_build_test: false,
         }
     }
@@ -53,6 +55,12 @@ impl InstallerOptions {
     /// Sets the verbose field.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    /// Sets the `skip_test` field.
+    pub fn skip_test(mut self, skip: bool) -> Self {
+        self.skip_test = skip;
         self
     }
 

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -52,7 +52,7 @@ impl InstallerOptions {
         self
     }
 
-    /// Sets the verbose field.
+    /// Sets the `verbose` field.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
         self

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -8,6 +8,7 @@ pub struct InstallerOptions {
     pub skip_active: bool,
     pub keep_build: bool,
     pub verbose: bool,
+    pub skip_build_test: bool,
 }
 
 impl Default for InstallerOptions {
@@ -19,6 +20,7 @@ impl Default for InstallerOptions {
             skip_active: false,
             keep_build: false,
             verbose: false,
+            skip_build_test: false,
         }
     }
 }
@@ -48,8 +50,15 @@ impl InstallerOptions {
         self
     }
 
+    /// Sets the verbose field.
     pub fn verbose(mut self, verbose: bool) -> Self {
         self.verbose = verbose;
+        self
+    }
+
+    /// Sets the `skip_build_test` field.
+    pub fn skip_build_test(mut self, skip: bool) -> Self {
+        self.skip_build_test = skip;
         self
     }
 }

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -107,6 +107,7 @@ pub struct ScriptData<'a> {
     config: &'a Config,
     args: &'a HashMap<&'a str, &'a str>,
     verbose: bool,
+    skip_build_test: bool,
 }
 
 impl<'a> ScriptData<'a> {
@@ -118,6 +119,7 @@ impl<'a> ScriptData<'a> {
         config: &'a Config,
         args: &'a HashMap<&str, &str>,
         verbose: bool,
+        skip_build_test: bool,
     ) -> Self {
         Self {
             path,
@@ -126,6 +128,7 @@ impl<'a> ScriptData<'a> {
             config,
             args,
             verbose,
+            skip_build_test,
         }
     }
 }
@@ -197,7 +200,8 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         .env("PACKIT_PACKAGE_PATH", package_install_path)
         .env("PACKIT_PACKAGE_VERSION", script_data.package_id.version.to_string())
         .env("PACKIT_PACKAGE_DEPENDENCIES_PATH", &package_dependencies_path)
-        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" });
+        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" })
+        .env("PACKIT_SKIP_BUILD_TEST", if script_data.skip_build_test { "1" } else { "0" });
 
     // Only display build logging if verbose is enabled, otherwise create combined pipe for reading
     let mut output = None;

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -107,7 +107,6 @@ pub struct ScriptData<'a> {
     config: &'a Config,
     args: &'a HashMap<&'a str, &'a str>,
     verbose: bool,
-    skip_build_test: bool,
 }
 
 impl<'a> ScriptData<'a> {
@@ -119,7 +118,6 @@ impl<'a> ScriptData<'a> {
         config: &'a Config,
         args: &'a HashMap<&str, &str>,
         verbose: bool,
-        skip_build_test: bool,
     ) -> Self {
         Self {
             path,
@@ -128,7 +126,6 @@ impl<'a> ScriptData<'a> {
             config,
             args,
             verbose,
-            skip_build_test,
         }
     }
 }
@@ -141,8 +138,10 @@ pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Re
 
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv) -> Result<()> {
-    run_script(script_data, run_dir, build_env.try_into()?, script_data.verbose)
+pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, skip_build_test: bool) -> Result<()> {
+    let mut env: Environment = build_env.try_into()?;
+    env.insert_var("PACKIT_SKIP_BUILD_TEST", if skip_build_test { "1" } else { "0" });
+    run_script(script_data, run_dir, env, script_data.verbose)
 }
 
 /// Runs the given post install script, in the package install directory.
@@ -200,8 +199,7 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         .env("PACKIT_PACKAGE_PATH", package_install_path)
         .env("PACKIT_PACKAGE_VERSION", script_data.package_id.version.to_string())
         .env("PACKIT_PACKAGE_DEPENDENCIES_PATH", &package_dependencies_path)
-        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" })
-        .env("PACKIT_SKIP_BUILD_TEST", if script_data.skip_build_test { "1" } else { "0" });
+        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" });
 
     // Only display build logging if verbose is enabled, otherwise create combined pipe for reading
     let mut output = None;

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -662,6 +662,7 @@ fn check_package_test(package_id: &PackageId, register: &PackageRegister, config
         config,
         &script_args,
         false,
+        false,
     );
 
     // Get the external test files

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -662,7 +662,6 @@ fn check_package_test(package_id: &PackageId, register: &PackageRegister, config
         config,
         &script_args,
         false,
-        false,
     );
 
     // Get the external test files


### PR DESCRIPTION
This PR adds two new flags to the `install` command, `--skip-test` to skip a Packit test and `--skip-build-test` to skip build script tests.