### PR TITLE
Add --pause-build flag to install command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `config repositories set-prebuilds` command, which can be used to change the prebuilds url of a repository.
 - The `config repositories disable-prebuilds` command, which can be used to enable or disable prebuilds of a repository.
 - The `config repositories add` command now has a `--unchecked` flag, which can be used to skip repository checks.
+- The `--pause-build` flag to the `install` command, to pause the build after build script execution.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The Packit repository is licensed under the GNU General Public License v3.0. See
 ## Usage
 The general usage of Packit is: `pit <COMMAND>`.
 
-#### `pit install <PACKAGE-NAME>[@<VERSION>] ... [--build] [--build-all] [--keep-build] [--skip-symlinking] [--skip-active] [--verbose] [--skip-test] [--skip-build-test]`
+#### `pit install <PACKAGE-NAME>[@<VERSION>] ... [--build] [--build-all] [--keep-build] [--skip-symlinking] [--skip-active] [--verbose] [--skip-test] [--skip-build-test] [--pause-build]`
 Installs the specified packages, if a version is given that version will be installed, if not the latest available version will be installed. Multiple packages can be specified by entering multiple names, split by a space.
 <br>
 If the `--build` option is given, the package is build from source, instead of installing a prebuild version.
@@ -60,6 +60,7 @@ If the `--skip-active` option is enabled, the package is not set to active and t
 If the `--skip-test` option is enabled, Packit tests are skipped.
 If the `--skip-build-test` option is enabled, build tests are skipped.
 If the `--verbose` option is given, extra verbose output is shown, like build output.
+If the `--pause-build` option is enabed, the build is paused after build script execution to debug builds.
 
 #### `pit uninstall <PACKAGE-NAME>[@<VERSION>] ...`
 Uninstalls the specified packages, if a version is given that version will be uninstalled, if not, you will be asked if you want to delete all versions of `<PACKAGE-NAME>` in case there are multiple versions installed. Multiple packages can be specified by entering multiple names, split by a space.

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -13,7 +13,11 @@ use crate::{
         BinaryPatcher, BuildEnv,
         error::{BuilderError, Result},
     },
-    cli::display::{ProgressBar, Spinner, logging::debug, styled::Styled},
+    cli::display::{
+        self, ProgressBar, Spinner,
+        logging::{debug, warning},
+        styled::Styled,
+    },
     config::Config,
     installer::{
         install_tree::InstallMeta,
@@ -36,6 +40,7 @@ pub struct Builder<'a> {
     repository_manager: &'a RepositoryManager<'a>,
     verbose: bool,
     skip_build_test: bool,
+    pause_build: bool,
 }
 
 impl<'a> Builder<'a> {
@@ -46,6 +51,7 @@ impl<'a> Builder<'a> {
         repository_manager: &'a RepositoryManager,
         verbose: bool,
         skip_build_test: bool,
+        pause_build: bool,
     ) -> Self {
         Self {
             config,
@@ -53,6 +59,7 @@ impl<'a> Builder<'a> {
             repository_manager,
             verbose,
             skip_build_test,
+            pause_build,
         }
     }
 
@@ -173,6 +180,7 @@ impl<'a> Builder<'a> {
         let script_data = ScriptData::new(&script_path, &destination_dir, &package_id, self.config, &script_args, self.verbose);
 
         // Show build spinner
+        let script_result;
         if !self.verbose {
             let styled_package = format!("{package_name}@{version}").bold().blue();
             let spinner_message = format!("Building {styled_package}");
@@ -180,7 +188,7 @@ impl<'a> Builder<'a> {
             spinner.show();
 
             // Run build script
-            scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test)?;
+            script_result = scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test);
 
             // Finish build spinner
             spinner.finish();
@@ -188,8 +196,21 @@ impl<'a> Builder<'a> {
             println!("Executing build script of {}", package_id.style());
 
             // Run build script
-            scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test)?;
+            script_result = scripts::run_build_script(&script_data, &build_directory, env, self.skip_build_test);
         }
+
+        // Wait before continuing when pause build is enabled
+        if self.pause_build {
+            if let Err(e) = &script_result {
+                warning!("Build script execution returned an error: {e}");
+            }
+
+            println!("Paused building in '{}'", build_directory.path().display());
+            display::wait_for_continue();
+        }
+
+        // Propagate script result
+        script_result?;
 
         // Patch binaries
         BinaryPatcher::new(self.config).patch_binaries_in(destination_dir.as_ref().to_path_buf(), &package_id, installed_dependencies)?;

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -62,6 +62,10 @@ pub struct InstallArgs {
     /// True to skip the build tests (note that these are not the same as the Packit tests)
     #[arg(long, default_value = "false")]
     skip_build_test: bool,
+
+    /// True to pause the install after the build is completed (to debug builds)
+    #[arg(long, default_value = "false")]
+    pause_build: bool,
 }
 
 impl HandleCommand for InstallArgs {
@@ -117,7 +121,8 @@ impl HandleCommand for InstallArgs {
             .keep_build(self.keep_build)
             .verbose(self.verbose)
             .skip_build_test(self.skip_build_test)
-            .skip_test(self.skip_test);
+            .skip_test(self.skip_test)
+            .pause_build(self.pause_build);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // TODO: Check if this exists as an external package (possibly leading to conflicts) (if so, add to external packages)

--- a/src/cli/display/mod.rs
+++ b/src/cli/display/mod.rs
@@ -19,6 +19,7 @@ pub use progressbar::ProgressBar;
 pub use prompts::QuestionResponse;
 pub use prompts::ask_user;
 pub use prompts::ask_user_input;
+pub use prompts::wait_for_continue;
 
 pub use reader::ReaderWithProgress;
 

--- a/src/cli/display/prompts.rs
+++ b/src/cli/display/prompts.rs
@@ -75,6 +75,14 @@ pub fn ask_user_input(question: &str) -> Result<Option<String>> {
     Ok(Some(input.to_string()))
 }
 
+/// Prompts the user to press enter to continue.
+pub fn wait_for_continue() {
+    print!("Press enter to continue...");
+
+    // Wait for user input
+    _ = read_line();
+}
+
 /// Reads a line from stdin
 fn read_line() -> Result<String> {
     io::stdout().flush().err_operation("flush stdout").map_err(DisplayError::IOError)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -211,6 +211,7 @@ impl<'a> Installer<'a> {
                 self.repository_manager,
                 self.options.verbose,
                 self.options.skip_build_test,
+                self.options.pause_build,
             )
             .build(install_meta, &install_directory)?,
         }

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -10,6 +10,7 @@ pub struct InstallerOptions {
     pub verbose: bool,
     pub skip_test: bool,
     pub skip_build_test: bool,
+    pub pause_build: bool,
 }
 
 impl Default for InstallerOptions {
@@ -23,6 +24,7 @@ impl Default for InstallerOptions {
             verbose: false,
             skip_test: false,
             skip_build_test: false,
+            pause_build: false,
         }
     }
 }
@@ -67,6 +69,12 @@ impl InstallerOptions {
     /// Sets the `skip_build_test` field.
     pub fn skip_build_test(mut self, skip: bool) -> Self {
         self.skip_build_test = skip;
+        self
+    }
+
+    /// Sets the `pause_build` field.
+    pub fn pause_build(mut self, pause: bool) -> Self {
+        self.pause_build = pause;
         self
     }
 }


### PR DESCRIPTION
This PR adds the `--pause-build` flag to the install command, which can be used to pause the build after build script execution. This can be handy to debug package build scripts.