### PR TITLE
Add '--latest' flag to search command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `skip-test` and `skip-build-test` flags in the `install` command, to skip Packit tests or skip build tests.
 - The `--tree` flag in the `search` command, to show the tree of a given package.
 - The `pit info` command to show information about the current Packit install, such as prefix path and target information.
+- The `--active` flag in the `info` command, to use the active version.
+- The `--latest` flag in the `search` command, to use the latest version.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -67,14 +67,14 @@ Uninstalls the specified packages, if a version is given that version will be un
 #### `pit list [--updatables] [--active]`
 Lists all the installed packages. If the `--updatables` flag is specified, all updatable packages are listed. If the `--active` flag is specified, only the active package versions are listed.
 
-#### `pit search <QUERY> [--regex] [--verbose] [--tree]`
-Searches a package with `<QUERY>`. If `--regex` is not enabled, the query is expected to be `<PACKAGE-NAME>[@<VERSION>]` and information based on the package metadata is shown, if the version is given that specific version is searched for. If `--regex` is given, all packages that match the given regular expression query are shown. The `--verbose` flag can be used to show more output. The `--tree` flag can be used to show the tree of a package. Note that the package version also needs to be given in this case and that the latest version is assumed for the dependencies.
+#### `pit search <QUERY> [--regex] [--verbose] [--tree] [--latest]`
+Searches a package with `<QUERY>`. If `--regex` is not enabled, the query is expected to be `<PACKAGE-NAME>[@<VERSION>]` and information based on the package metadata is shown, if the version is given that specific version is searched for. If `--regex` is given, all packages that match the given regular expression query are shown. The `--verbose` flag can be used to show more output. The `--tree` flag can be used to show the tree of a package. Note that the package version also needs to be given in this case and that the latest version is assumed for the dependencies. The `--latest` flag can be used to use the latest version of a specified package, instead of specifying a version.
 
 #### `pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...]`
 Updates the specified package to the new version, or the latest version if no new version is specified. If multiple packages are specified they are all updated to the latest version (and `--new-version` cannot be used). If multiple versions of the same package are installed, the latest installed version is assumed. The `--new-version` flag can be used to specify the new version to install. The `--all` flag can be used to update all packages (the latest installed version will be updated). The `--exclude` flag can be used to exclude certain packages when using the `--all` flag.
 
-#### `pit info [<PACKAGE-NAME>[@<VERSION>] [-v] [--tree]]`
-Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown. If no arguments are given, information about the current Packit install is shown.
+#### `pit info [<PACKAGE-NAME>[@<VERSION>] [-v] [--tree] [--active]]`
+Shows info about the specified installed package. If the `-v` option is given, extra information is shown. If the `--tree` option is enabled, the whole dependency tree is shown. If no arguments are given, information about the current Packit install is shown. The `--active` flag can be used to use the active version of a specified package, instead of specifying a version.
 
 #### `pit check [<PACKAGE-NAME>[@<VERSION>] ...]`
 Checks the Packit installation for issues. When package name(s) and version(s) are given, only those package(s) are checked for issues. 

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -67,12 +67,12 @@ impl HandleCommand for SearchArgs {
             return;
         }
 
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
-
         // Get the optional id
         let message = "The given search query isn't a valid package. For regex use `--regex`.";
         let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
+
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
 
         // Check if there is version ambiguity (version and `--latest` specified)
         if optional_id.version.is_some() && self.latest {
@@ -100,8 +100,8 @@ impl HandleCommand for SearchArgs {
 
         match package_version {
             Some(version) if self.tree => self.search_tree(&manager, PackageId::new(optional_id.name, version.clone())),
-            Some(version) => self.search_package_version(&PackageId::new(optional_id.name, version.clone())),
-            None => self.search_package(&optional_id.name),
+            Some(version) => self.search_package_version(&manager, &PackageId::new(optional_id.name, version.clone())),
+            None => self.search_package(&manager, &optional_id.name),
         }
     }
 }
@@ -168,9 +168,7 @@ impl SearchArgs {
     }
 
     /// Searches for and shows package specific information for a given package.
-    fn search_package(&self, package_name: &PackageName) {
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
+    fn search_package(&self, manager: &RepositoryManager, package_name: &PackageName) {
         let (repository_id, package) = match manager.read_package(package_name) {
             Ok(package) => package,
             Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package(package_name, &manager, reason),
@@ -214,9 +212,7 @@ impl SearchArgs {
     }
 
     /// Searches for and shows package version specific information for a given package.
-    fn search_package_version(&self, package_id: &PackageId) {
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
+    fn search_package_version(&self, manager: &RepositoryManager, package_id: &PackageId) {
         let package_and_version = manager.read_package_and_version(&package_id.clone().into(), &Target::current());
         let (repository_id, package, package_version) = match package_and_version {
             Ok(package) => package,

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -71,14 +71,14 @@ impl HandleCommand for SearchArgs {
         let message = "The given search query isn't a valid package. For regex use `--regex`.";
         let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
 
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
-
         // Check if there is version ambiguity (version and `--latest` specified)
         if optional_id.version.is_some() && self.latest {
             error!(msg: "Version is ambiguous, version and `--latest` are both specified");
             exit(1);
         }
+
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
 
         // Get the package version
         let package_version = match &optional_id.version {

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 use std::{
     cmp::max,
     collections::{HashSet, VecDeque},
+    process::exit,
     str::FromStr,
 };
 
@@ -52,6 +53,10 @@ pub struct SearchArgs {
     /// True if verbose information should be shown
     #[arg(short, long, default_value = "false")]
     verbose: bool,
+
+    /// True to use the latest version
+    #[arg(long, default_value = "false", conflicts_with = "regex")]
+    latest: bool,
 }
 
 impl HandleCommand for SearchArgs {
@@ -62,9 +67,41 @@ impl HandleCommand for SearchArgs {
             return;
         }
 
-        match self.tree {
-            true => self.search_tree(),
-            false => self.search(),
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let manager = RepositoryManager::new(&config);
+
+        // Get the optional id
+        let message = "The given search query isn't a valid package. For regex use `--regex`.";
+        let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
+
+        // Check if there is version ambiguity (version and `--latest` specified)
+        if optional_id.version.is_some() && self.latest {
+            error!(msg: "Version is ambiguous, version and `--latest` are both specified");
+            exit(1);
+        }
+
+        // Get the package version
+        let package_version = match &optional_id.version {
+            Some(version) => Some(version.clone()),
+            None if self.latest => {
+                let (repository_id, package_meta) = manager.read_package(&optional_id.name).unwrap_or_exit(1);
+                let version_meta =
+                    manager.read_latest_supported_version(&repository_id, &package_meta, &Target::current()).unwrap_or_exit(1);
+                Some(version_meta.version)
+            },
+            None => None,
+        };
+
+        // Version cannot be none if `--tree` is specified
+        if self.tree && package_version.is_none() {
+            error!(msg: "The given search query isn't a valid package id. Use `--latest` for the latest version.");
+            exit(1);
+        }
+
+        match package_version {
+            Some(version) if self.tree => self.search_tree(&manager, PackageId::new(optional_id.name, version.clone())),
+            Some(version) => self.search_package_version(&PackageId::new(optional_id.name, version.clone())),
+            None => self.search_package(&optional_id.name),
         }
     }
 }
@@ -98,14 +135,7 @@ impl SearchArgs {
 
     /// Searches the tree of a given package, always using the latest version for the current target of each dependency.
     /// Fails if the given query is not a valid `PackageId`.
-    fn search_tree(&self) {
-        // Get the package id
-        let message = "The given search query isn't a valid package id.";
-        let package_id = PackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
-
-        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
-        let manager = RepositoryManager::new(&config);
-
+    fn search_tree(&self, manager: &RepositoryManager, package_id: PackageId) {
         let root = Node::new(package_id, (), ());
         let mut tree = Tree::new(root);
 
@@ -135,19 +165,6 @@ impl SearchArgs {
         }
 
         println!("{tree}");
-    }
-
-    /// Searches information of a package based on the provided `OptionalPackageId`.
-    /// Fails if the given query is not a valid `OptionalPackageId`.
-    fn search(&self) {
-        // Get the optional id
-        let message = "The given search query isn't a valid package. For regex use `--regex`.";
-        let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
-
-        match optional_id.versioned() {
-            Some(package_id) => self.search_package_version(&package_id),
-            None => self.search_package(&optional_id.name),
-        }
     }
 
     /// Searches for and shows package specific information for a given package.


### PR DESCRIPTION
This PR adds the `--latest` flag the the search command, so the latest version is used when specified.