### PR TITLE
Add packit info command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
     - Prebuilds can now exclude certain paths of a package.
 - The `skip-test` and `skip-build-test` flags in the `install` command, to skip Packit tests or skip build tests.
 - The `--tree` flag in the `search` command, to show the tree of a given package.
+- The `pit info` command to show information about the current Packit install, such as prefix path and target information.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Searches a package with `<QUERY>`. If `--regex` is not enabled, the query is exp
 #### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
 Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and `--new-version` cannot be used). If multiple versions of the same package are installed, the latest installed version is assumed. The `--new-version` flag can be used to specify the new version to install. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.
 
-#### `pit info <PACKAGE-NAME>[@<VERSION>] [-v] [--tree]`
-Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown.
+#### `pit info [<PACKAGE-NAME>[@<VERSION>] [-v] [--tree]]`
+Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown. If no arguments are given, information about the current Packit install is shown.
 
 #### `pit check [<PACKAGE-NAME>[@<VERSION>] ...]`
 Checks the Packit installation for issues. When package name(s) and version(s) are given, only those package(s) are checked for issues. 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -71,7 +71,7 @@ enum Commands {
     /// Check the installation and fix issues
     Fix(FixArgs),
 
-    /// Get info from a specific package
+    /// Get info from a specific package or the Packit install
     Info(InfoArgs),
 
     /// Update an installed package

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -2,6 +2,7 @@
 use crate::{
     cli::display::{standard_print::DisplayJoined, styled::MapStyled},
     installer::types::PackageName,
+    platforms::{DEFAULT_CONFIG_DIR, OsVersion, Target},
     utils::packit_version::{packit_version, packit_version_name},
 };
 use clap::Args;
@@ -99,8 +100,38 @@ impl InfoArgs {
         println!("{}", packit_version_name!().italic().cyan());
 
         let mut pair_aligner = PairAligner::new();
-        pair_aligner.add("Prefix", config.prefix_directory.display());
+        pair_aligner.add("Config directory", DEFAULT_CONFIG_DIR);
+        pair_aligner.add("Prefix directory", config.prefix_directory.display());
+        pair_aligner.add("Multiuser mode", if config.multiuser { "on" } else { "off" });
         pair_aligner.add("Installed packages", register.iterate_all().count());
+        pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+        println!();
+
+        let target = Target::current();
+        println!("Current system");
+        let mut pair_aligner = PairAligner::new();
+
+        match &target.os {
+            OsVersion::MacOs { version } => {
+                pair_aligner.add("OS", format!("macOS {version}"));
+            },
+            OsVersion::Linux {
+                distro,
+                distro_version,
+                kernel_version,
+            } => {
+                pair_aligner.add("OS", format!("Linux {distro} {distro_version}"));
+                pair_aligner.add("Kernel version", kernel_version);
+            },
+            OsVersion::Windows { version } => {
+                pair_aligner.add("OS", format!("Windows {version}"));
+            },
+            OsVersion::Unknown => {
+                pair_aligner.add("OS", "Unknown".dimmed());
+            },
+        }
+
+        pair_aligner.add("Architecture", target.architecture);
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
     }

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -3,11 +3,12 @@ use crate::{
     cli::display::{standard_print::DisplayJoined, styled::MapStyled},
     installer::types::PackageName,
     platforms::{DEFAULT_CONFIG_DIR, OsVersion, Target},
-    utils::packit_version::{packit_version, packit_version_name},
+    repositories::manager::RepositoryManager,
+    utils::packit_version::{current_packit_version, packit_version, packit_version_name},
 };
 use clap::Args;
 use colored::Colorize;
-use std::process::exit;
+use std::{process::exit, str::FromStr};
 
 use crate::{
     cli::{
@@ -96,6 +97,31 @@ impl InfoArgs {
             exit(1);
         }
 
+        let target = Target::current();
+
+        // Read latest version of packit
+        let manager = RepositoryManager::new(config);
+        let latest_version;
+        match manager.read_package(&PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name")) {
+            Ok((repository_id, package_meta)) => match manager.read_latest_supported_version(&repository_id, &package_meta, &target) {
+                Ok(version_meta) => latest_version = Some(version_meta.version),
+                Err(e) => {
+                    error!(e, "Cannot request packit version metadata");
+                    latest_version = None;
+                },
+            },
+            Err(e) => {
+                error!(e, "Cannot request packit metadata");
+                latest_version = None;
+            },
+        }
+
+        // Create display for new version
+        let new_version_disp = match latest_version {
+            Some(latest_version) if latest_version > current_packit_version() => format!("yes, {}", latest_version.style()),
+            Some(_) | None => "no".into(),
+        };
+
         println!("{}{}", "packit@".bold().blue(), packit_version!().bold().blue());
         println!("{}", packit_version_name!().italic().cyan());
 
@@ -104,10 +130,10 @@ impl InfoArgs {
         pair_aligner.add("Prefix directory", config.prefix_directory.display());
         pair_aligner.add("Multiuser mode", if config.multiuser { "on" } else { "off" });
         pair_aligner.add("Installed packages", register.iterate_all().count());
+        pair_aligner.add("New version available", new_version_disp);
         pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         println!();
 
-        let target = Target::current();
         println!("Current system");
         let mut pair_aligner = PairAligner::new();
 

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -1,5 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use crate::cli::display::{standard_print::DisplayJoined, styled::MapStyled};
+use crate::{
+    cli::display::{standard_print::DisplayJoined, styled::MapStyled},
+    installer::types::PackageName,
+    utils::packit_version::{packit_version, packit_version_name},
+};
 use clap::Args;
 use colored::Colorize;
 use std::process::exit;
@@ -28,7 +32,7 @@ use crate::{
 #[derive(Args, Debug)]
 pub struct InfoArgs {
     /// Optional package id
-    package: OptionalPackageId,
+    package: Option<OptionalPackageId>,
 
     /// True if verbose information should be shown
     #[arg(short, long, default_value = "false")]
@@ -45,15 +49,20 @@ impl HandleCommand for InfoArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
+        let Some(package) = &self.package else {
+            self.display_packit_info(&config, &register);
+            return;
+        };
+
         // Get package information
-        let package = match register.get_package(&self.package.name) {
+        let installed_package = match register.get_package(&package.name) {
             Some(package) => package,
-            None => not_found::register_package(&self.package.name, &register),
+            None => not_found::register_package(&package.name, &register),
         };
 
         // Display tree if tree flag is given
         if self.tree {
-            let Some(package_id) = self.package.versioned() else {
+            let Some(package_id) = package.versioned() else {
                 error!(msg: "Displaying a tree requires package version to be specified.");
                 exit(1);
             };
@@ -69,23 +78,40 @@ impl HandleCommand for InfoArgs {
         }
 
         // Show package version specific information
-        if let Some(package_id) = self.package.versioned() {
-            self.display_package_version_info(&package_id, &register, package);
+        if let Some(package_id) = package.versioned() {
+            self.display_package_version_info(&package_id, &register, installed_package);
             return;
         }
 
-        self.display_package_info(package);
+        self.display_package_info(&package.name, installed_package);
     }
 }
 
 impl InfoArgs {
+    /// Displays information about the Packit installation.
+    fn display_packit_info(&self, config: &Config, register: &PackageRegister) {
+        if self.tree {
+            error!(msg: "Displaying a tree requires package version to be specified.");
+            exit(1);
+        }
+
+        println!("{}{}", "packit@".bold().blue(), packit_version!().bold().blue());
+        println!("{}", packit_version_name!().italic().cyan());
+
+        let mut pair_aligner = PairAligner::new();
+        pair_aligner.add("Prefix", config.prefix_directory.display());
+        pair_aligner.add("Installed packages", register.iterate_all().count());
+        pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+        println!();
+    }
+
     /// Displays package info.
-    fn display_package_info(&self, package: &InstalledPackage) {
+    fn display_package_info(&self, package_name: &PackageName, package: &InstalledPackage) {
         // Sort installed versions for display
         let mut installed_versions: Vec<_> = package.versions.keys().collect();
         installed_versions.sort();
 
-        println!("{}", self.package.name.style());
+        println!("{}", package_name.style());
         println!("{}", package.description.italic().cyan());
 
         let mut pair_aligner = PairAligner::new();

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -4,11 +4,11 @@ use crate::{
     installer::types::PackageName,
     platforms::{DEFAULT_CONFIG_DIR, OsVersion, Target},
     repositories::manager::RepositoryManager,
-    utils::packit_version::{current_packit_version, packit_version, packit_version_name},
+    utils::packit_version::{current_packit_version, packit_version_name},
 };
 use clap::Args;
 use colored::Colorize;
-use std::{process::exit, str::FromStr};
+use std::process::exit;
 
 use crate::{
     cli::{
@@ -41,7 +41,7 @@ pub struct InfoArgs {
     verbose: bool,
 
     /// True if displaying package trees as well
-    #[arg(long, default_value = "false")]
+    #[arg(long, default_value = "false", requires = "package")]
     tree: bool,
 }
 
@@ -98,11 +98,12 @@ impl InfoArgs {
         }
 
         let target = Target::current();
+        let package_id = PackageId::new(PackageName::packit(), current_packit_version());
 
         // Read latest version of packit
         let manager = RepositoryManager::new(config);
         let latest_version;
-        match manager.read_package(&PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name")) {
+        match manager.read_package(&package_id.name) {
             Ok((repository_id, package_meta)) => match manager.read_latest_supported_version(&repository_id, &package_meta, &target) {
                 Ok(version_meta) => latest_version = Some(version_meta.version),
                 Err(e) => {
@@ -122,7 +123,7 @@ impl InfoArgs {
             Some(_) | None => "no".into(),
         };
 
-        println!("{}{}", "packit@".bold().blue(), packit_version!().bold().blue());
+        println!("{}", package_id.style());
         println!("{}", packit_version_name!().italic().cyan());
 
         let mut pair_aligner = PairAligner::new();

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -22,6 +22,11 @@ impl PackageName {
     pub fn get_prefix(&self) -> char {
         self.0.chars().next().expect("Expected first char, based on regex")
     }
+
+    /// Gets the package name of Packit itself.
+    pub fn packit() -> Self {
+        Self("packit".to_string())
+    }
 }
 
 impl<'de> Deserialize<'de> for PackageName {


### PR DESCRIPTION
This PR adds the `pit info` command to show information about the current packit installation. This command can be used to easily share information about the installation for debugging issues.