### PR TITLE
Fix confusing package not found messages for invalid metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix "check length methods" from the verifier returning wrong length in case of an incomplete check list.
 - Fix portable repositories generating an invalid prebuild repository structure.
 - Fix writable checks by ignoring the readonly attribute on Windows.
+- Fix package not found message when metadata cannot be parsed.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -80,7 +80,7 @@ pub enum PackageNotFoundReason {
 
     #[error("the metadata cannot be parsed: {error}")]
     InvalidMetadata {
-        error: toml::de::Error,
+        error: Box<toml::de::Error>,
     },
 
     #[error("package is disabled since {since}{}", reason.as_ref().map(|reason| format!(", with reason '{reason}'")).unwrap_or_default())]
@@ -123,20 +123,16 @@ impl PackageNotFoundReason {
                 },
 
                 // If the primary is `Disabled`, only use the new one if the next if `UnsupportedTarget` or `NotSupported`, or a newer disable
-                PackageNotFoundReason::Disabled { since, .. } => {
-                    match next {
-                        PackageNotFoundReason::UnsupportedTarget | PackageNotFoundReason::NotSupported { .. } => primary = next.clone(),
-                        PackageNotFoundReason::Disabled { since: since_next, .. } if since_next > since => primary = next.clone(),
-                        _ => {},
-                    };
+                PackageNotFoundReason::Disabled { since, .. } => match next {
+                    PackageNotFoundReason::UnsupportedTarget | PackageNotFoundReason::NotSupported { .. } => primary = next.clone(),
+                    PackageNotFoundReason::Disabled { since: since_next, .. } if since_next > since => primary = next.clone(),
+                    _ => {},
                 },
 
                 // If the current primary is `InvalidMetadata`, only use the new one if it is not `NotFound` or `InvalidMetadata`
-                PackageNotFoundReason::InvalidMetadata { .. } => {
-                    match next {
-                        PackageNotFoundReason::NotFound | PackageNotFoundReason::InvalidMetadata { .. } => {},
-                        _ => primary = next.clone(),
-                    };
+                PackageNotFoundReason::InvalidMetadata { .. } => match next {
+                    PackageNotFoundReason::NotFound | PackageNotFoundReason::InvalidMetadata { .. } => {},
+                    _ => primary = next.clone(),
                 },
 
                 // If the current primary is `NotFound`, always use the new one

--- a/src/repositories/error.rs
+++ b/src/repositories/error.rs
@@ -78,6 +78,11 @@ pub enum PackageNotFoundReason {
     #[error("cannot be found in any repository")]
     NotFound,
 
+    #[error("the metadata cannot be parsed: {error}")]
+    InvalidMetadata {
+        error: toml::de::Error,
+    },
+
     #[error("package is disabled since {since}{}", reason.as_ref().map(|reason| format!(", with reason '{reason}'")).unwrap_or_default())]
     Disabled {
         since: Date,
@@ -101,9 +106,9 @@ impl PackageNotFoundReason {
 
         for next in reasons {
             match &primary {
-                // If the primary is `UnsupportedTarget`, only use the new one if the next is not `NotFound` or `Disabled`
+                // If the primary is `UnsupportedTarget`, only use the new one if the next is `NotSupported`
                 PackageNotFoundReason::UnsupportedTarget => {
-                    if !matches!(next, PackageNotFoundReason::NotFound | PackageNotFoundReason::Disabled { .. }) {
+                    if matches!(next, PackageNotFoundReason::NotSupported { .. }) {
                         primary = next.clone();
                     }
                 },
@@ -123,6 +128,14 @@ impl PackageNotFoundReason {
                         PackageNotFoundReason::UnsupportedTarget | PackageNotFoundReason::NotSupported { .. } => primary = next.clone(),
                         PackageNotFoundReason::Disabled { since: since_next, .. } if since_next > since => primary = next.clone(),
                         _ => {},
+                    };
+                },
+
+                // If the current primary is `InvalidMetadata`, only use the new one if it is not `NotFound` or `InvalidMetadata`
+                PackageNotFoundReason::InvalidMetadata { .. } => {
+                    match next {
+                        PackageNotFoundReason::NotFound | PackageNotFoundReason::InvalidMetadata { .. } => {},
+                        _ => primary = next.clone(),
                     };
                 },
 

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -146,6 +146,11 @@ impl<'a> RepositoryManager<'a> {
 
             let package = match provider.read_package(package) {
                 Ok(package) => package,
+                Err(RepositoryError::ParseError(error)) => {
+                    debug!(err: &error, "Unable to parse {} from repository '{repository_id}', continuing...", package.style());
+                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error });
+                    continue;
+                },
                 Err(e) => {
                     debug!(err: e, "Unable to read {} from repository '{repository_id}', continuing...", package.style());
                     continue;

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -237,6 +237,14 @@ impl<'a> RepositoryManager<'a> {
 
             let package = match provider.read_package_version(&package_id.name, &package_id.version) {
                 Ok(package) => package,
+                Err(RepositoryError::ParseError(error)) => {
+                    debug!(
+                        "Cannot parse package {} in repository '{repository_id}', continuing.",
+                        package_id.style()
+                    );
+                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error });
+                    continue;
+                },
                 Err(_) => {
                     debug!(
                         "Cannot find package {} in repository '{repository_id}', continuing.",

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -146,9 +146,9 @@ impl<'a> RepositoryManager<'a> {
 
             let package = match provider.read_package(package) {
                 Ok(package) => package,
-                Err(RepositoryError::ParseError(error)) => {
-                    debug!(err: &error, "Unable to parse {} from repository '{repository_id}', continuing...", package.style());
-                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error });
+                Err(RepositoryError::ParseError(e)) => {
+                    debug!(err: &e, "Unable to parse {} from repository '{repository_id}', continuing...", package.style());
+                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error: Box::new(e) });
                     continue;
                 },
                 Err(e) => {
@@ -242,12 +242,12 @@ impl<'a> RepositoryManager<'a> {
 
             let package = match provider.read_package_version(&package_id.name, &package_id.version) {
                 Ok(package) => package,
-                Err(RepositoryError::ParseError(error)) => {
+                Err(RepositoryError::ParseError(e)) => {
                     debug!(
                         "Cannot parse package {} in repository '{repository_id}', continuing.",
                         package_id.style()
                     );
-                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error });
+                    not_found_reasons.insert(repository_id, PackageNotFoundReason::InvalidMetadata { error: Box::new(e) });
                     continue;
                 },
                 Err(_) => {


### PR DESCRIPTION
This PR adds a new `PackageNotFoundReason::InvalidMetadata` to fix confusing error messages when metadata cannot be parsed. Previously this showed that the package could not be found in any repository, followed by a list of versions (including the invalid version)