### PR TITLE
Extend config command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `config repositories set-url` command, which can be used to change the url of a repository.
 - The `config repositories set-prebuilds` command, which can be used to change the prebuilds url of a repository.
 - The `config repositories disable-prebuilds` command, which can be used to enable or disable prebuilds of a repository.
+- The `config repositories add` command now has a `--unchecked` flag, which can be used to skip repository checks.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `--latest` flag in the `search` command, to use the latest version.
 - Progress bars are now shown while build sources or prebuilds are being downloaded.
 - The `--target-only` flag on the `search` command, to show only the packages that are supported for the current target.
+- The `config repositories set-url` command, which can be used to change the url of a repository.
+- The `config repositories set-prebuilds` command, which can be used to change the prebuilds url of a repository.
+- The `config repositories disable-prebuilds` command, which can be used to enable or disable prebuilds of a repository.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.
@@ -29,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `prebuild_url` and `prebuild_provider` fields in the `repository.toml` file now represent a suggestion that needs to be added to the config in order to be used.
 - The `Alterations` verifier check is now enabled for packages that were installed from a prebuild.
 - The `search --regex` results are now sorted by package name.
+- The `config show` command now also shows the `prebuilds_disabled` option.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/README.md
+++ b/README.md
@@ -118,14 +118,14 @@ Lists all configured repositories.
 #### `pit config repositories set-rank <REPOSITORY-ID>`
 Sets the repositories rank in the config. Multiple `<REPOSITORY-ID>` can be given for multiple repositories in the rank.
 
-#### `pit config repositories add <ID> <URL> [PROVIDER]`
-Adds a new repository to the config. Also adds the new repository to the back of the repositories rank.
+#### `pit config repositories add <ID> <URL> [PROVIDER] [--unchecked]`
+Adds a new repository to the config. Also adds the new repository to the back of the repositories rank. If the `--unchecked` flag is given, the new repository is not checked for availability and compatibility.
 
 #### `pit config repositories remove <ID>`
 Removes a repository from the config. Also removes the repository from the repositories rank.
 
-#### `pit config repositories set-url <ID> <URL> [PROVIDER]`
-Sets the url of a repository in the config. If no provider is given, the old provider is used.
+#### `pit config repositories set-url <ID> <URL> [PROVIDER] [--unchecked]`
+Sets the url of a repository in the config. If no provider is given, the old provider is used. If the `--unchecked` flag is given, the new repository is not checked for availability and compatibility.
 
 #### `pit config repositories set-prebuilds <ID> <PREBUILDS-URL> [PREBUILDS-PROVIDER]`
 Sets the prebuilds url of a repository in the config. If no provider is given, the old provider is used.

--- a/README.md
+++ b/README.md
@@ -124,6 +124,15 @@ Adds a new repository to the config. Also adds the new repository to the back of
 #### `pit config repositories remove <ID>`
 Removes a repository from the config. Also removes the repository from the repositories rank.
 
+#### `pit config repositories set-url <ID> <URL> [PROVIDER]`
+Sets the url of a repository in the config. If no provider is given, the old provider is used.
+
+#### `pit config repositories set-prebuilds <ID> <PREBUILDS-URL> [PREBUILDS-PROVIDER]`
+Sets the prebuilds url of a repository in the config. If no provider is given, the old provider is used.
+
+#### `pit config repositories disable-prebuilds <ID> <VALUE> [--remove-urls]`
+Disables or enables the prebuilds url of a repository in the config. If the `--remove-urls` flag is given, the urls are removed if `<VALUE>` is true.
+
 #### `pit init [--prefix <PREFIX>]`
 Initializes the Packit environment by setting up all required files and directories. If the `--prefix` option is given, the given path is used as prefix, instead of the [default prefix](#prefix).
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     config::{Config, EditableConfig, Repository},
     register::package_register::PackageRegister,
-    repositories::{manager::RepositoryManager, metadata::DEFAULT_METADATA_PROVIDER_ID, provider},
+    repositories::{manager::RepositoryManager, metadata::DEFAULT_METADATA_PROVIDER_ID, provider, types::RepositoryMeta},
     utils::{packit_version::current_packit_version, unwrap_or_exit::UnwrapOrExit},
 };
 
@@ -69,6 +69,10 @@ pub enum RepositoriesArgs {
 
         /// The optional provider of the new repository, `web` is used as default
         provider: Option<String>,
+
+        /// True if the repository availability checks should be skipped
+        #[arg(long, default_value = "false")]
+        unchecked: bool,
     },
 
     /// Removes a repository from the config
@@ -87,6 +91,10 @@ pub enum RepositoriesArgs {
 
         /// The new provider of the repository, if no value is given, the old value is used
         provider: Option<String>,
+
+        /// True if the repository availability checks should be skipped
+        #[arg(long, default_value = "false")]
+        unchecked: bool,
     },
 
     /// Sets the prebuilds repository url and provider
@@ -127,9 +135,19 @@ impl HandleCommand for ConfigArgs {
             ConfigArgs::SetMultiuser { multiuser } => self.handle_set_multiuser(config, *multiuser),
             ConfigArgs::Repositories(RepositoriesArgs::List) => self.handle_list_repositories(config),
             ConfigArgs::Repositories(RepositoriesArgs::SetRank { new_rank }) => self.handle_set_repositories_rank(config, new_rank),
-            ConfigArgs::Repositories(RepositoriesArgs::Add { id, url, provider }) => self.handle_add_repository(config, id, url, provider),
+            ConfigArgs::Repositories(RepositoriesArgs::Add {
+                id,
+                url,
+                provider,
+                unchecked,
+            }) => self.handle_add_repository(config, id, url, provider, *unchecked),
             ConfigArgs::Repositories(RepositoriesArgs::Remove { id }) => self.handle_remove_repository(config, id),
-            ConfigArgs::Repositories(RepositoriesArgs::SetUrl { id, url, provider }) => self.handle_set_url(config, id, url, provider),
+            ConfigArgs::Repositories(RepositoriesArgs::SetUrl {
+                id,
+                url,
+                provider,
+                unchecked,
+            }) => self.handle_set_url(config, id, url, provider, *unchecked),
             ConfigArgs::Repositories(RepositoriesArgs::SetPrebuilds {
                 id,
                 prebuilds_url,
@@ -277,7 +295,7 @@ impl ConfigArgs {
     }
 
     /// Handles the config repositories add command.
-    fn handle_add_repository(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>) {
+    fn handle_add_repository(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>, unchecked: bool) {
         // Check if the config already contains a repository with this id
         if config.get_config().repositories.contains_key(id) {
             error!(msg: "A repository with id '{id}' already exists.");
@@ -290,36 +308,34 @@ impl ConfigArgs {
         };
         let mut repository = Repository::new(url, provider);
 
-        // Try to connect to the repository
-        let provider = provider::create_metadata_provider(&repository).unwrap_or_exit_msg("Unable to connect to repository", 1);
-        let repo_meta = provider.read_repository_metadata().unwrap_or_exit_msg("Unable to read repository metadata", 1);
+        // Only run checks if unchecked is not enabled
+        if !unchecked {
+            let repo_meta = self.check_metadata_repository_availability(&repository);
+            let is_repository_reachable = repo_meta.as_ref().map(|x| self.check_metadata_repository_compatibility(x)).unwrap_or(false);
 
-        // Check if the repository is supported
-        if repo_meta.required_packit_version > current_packit_version() {
-            warning!(
-                "This repository requires Packit version {}, while your current version is {}",
-                repo_meta.required_packit_version.style(),
-                current_packit_version().style()
-            );
-
-            if ask_user("Are you sure you want to add this repository?", QuestionResponse::No).unwrap_or_exit(1).is_no_or_invalid() {
-                println!("Cancelling adding of repository.");
-                return;
+            // Check if the repository is reachable
+            if is_repository_reachable {
+                if ask_user("Are you sure you want to add this repository?", QuestionResponse::No).unwrap_or_exit(1).is_no_or_invalid() {
+                    println!("Cancelling adding of repository.");
+                    return;
+                }
             }
-        }
 
-        // Check if repository suggests a prebuild url
-        if let Some(prebuilds_url) = &repo_meta.prebuilds_url {
-            println!("This repository suggests using the following prebuilds repository:");
-            let mut pair_aligner = PairAligner::new();
-            pair_aligner.add("Url", prebuilds_url);
-            pair_aligner.add("Provider", repo_meta.prebuilds_provider.display());
-            pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
+            if let Some(repo_meta) = repo_meta {
+                // Check if repository suggests a prebuild url
+                if let Some(prebuilds_url) = &repo_meta.prebuilds_url {
+                    println!("This repository suggests using the following prebuilds repository:");
+                    let mut pair_aligner = PairAligner::new();
+                    pair_aligner.add("Url", prebuilds_url);
+                    pair_aligner.add("Provider", repo_meta.prebuilds_provider.display());
+                    pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
 
-            if ask_user("Do you want to add this prebuild repository?", QuestionResponse::Yes).unwrap_or_exit(1).is_yes() {
-                println!("Adding prebuild repository to config.");
-                repository.prebuilds_url = Some(prebuilds_url.clone());
-                repository.prebuilds_provider = repo_meta.prebuilds_provider;
+                    if ask_user("Do you want to add this prebuild repository?", QuestionResponse::Yes).unwrap_or_exit(1).is_yes() {
+                        println!("Adding prebuild repository to config.");
+                        repository.prebuilds_url = Some(prebuilds_url.clone());
+                        repository.prebuilds_provider = repo_meta.prebuilds_provider;
+                    }
+                }
             }
         }
 
@@ -356,37 +372,21 @@ impl ConfigArgs {
     }
 
     /// Handles the config repositories set-url command.
-    fn handle_set_url(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>) {
+    fn handle_set_url(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>, unchecked: bool) {
         // Check if the config even contains this repository
         let Some(mut repository) = config.get_config().repositories.get(id).cloned() else {
             error!(msg: "Repository '{id}' does not exist.");
             exit(1);
         };
 
-        // Check if the repository is reachable
-        let repo_meta = provider::create_metadata_provider(&repository).map(|x| x.read_repository_metadata());
-        match repo_meta {
-            Some(Ok(repo_meta)) => {
-                // Check if the repository is supported
-                if repo_meta.required_packit_version > current_packit_version() {
-                    warning!(
-                        "This repository requires Packit version {}, while your current version is {}",
-                        repo_meta.required_packit_version.style(),
-                        current_packit_version().style()
-                    );
+        // Only run checks if unchecked is not enabled
+        if !unchecked {
+            let repository = Repository::new(url, provider.as_ref().unwrap_or(&repository.provider));
+            let repo_meta = self.check_metadata_repository_availability(&repository);
+            let is_repository_reachable = repo_meta.map(|x| self.check_metadata_repository_compatibility(&x)).unwrap_or(false);
 
-                    if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
-                        .unwrap_or_exit(1)
-                        .is_no_or_invalid()
-                    {
-                        println!("Cancelling repository url change.");
-                        return;
-                    }
-                }
-            },
-            Some(Err(e)) => {
-                warning!("Cannot request repository metadata: {e}");
-
+            // Check if the repository is reachable
+            if !is_repository_reachable {
                 if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
                     .unwrap_or_exit(1)
                     .is_no_or_invalid()
@@ -394,18 +394,7 @@ impl ConfigArgs {
                     println!("Cancelling repository url change.");
                     return;
                 }
-            },
-            None => {
-                warning!("Cannot connect to repository");
-
-                if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
-                    .unwrap_or_exit(1)
-                    .is_no_or_invalid()
-                {
-                    println!("Cancelling repository url change.");
-                    return;
-                }
-            },
+            }
         }
 
         println!("Overwriting url: {}, provider: {}", repository.url, repository.provider);
@@ -476,5 +465,45 @@ impl ConfigArgs {
         let status = if value { "disabled" } else { "enabled" };
         let styled_message = format!("Succesfully {status} prebuilds for '{id}'!").bold().green();
         println!("{styled_message}");
+    }
+
+    /// Check if the metadata repository is available.
+    /// Shows a message with the found issues.
+    /// Returns the repository metadata if the repository is available, false otherwise
+    fn check_metadata_repository_availability(&self, repository: &Repository) -> Option<RepositoryMeta> {
+        // Check if the provider can be created
+        let Some(provider) = provider::create_metadata_provider(repository) else {
+            warning!("Cannot connect to repository");
+            return None;
+        };
+
+        // Check if the repository metadata can be read
+        let repo_meta = match provider.read_repository_metadata() {
+            Ok(repo_meta) => repo_meta,
+            Err(e) => {
+                warning!("Cannot request repository metadata: {e}");
+                return None;
+            },
+        };
+
+        Some(repo_meta)
+    }
+
+    /// Check if the metadata repository is compatible with the current system.
+    /// Shows a message with the found issues.
+    /// Returns true if the repository is compatible, false otherwise
+    fn check_metadata_repository_compatibility(&self, repo_meta: &RepositoryMeta) -> bool {
+        // Check if the repository is supported
+        if repo_meta.required_packit_version > current_packit_version() {
+            warning!(
+                "This repository requires Packit version {}, while your current version is {}",
+                repo_meta.required_packit_version.style(),
+                current_packit_version().style()
+            );
+
+            return false;
+        }
+
+        true
     }
 }

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -363,7 +363,52 @@ impl ConfigArgs {
             exit(1);
         };
 
-        warning!("Overwriting url: {}, provider: {}", repository.url, repository.provider);
+        // Check if the repository is reachable
+        let repo_meta = provider::create_metadata_provider(&repository).map(|x| x.read_repository_metadata());
+        match repo_meta {
+            Some(Ok(repo_meta)) => {
+                // Check if the repository is supported
+                if repo_meta.required_packit_version > current_packit_version() {
+                    warning!(
+                        "This repository requires Packit version {}, while your current version is {}",
+                        repo_meta.required_packit_version.style(),
+                        current_packit_version().style()
+                    );
+
+                    if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
+                        .unwrap_or_exit(1)
+                        .is_no_or_invalid()
+                    {
+                        println!("Cancelling repository url change.");
+                        return;
+                    }
+                }
+            },
+            Some(Err(e)) => {
+                warning!("Cannot request repository metadata: {e}");
+
+                if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
+                    .unwrap_or_exit(1)
+                    .is_no_or_invalid()
+                {
+                    println!("Cancelling repository url change.");
+                    return;
+                }
+            },
+            None => {
+                warning!("Cannot connect to repository");
+
+                if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
+                    .unwrap_or_exit(1)
+                    .is_no_or_invalid()
+                {
+                    println!("Cancelling repository url change.");
+                    return;
+                }
+            },
+        }
+
+        println!("Overwriting url: {}, provider: {}", repository.url, repository.provider);
 
         repository.url = url.into();
         if let Some(provider) = provider {
@@ -374,7 +419,7 @@ impl ConfigArgs {
 
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
-        let styled_message = format!("Succesfully set repository url for '{id}' to {url}!").bold().green();
+        let styled_message = format!("Succesfully set repository url for '{id}' to '{url}'!").bold().green();
         println!("{styled_message}");
     }
 
@@ -388,8 +433,8 @@ impl ConfigArgs {
 
         // Check if a prebuilds repository was already configured
         if let Some(old_prebuilds_url) = &repository.prebuilds_url {
-            warning!("Repository '{id}' already had a prebuild repository, overwriting url and provider...");
-            warning!(
+            println!("Repository '{id}' already had a prebuild repository, overwriting url and provider...");
+            println!(
                 "Old prebuilds url: {old_prebuilds_url}, provider: {}",
                 repository.prebuilds_provider.display()
             );
@@ -404,7 +449,7 @@ impl ConfigArgs {
 
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
-        let styled_message = format!("Succesfully set prebuilds repository for '{id}' to {prebuilds_url}!").bold().green();
+        let styled_message = format!("Succesfully set prebuilds repository for '{id}' to '{prebuilds_url}'!").bold().green();
         println!("{styled_message}");
     }
 
@@ -428,8 +473,8 @@ impl ConfigArgs {
 
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
-        let disabled = if value { "disabled" } else { "enabled" };
-        let styled_message = format!("Succesfully {disabled} prebuilds for '{id}'!").bold().green();
+        let status = if value { "disabled" } else { "enabled" };
+        let styled_message = format!("Succesfully {status} prebuilds for '{id}'!").bold().green();
         println!("{styled_message}");
     }
 }

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -76,6 +76,18 @@ pub enum RepositoriesArgs {
         /// The id of the repository to remove
         id: String,
     },
+
+    /// Sets the prebuilds repository url and provider
+    SetPrebuilds {
+        /// The id of the repository to set the prebuilds repository of
+        id: String,
+
+        /// The url of the prebuilds repository
+        prebuilds_url: String,
+
+        /// The optional provider of the prebuilds repository, `web` is used as default
+        prebuilds_provider: Option<String>,
+    },
 }
 
 impl HandleCommand for ConfigArgs {
@@ -91,6 +103,11 @@ impl HandleCommand for ConfigArgs {
             ConfigArgs::Repositories(RepositoriesArgs::SetRank { new_rank }) => self.handle_set_repositories_rank(config, new_rank),
             ConfigArgs::Repositories(RepositoriesArgs::Add { id, url, provider }) => self.handle_add_repository(config, id, url, provider),
             ConfigArgs::Repositories(RepositoriesArgs::Remove { id }) => self.handle_remove_repository(config, id),
+            ConfigArgs::Repositories(RepositoriesArgs::SetPrebuilds {
+                id,
+                prebuilds_url,
+                prebuilds_provider,
+            }) => self.handle_set_prebuilds(config, id, prebuilds_url, prebuilds_provider),
         }
     }
 }
@@ -305,6 +322,34 @@ impl ConfigArgs {
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
         let styled_message = format!("Succesfully removed repository '{id}' from the config!").bold().green();
+        println!("{styled_message}");
+    }
+
+    /// Handles the config repositories set-prebuilds command.
+    fn handle_set_prebuilds(&self, mut config: EditableConfig, id: &str, prebuilds_url: &str, prebuilds_provider: &Option<String>) {
+        // Check if the config even contains this repository
+        let Some(mut repository) = config.get_config().repositories.get(id).cloned() else {
+            error!(msg: "Repository '{id}' does not exist.");
+            exit(1);
+        };
+
+        // Check if a prebuilds repository was already configured
+        if let Some(old_prebuilds_url) = &repository.prebuilds_url {
+            warning!("Repository '{id}' already had a prebuild repository, overwriting url and provider...");
+            warning!(
+                "Old prebuilds url: {old_prebuilds_url}, provider: {}",
+                repository.prebuilds_provider.display()
+            );
+        }
+
+        repository.prebuilds_url = Some(prebuilds_url.into());
+        repository.prebuilds_provider = prebuilds_provider.clone();
+
+        config.set_repository(id, repository);
+
+        config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
+
+        let styled_message = format!("Succesfully set prebuilds repository for '{id}' to {prebuilds_url}!").bold().green();
         println!("{styled_message}");
     }
 }

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -77,15 +77,27 @@ pub enum RepositoriesArgs {
         id: String,
     },
 
-    /// Sets the prebuilds repository url and provider
-    SetPrebuilds {
-        /// The id of the repository to set the prebuilds repository of
+    /// Sets the repository url and provider
+    SetUrl {
+        /// The id of the repository to set the url of
         id: String,
 
-        /// The url of the prebuilds repository
+        /// The new url of the repository
+        url: String,
+
+        /// The new provider of the repository, if no value is given, the old value is used
+        provider: Option<String>,
+    },
+
+    /// Sets the prebuilds repository url and provider
+    SetPrebuilds {
+        /// The id of the repository to set the prebuilds url of
+        id: String,
+
+        /// The new url of the prebuilds repository
         prebuilds_url: String,
 
-        /// The optional provider of the prebuilds repository, `web` is used as default
+        /// The new provider of the prebuilds repository, if no value is given, the old value is used
         prebuilds_provider: Option<String>,
     },
 }
@@ -103,6 +115,7 @@ impl HandleCommand for ConfigArgs {
             ConfigArgs::Repositories(RepositoriesArgs::SetRank { new_rank }) => self.handle_set_repositories_rank(config, new_rank),
             ConfigArgs::Repositories(RepositoriesArgs::Add { id, url, provider }) => self.handle_add_repository(config, id, url, provider),
             ConfigArgs::Repositories(RepositoriesArgs::Remove { id }) => self.handle_remove_repository(config, id),
+            ConfigArgs::Repositories(RepositoriesArgs::SetUrl { id, url, provider }) => self.handle_set_url(config, id, url, provider),
             ConfigArgs::Repositories(RepositoriesArgs::SetPrebuilds {
                 id,
                 prebuilds_url,
@@ -325,6 +338,29 @@ impl ConfigArgs {
         println!("{styled_message}");
     }
 
+    /// Handles the config repositories set-url command.
+    fn handle_set_url(&self, mut config: EditableConfig, id: &str, url: &str, provider: &Option<String>) {
+        // Check if the config even contains this repository
+        let Some(mut repository) = config.get_config().repositories.get(id).cloned() else {
+            error!(msg: "Repository '{id}' does not exist.");
+            exit(1);
+        };
+
+        warning!("Overwriting url: {}, provider: {}", repository.url, repository.provider);
+
+        repository.url = url.into();
+        if let Some(provider) = provider {
+            repository.provider = provider.clone();
+        }
+
+        config.set_repository(id, repository);
+
+        config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
+
+        let styled_message = format!("Succesfully set repository url for '{id}' to {url}!").bold().green();
+        println!("{styled_message}");
+    }
+
     /// Handles the config repositories set-prebuilds command.
     fn handle_set_prebuilds(&self, mut config: EditableConfig, id: &str, prebuilds_url: &str, prebuilds_provider: &Option<String>) {
         // Check if the config even contains this repository
@@ -343,7 +379,9 @@ impl ConfigArgs {
         }
 
         repository.prebuilds_url = Some(prebuilds_url.into());
-        repository.prebuilds_provider = prebuilds_provider.clone();
+        if prebuilds_provider.is_some() {
+            repository.prebuilds_provider = prebuilds_provider.clone();
+        }
 
         config.set_repository(id, repository);
 

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -100,6 +100,20 @@ pub enum RepositoriesArgs {
         /// The new provider of the prebuilds repository, if no value is given, the old value is used
         prebuilds_provider: Option<String>,
     },
+
+    /// Disables or enables the prebuilds of a repository
+    DisablePrebuilds {
+        /// The id of the repository to enable or disable the prebuilds of
+        id: String,
+
+        /// True to disable prebuilds, false to enable
+        #[arg(action = ArgAction::Set)]
+        value: bool,
+
+        /// True if the prebuilds url should be removed
+        #[arg(long, default_value = "false")]
+        remove_urls: bool,
+    },
 }
 
 impl HandleCommand for ConfigArgs {
@@ -121,6 +135,9 @@ impl HandleCommand for ConfigArgs {
                 prebuilds_url,
                 prebuilds_provider,
             }) => self.handle_set_prebuilds(config, id, prebuilds_url, prebuilds_provider),
+            ConfigArgs::Repositories(RepositoriesArgs::DisablePrebuilds { id, value, remove_urls }) => {
+                self.handle_disable_prebuilds(config, id, *value, *remove_urls)
+            },
         }
     }
 }
@@ -388,6 +405,31 @@ impl ConfigArgs {
         config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
 
         let styled_message = format!("Succesfully set prebuilds repository for '{id}' to {prebuilds_url}!").bold().green();
+        println!("{styled_message}");
+    }
+
+    /// Handles the config repositories disable-prebuilds command.
+    fn handle_disable_prebuilds(&self, mut config: EditableConfig, id: &str, value: bool, remove_urls: bool) {
+        // Check if the config even contains this repository
+        let Some(mut repository) = config.get_config().repositories.get(id).cloned() else {
+            error!(msg: "Repository '{id}' does not exist.");
+            exit(1);
+        };
+
+        repository.disable_prebuilds = value;
+
+        // Remove url if prebuilds disabled and `--remove-urls` flag is enabled
+        if value && remove_urls {
+            repository.prebuilds_url = None;
+            repository.prebuilds_provider = None;
+        }
+
+        config.set_repository(id, repository);
+
+        config.save_to(&Config::get_default_path()).unwrap_or_exit_msg("Cannot save config file", 1);
+
+        let disabled = if value { "disabled" } else { "enabled" };
+        let styled_message = format!("Succesfully {disabled} prebuilds for '{id}'!").bold().green();
         println!("{styled_message}");
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -240,26 +240,62 @@ impl EditableConfig {
     }
 
     /// Sets the repository with the given id.
+    /// Tries to preserve comments and field ordering.
     pub fn set_repository(&mut self, id: &str, repository: Repository) {
         // Ensure repositories is a table, not an inline table
         if !self.document.contains_table("repositories") {
             self.document["repositories"] = toml_edit::Table::new().into();
         }
 
-        // TODO: don't fully replace existing tables
+        let repositories = self.document["repositories"].as_table_like_mut().expect("Expected repositories to be a table!");
+        let already_existed = repositories.contains_key(id);
+
+        // Load existing table, or use a new one
         let mut new_value = toml_edit::Table::new();
-        new_value["url"] = (&repository.url).into();
-        new_value["provider"] = (&repository.provider).into();
+        let repository_table = match already_existed {
+            true => repositories
+                .get_mut(id)
+                .expect("Expected key to existing in repositories!")
+                .as_table_like_mut()
+                .expect("Expected repository to be a table!"),
+            false => &mut new_value,
+        };
+
+        // Replace url and provider if the new value does not match the old value
+        if repository_table.get("url").map(|x| x.as_str()).flatten() != Some(&repository.url) {
+            repository_table.insert("url", (&repository.url).into());
+        }
+        if repository_table.get("provider").map(|x| x.as_str()).flatten() != Some(&repository.provider) {
+            repository_table.insert("provider", (&repository.provider).into());
+        }
+
+        // Replace prebuilds url and provider if the new value does not match the old value
+        // If the value is not present, remove the field.
         if let Some(prebuilds_url) = &repository.prebuilds_url {
-            new_value["prebuilds_url"] = prebuilds_url.into();
+            if repository_table.get("prebuilds_url").map(|x| x.as_str()).flatten() != Some(&prebuilds_url) {
+                repository_table.insert("prebuilds_url", prebuilds_url.into());
+            }
+        } else {
+            repository_table.remove("prebuilds_url");
         }
         if let Some(prebuilds_provider) = &repository.prebuilds_provider {
-            new_value["prebuilds_provider"] = prebuilds_provider.into();
+            if repository_table.get("prebuildsprebuilds_provider_url").map(|x| x.as_str()).flatten() != Some(&prebuilds_provider) {
+                repository_table.insert("prebuilds_provider", prebuilds_provider.into());
+            }
+        } else {
+            repository_table.remove("prebuilds_provider");
         }
+
+        // Set `disable_prebuilds` if it is true, delete field otherwise
         if repository.disable_prebuilds {
-            new_value["disable_prebuilds"] = true.into();
+            repository_table.insert("disable_prebuilds", true.into());
+        } else {
+            repository_table.remove("disable_prebuilds");
         }
-        self.document["repositories"][id] = new_value.into();
+
+        if !already_existed {
+            self.document["repositories"][id] = new_value.into();
+        }
 
         self.config.repositories.insert(id.into(), repository);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -161,6 +161,7 @@ impl Config {
             pair_aligner.add("Provider", &repo.provider);
             pair_aligner.add("Prebuilds url", repo.prebuilds_url.display());
             pair_aligner.add("Prebuilds provider", repo.prebuilds_provider.display());
+            pair_aligner.add("Prebuilds disabled", if repo.disable_prebuilds { "yes" } else { "no" });
             pair_aligner.display(PairAligner::VERTICAL_LINE_PREFIX);
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -246,6 +246,7 @@ impl EditableConfig {
             self.document["repositories"] = toml_edit::Table::new().into();
         }
 
+        // TODO: don't fully replace existing tables
         let mut new_value = toml_edit::Table::new();
         new_value["url"] = (&repository.url).into();
         new_value["provider"] = (&repository.provider).into();

--- a/src/config.rs
+++ b/src/config.rs
@@ -278,6 +278,7 @@ impl EditableConfig {
         } else {
             repository_table.remove("prebuilds_url");
         }
+
         if let Some(prebuilds_provider) = &repository.prebuilds_provider {
             if repository_table.get("prebuildsprebuilds_provider_url").map(|x| x.as_str()).flatten() != Some(&prebuilds_provider) {
                 repository_table.insert("prebuilds_provider", prebuilds_provider.into());


### PR DESCRIPTION
This PR extends the config command with three new commands:
- `config repositories set-url`
- `config repositories set-prebuilds`
- `config repositories disable-prebuilds`

It also adds the `disable_prebuilds` field to the `config show` command and changes the EditableConfig::set_repository to preserve comments and existing field ordering.