### PR TITLE
Add use_<script> fields to skip script downloads for non-existent scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `Alterations` verifier check is now enabled for packages that were installed from a prebuild.
 - The `search --regex` results are now sorted by package name.
 - The `config show` command now also shows the `prebuilds_disabled` option.
+- Setting the `use_<script>` field is now required to use `preinstall`, `postinstall` and `uninstall` scripts.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -51,6 +51,7 @@ See the tables below for all different fields, see [Target fields](#target-field
 | `dependencies`                  | Defines all the dependencies of the package, that are shared by all targets.   |
 | `build_dependencies`            | Defines all build dependencies of the package, that are shared by all targets. |
 | `use_version_specific_<script>` | When set to yes, the specified script is read from the package version directory, instead of the package directory. |
+| `use_<script>`                  | Needs to be set to true when the script should be used. (Only for `preinstall`, `postinstall` and `uninstall`) |
 | `skip_symlinking`               | When set to yes, the package is not symlinked after installation, preventing the package to be detectable through the PATH. |
 | `revisions`                     | A list of strings containing a description of what changed in each metadata or script revision. |
 | `deprecation`                   | Defines when the version deprecates, disables and the reason.                  |
@@ -102,6 +103,7 @@ Targets are specified as `[targets.<bounds>]`, where bounds specify the support 
 | `test_requirements`             | Defines all requirements that are needed on the system for testing the package, these need to be installed by the user manually. |
 | `skip_symlinking`               | When set to yes, the package is not symlinked after installation, preventing the package to be detectable through the PATH. Overrides the value defined in the global field. |
 | `<script-type>_script`          | Defines the name of the script to use instead of the default script name.            |
+| `use_<script>`                  | Overwrites the global `use_<script>` field. (Only for `preinstall`, `postinstall` and `uninstall`) |
 | `script_args`                   | A table of key-value pairs containing arguments passed to scripts, additional to the args defined in the global field. |
 | `source`                        | Defines which source to use, required when multiple sources are defined.             |
 | `external_test_files`           | A list of external test files that are needed for executing the test script for this target, additional to the files specified in the global field. These files are automatically downloaded. |

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -21,7 +21,7 @@ use crate::{
     config::Config,
     installer::{
         install_tree::InstallMeta,
-        scripts::{self, ScriptData, ScriptError},
+        scripts::{self, ScriptData},
         types::{PackageId, PackageName},
         unpack::{ArchiveExtension, unpack},
     },
@@ -175,8 +175,7 @@ impl<'a> Builder<'a> {
 
         // Download and run build script
         let script_path = install_meta.version_metadata.get_build_script_path(&install_meta.target_bounds)?;
-        let script_path = scripts::download_script(self.repository_manager, &script_path, package_name, &install_meta.repository_id)?
-            .ok_or(ScriptError::ScriptNotFound("build".into()))?;
+        let script_path = scripts::download_script(self.repository_manager, &script_path, package_name, &install_meta.repository_id)?;
         let script_data = ScriptData::new(&script_path, &destination_dir, &package_id, self.config, &script_args, self.verbose);
 
         // Show build spinner

--- a/src/builder/patcher.rs
+++ b/src/builder/patcher.rs
@@ -185,11 +185,11 @@ impl<'a> BinaryPatcher<'a> {
                 Ok(status) if !status.success() => {
                     let message = match status.code() {
                         Some(code) => format!("codesign exited with status code {code}"),
-                        None => format!("codesign exited without a status code"),
+                        None => "codesign exited without a status code".to_string(),
                     };
                     return Err(BinaryPatcherError::CannotReSign {
                         path,
-                        error: std::io::Error::new(std::io::ErrorKind::Other, message),
+                        error: std::io::Error::other(message),
                     });
                 },
                 Ok(_) => (),

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -196,7 +196,7 @@ impl SearchArgs {
     fn search_package(&self, manager: &RepositoryManager, package_name: &PackageName) {
         let (repository_id, package) = match manager.read_package(package_name) {
             Ok(package) => package,
-            Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package(package_name, &manager, reason),
+            Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package(package_name, manager, reason),
             Err(e) => {
                 error!(e, "Cannot read package");
                 return;
@@ -241,9 +241,7 @@ impl SearchArgs {
         let package_and_version = manager.read_package_and_version(&package_id.clone().into(), &Target::current());
         let (repository_id, package, package_version) = match package_and_version {
             Ok(package) => package,
-            Err(RepositoryError::PackageNotFoundError { reason, .. }) => {
-                not_found::repository_package_version(package_id, &manager, reason)
-            },
+            Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package_version(package_id, manager, reason),
             Err(e) => {
                 error!(e, "Cannot read package");
                 return;

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,17 +262,17 @@ impl EditableConfig {
         };
 
         // Replace url and provider if the new value does not match the old value
-        if repository_table.get("url").map(|x| x.as_str()).flatten() != Some(&repository.url) {
+        if repository_table.get("url").and_then(|x| x.as_str()) != Some(&repository.url) {
             repository_table.insert("url", (&repository.url).into());
         }
-        if repository_table.get("provider").map(|x| x.as_str()).flatten() != Some(&repository.provider) {
+        if repository_table.get("provider").and_then(|x| x.as_str()) != Some(&repository.provider) {
             repository_table.insert("provider", (&repository.provider).into());
         }
 
         // Replace prebuilds url and provider if the new value does not match the old value
         // If the value is not present, remove the field.
         if let Some(prebuilds_url) = &repository.prebuilds_url {
-            if repository_table.get("prebuilds_url").map(|x| x.as_str()).flatten() != Some(&prebuilds_url) {
+            if repository_table.get("prebuilds_url").and_then(|x| x.as_str()) != Some(prebuilds_url) {
                 repository_table.insert("prebuilds_url", prebuilds_url.into());
             }
         } else {
@@ -280,7 +280,7 @@ impl EditableConfig {
         }
 
         if let Some(prebuilds_provider) = &repository.prebuilds_provider {
-            if repository_table.get("prebuildsprebuilds_provider_url").map(|x| x.as_str()).flatten() != Some(&prebuilds_provider) {
+            if repository_table.get("prebuildsprebuilds_provider_url").and_then(|x| x.as_str()) != Some(prebuilds_provider) {
                 repository_table.insert("prebuilds_provider", prebuilds_provider.into());
             }
         } else {

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -255,6 +255,14 @@ impl<'a> Installer<'a> {
         install_directory: &PathBuf,
         script_args: &HashMap<&str, &str>,
     ) -> Result<()> {
+        // Check if preinstall script should be used
+        let target_meta = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
+        let use_script = target_meta.use_preinstall.unwrap_or(install_meta.version_metadata.use_preinstall.unwrap_or(false));
+        if !use_script {
+            debug!("Skipping preinstall script execution since metadata does not define it");
+            return Ok(());
+        }
+
         // Download and run preinstall script if it exists
         let script_path = install_meta.version_metadata.get_preinstall_script_path(&install_meta.target_bounds)?;
         let downloaded_script =
@@ -351,6 +359,14 @@ impl<'a> Installer<'a> {
         install_directory: &PathBuf,
         script_args: &HashMap<&str, &str>,
     ) -> Result<()> {
+        // Check if postinstall script should be used
+        let target_meta = install_meta.version_metadata.get_target(&install_meta.target_bounds)?;
+        let use_script = target_meta.use_postinstall.unwrap_or(install_meta.version_metadata.use_postinstall.unwrap_or(false));
+        if !use_script {
+            debug!("Skipping postinstall script execution since metadata does not define it");
+            return Ok(());
+        }
+
         // Download and run post install script if it exists
         let script_path = install_meta.version_metadata.get_postinstall_script_path(&install_meta.target_bounds)?;
         let downloaded_script =
@@ -761,6 +777,14 @@ impl<'a> Installer<'a> {
         };
 
         let target_bounds = package_version.get_best_target(&Target::current())?;
+
+        // Check if uninstall script should be used
+        let target_meta = package_version.get_target(&target_bounds)?;
+        let use_script = target_meta.use_postinstall.unwrap_or(package_version.use_postinstall.unwrap_or(false));
+        if !use_script {
+            debug!("Skipping uninstall script execution since metadata does not define it");
+            return Ok(());
+        }
 
         // Get script data from package version metadata
         let script_path = package_version.get_uninstall_script_path(&target_bounds)?;

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -263,12 +263,10 @@ impl<'a> Installer<'a> {
             return Ok(());
         }
 
-        // Download and run preinstall script if it exists
+        // Download preinstall script if it exists
         let script_path = install_meta.version_metadata.get_preinstall_script_path(&install_meta.target_bounds)?;
-        let downloaded_script =
-            scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
+        let script_file = scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
 
-        let Some(script_file) = downloaded_script else { return Ok(()) };
         let script_data = ScriptData::new(
             &script_file,
             &install_directory,
@@ -367,12 +365,10 @@ impl<'a> Installer<'a> {
             return Ok(());
         }
 
-        // Download and run post install script if it exists
+        // Download postinstall script if it exists
         let script_path = install_meta.version_metadata.get_postinstall_script_path(&install_meta.target_bounds)?;
-        let downloaded_script =
-            scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
+        let script_file = scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
 
-        let Some(script_file) = downloaded_script else { return Ok(()) };
         let script_data = ScriptData::new(
             &script_file,
             &install_directory,
@@ -474,10 +470,16 @@ impl<'a> Installer<'a> {
     ) -> Result<()> {
         // Download and run test script if it exists
         let script_path = install_meta.version_metadata.get_test_script_path(&install_meta.target_bounds)?;
-        let downloaded_script =
-            scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id)?;
+        let download = scripts::download_script(self.repository_manager, &script_path, &package_id.name, &install_meta.repository_id);
+        let script_file = match download {
+            Ok(script_file) => script_file,
+            Err(ScriptError::ScriptNotFound(_)) => {
+                debug!("Test script not found, skipping execution");
+                return Ok(());
+            },
+            Err(e) => return Err(e.into()),
+        };
 
-        let Some(script_file) = downloaded_script else { return Ok(()) };
         let script_data = ScriptData::new(
             &script_file,
             &install_directory,
@@ -786,20 +788,19 @@ impl<'a> Installer<'a> {
             return Ok(());
         }
 
-        // Get script data from package version metadata
+        // Get script path from package version metadata
         let script_path = package_version.get_uninstall_script_path(&target_bounds)?;
 
-        // Download and run script if it exists
+        // Download uninstall script if it exists
         let Some(script_text) = provider.read_file(&package_id.name, &script_path)? else {
-            return Ok(());
+            return Err(ScriptError::ScriptNotFound(script_path).into());
         };
-
-        let script_path = scripts::write_script_to_tempfile(&script_text)?;
+        let script_file = scripts::write_script_to_tempfile(&script_text)?;
 
         // Run script
         let script_args = package_version.get_script_args(&target_bounds)?;
         let script_data = ScriptData::new(
-            &script_path,
+            &script_file,
             &install_directory,
             package_id,
             self.config,

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -272,14 +272,14 @@ pub fn download_script(
     script_path: &str,
     package_name: &PackageName,
     repository_id: &str,
-) -> Result<Option<NamedTempFile>> {
+) -> Result<NamedTempFile> {
     let script_text = match repository_manager.read_file(repository_id, package_name, script_path)? {
         Some(script_text) => script_text,
-        None => return Ok(None), // Script not found, so return `None`
+        None => return Err(ScriptError::ScriptNotFound(script_path.to_string())), // Script not found, so return `ScriptError::ScriptNotFound`
     };
 
     // Write script to file
-    Ok(Some(write_script_to_tempfile(&script_text)?))
+    Ok(write_script_to_tempfile(&script_text)?)
 }
 
 /// Downloads a script and saves it as a temp file.

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -279,7 +279,7 @@ pub fn download_script(
     };
 
     // Write script to file
-    Ok(write_script_to_tempfile(&script_text)?)
+    write_script_to_tempfile(&script_text)
 }
 
 /// Downloads a script and saves it as a temp file.

--- a/src/register/package_register.rs
+++ b/src/register/package_register.rs
@@ -503,6 +503,9 @@ pub mod tests {
             use_version_specific_postinstall: false,
             use_version_specific_test: false,
             use_version_specific_uninstall: false,
+            use_preinstall: None,
+            use_postinstall: None,
+            use_uninstall: None,
             revisions: Vec::new(),
         }
     }

--- a/src/repositories/types/package_target.rs
+++ b/src/repositories/types/package_target.rs
@@ -33,6 +33,15 @@ pub struct PackageTarget {
     pub test_script: Option<Script>,
     pub uninstall_script: Option<Script>,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_preinstall: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_postinstall: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_uninstall: Option<bool>,
+
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub external_test_files: HashSet<String>,
 

--- a/src/repositories/types/package_version.rs
+++ b/src/repositories/types/package_version.rs
@@ -51,6 +51,15 @@ pub struct PackageVersionMeta {
     #[serde(skip_serializing_if = "PackageVersionMeta::is_default_use_version_specific")]
     pub use_version_specific_uninstall: bool,
 
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_preinstall: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_postinstall: Option<bool>,
+
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub use_uninstall: Option<bool>,
+
     #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     pub external_test_files: HashSet<String>,
 


### PR DESCRIPTION
This PR adds the `use_preinstall`, `use_postinstall` and `use_uninstall` fields to the `targets.toml` file. These need to be set to true for scripts to be found by Packit.

Should Packit return an error for scripts that have a `use_<script>` but not the corresponding script?