### PR TITLE
Create a '--tree' flag on the search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Prebuilds can now be shared by multiple targets.
     - Prebuilds can now exclude certain paths of a package.
 - The `skip-test` and `skip-build-test` flags in the `install` command, to skip Packit tests or skip build tests.
+- The `--tree` flag in the `search` command, to show the tree of a given package.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ Uninstalls the specified packages, if a version is given that version will be un
 #### `pit list [--updatables] [--active]`
 Lists all the installed packages. If the `--updatables` flag is specified, all updatable packages are listed. If the `--active` flag is specified, only the active package versions are listed.
 
-#### `pit search <QUERY> [--regex] [--verbose]`
-Searches a package with `<QUERY>`. If `--regex` is not enabled, the query is expected to be `<PACKAGE-NAME>[@<VERSION>]` and information based on the package metadata is shown, if the version is given that specific version is searched for. If `--regex` is given, all packages that match the given regular expression query are shown. The `--verbose` flag can be used to show more output.
+#### `pit search <QUERY> [--regex] [--verbose] [--tree]`
+Searches a package with `<QUERY>`. If `--regex` is not enabled, the query is expected to be `<PACKAGE-NAME>[@<VERSION>]` and information based on the package metadata is shown, if the version is given that specific version is searched for. If `--regex` is given, all packages that match the given regular expression query are shown. The `--verbose` flag can be used to show more output. The `--tree` flag can be used to show the tree of a package. Note that the package version also needs to be given in this case and that the latest version is assumed for the dependencies.
 
 #### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
 Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and `--new-version` cannot be used). If multiple versions of the same package are installed, the latest installed version is assumed. The `--new-version` flag can be used to specify the new version to install. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -141,7 +141,7 @@ impl SearchArgs {
     /// Fails if the given query is not a valid `OptionalPackageId`.
     fn search(&self) {
         // Get the optional id
-        let message = "The given search query isn't a valid package.";
+        let message = "The given search query isn't a valid package. For regex use `--regex`.";
         let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
 
         match optional_id.versioned() {

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -2,7 +2,11 @@
 use clap::Args;
 use colored::Colorize;
 use regex::Regex;
-use std::{cmp::max, collections::HashSet, str::FromStr};
+use std::{
+    cmp::max,
+    collections::{HashSet, VecDeque},
+    str::FromStr,
+};
 
 use crate::{
     cli::{
@@ -21,12 +25,16 @@ use crate::{
     installer::types::{OptionalPackageId, PackageId, PackageName},
     platforms::Target,
     repositories::{error::RepositoryError, manager::RepositoryManager},
-    utils::unwrap_or_exit::UnwrapOrExit,
+    utils::{
+        tree::{Node, Tree},
+        unwrap_or_exit::UnwrapOrExit,
+    },
 };
 
 /// Searches a package with `<PACKAGE-NAME>[@<PACKAGE-VERSION]` and shows information based on the package (version) metadata.
 /// Alternatively, when the regex flag is true, it uses the regex query to search for packages which match the regex.
 /// Package version specific information is shown when the version is given, otherwise package specific information is shown.
+/// Note that the version is necessary if `--tree` is specified.
 #[derive(Args, Debug)]
 pub struct SearchArgs {
     /// The query to search with (can be an `OptionalPackageId` or regex string)
@@ -36,6 +44,11 @@ pub struct SearchArgs {
     #[arg(long, default_value = "false")]
     regex: bool,
 
+    /// True to show the tree of a package
+    /// Note that the tree assumes the latest versions
+    #[arg(long, default_value = "false", conflicts_with = "regex")]
+    tree: bool,
+
     /// True if verbose information should be shown
     #[arg(short, long, default_value = "false")]
     verbose: bool,
@@ -44,8 +57,13 @@ pub struct SearchArgs {
 impl HandleCommand for SearchArgs {
     /// Handles the search command, searching a certain package.
     fn handle(&self) {
-        match self.regex {
-            true => self.regex_search(),
+        if self.regex {
+            self.regex_search();
+            return;
+        }
+
+        match self.tree {
+            true => self.search_tree(),
             false => self.search(),
         }
     }
@@ -78,11 +96,52 @@ impl SearchArgs {
         display::print_grid(&matches.into_iter().map_styled().collect());
     }
 
+    /// Searches the tree of a given package, always using the latest version for the current target of each dependency.
+    /// Fails if the given query is not a valid `PackageId`.
+    fn search_tree(&self) {
+        // Get the package id
+        let message = "The given search query isn't a valid package id.";
+        let package_id = PackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
+
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
+
+        let root = Node::new(package_id, (), ());
+        let mut tree = Tree::new(root);
+
+        let mut package_queue = VecDeque::from([0]);
+        while let Some(node_index) = package_queue.pop_front() {
+            let node = tree.get_node_by_index_mut(node_index).expect("Expected node to exist");
+
+            let (_, _, version_meta) =
+                manager.read_package_and_version(&node.get_package_id().clone().into(), &Target::current()).unwrap_or_exit(1);
+
+            let target_bounds = version_meta.get_best_target(&Target::current()).unwrap_or_exit(1);
+            let target = version_meta.get_target(&target_bounds).unwrap_or_exit(1);
+            let dependencies = version_meta.dependencies.iter().chain(target.dependencies.iter());
+            let build_dependencies = version_meta.build_dependencies.iter().chain(target.build_dependencies.iter());
+
+            for dependency in build_dependencies.chain(dependencies) {
+                let (repository_id, dependency_meta) = manager.read_package(dependency.get_name()).unwrap_or_exit(1);
+                let dependency_version_meta = manager
+                    .read_latest_supported_dependency_version(&repository_id, &dependency_meta, dependency, &Target::current())
+                    .unwrap_or_exit(1);
+
+                let dependency_id = PackageId::new(dependency.get_name().clone(), dependency_version_meta.version);
+                let new_node = Node::new(dependency_id, (), ());
+                let new_index = tree.add_node(node_index, new_node).unwrap_or_exit(1);
+                package_queue.push_back(new_index);
+            }
+        }
+
+        println!("{tree}");
+    }
+
     /// Searches information of a package based on the provided `OptionalPackageId`.
     /// Fails if the given query is not a valid `OptionalPackageId`.
     fn search(&self) {
         // Get the optional id
-        let message = "The given search query isn't a valid package. For regex use `--regex`.";
+        let message = "The given search query isn't a valid package.";
         let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
 
         match optional_id.versioned() {

--- a/src/utils/tree.rs
+++ b/src/utils/tree.rs
@@ -6,10 +6,7 @@ use std::{
 
 use thiserror::Error;
 
-use crate::{
-    cli::display::styled::Styled, installer::types::PackageId, register::package_register::PackageRegister,
-    repositories::error::RepositoryError,
-};
+use crate::{cli::display::styled::Styled, installer::types::PackageId, register::package_register::PackageRegister};
 
 // Static string prefixes for the tree display
 const BRANCH: &str = "\u{251C}\u{2500}\u{2500}\u{2500} ";
@@ -28,9 +25,6 @@ pub enum TreeError {
 
     #[error("{} has itself as a dependency, creating a cycle in the tree", .0.style())]
     CycleError(PackageId),
-
-    #[error("Cannot create tree, because of an error reading the repository.")]
-    RepositoryError(#[from] RepositoryError),
 }
 
 pub type Result<T> = std::result::Result<T, TreeError>;


### PR DESCRIPTION
This PR adds the `--tree` flag for the search command. Which can be used to show the dependency tree of a package.