### PR TITLE
Fix cargo install in Packit install scripts

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -107,7 +107,7 @@ if ERRORLEVEL 1 goto cleanup
 
 REM Install Packit to the prefix directory 
 echo Downloading Packit prebuild from `%PREBUILD_URL%`
-curl --proto "=https" -sSfL %PREBUILD_URL% --output packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
+curl --proto "=https" -sSfL "%PREBUILD_URL%" --output packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
 if not ERRORLEVEL 1 (
     tar -xf packit@%VERSION%-%REVISION%-%TARGET%.tar.gz
     if ERRORLEVEL 1 goto cleanup
@@ -153,18 +153,26 @@ if not ERRORLEVEL 1 (
             goto cleanup
         )
 
+        REM Check for empty USERPROFILE
+        if "%USERPROFILE%"=="" (
+            echo Cannot do rustup install, because USERPROFILE variable is empty
+            goto cleanup
+        )
+
         REM Install cargo
         echo Installing cargo from '!RUSTUP_URL!'
+        set "RUSTUP_HOME=%USERPROFILE%\.rustup"
+        set "CARGO_HOME=%USERPROFILE%\.cargo"
         curl --proto "=https" --tlsv1.2 -sSfL "!RUSTUP_URL!" --output rustup-init.exe
         if ERRORLEVEL 1 goto cleanup
         
-        .\rustup-init.exe
+        .\rustup-init.exe -y
         if ERRORLEVEL 1 goto cleanup
         del .\rustup-init.exe
         if ERRORLEVEL 1 goto cleanup
 
         REM Make sure that the rustup install was successful
-        where cargo 2>nul >nul
+        !CARGO_HOME!\bin\cargo.exe --version 2>nul >nul 
         if ERRORLEVEL 1 (
             echo Installing rustup failed, canceling Packit installation
             goto cleanup
@@ -190,21 +198,19 @@ if not ERRORLEVEL 1 (
     if ERRORLEVEL 1 goto cleanup
 
     echo Building Packit from source
-    cargo build-install --destination ..\%VERSION%
+    "!CARGO_HOME!\bin\cargo.exe" build-install --destination ..\%VERSION%
     if ERRORLEVEL 1 goto cleanup
     cd ..
     if ERRORLEVEL 1 goto cleanup
     rmdir /s /q .\packit@%VERSION%
     if ERRORLEVEL 1 goto cleanup
 
-    if "!RUSTUP_INSTALLED!"==1 (
-        call :ask "Y" "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it"
-        if ERRORLEVEL 1 (
-            echo Uninstalling rustup
-            rustup self uninstall
-            if ERRORLEVEL 1 goto cleanup
-            echo Uninstalling rustup successful
-        )
+    REM Remove rustup after building Packit
+    if "!RUSTUP_INSTALLED!"=="1" (
+        echo Uninstalling rustup
+        "!CARGO_HOME!\bin\rustup.exe" self uninstall -y
+        if ERRORLEVEL 1 goto cleanup
+        echo Uninstalling rustup successful
     )
 
     echo Building Packit from source successful

--- a/install.sh
+++ b/install.sh
@@ -149,7 +149,7 @@ cd "$PREFIX_DIR/packages/packit/"
 
 # Install Packit to the prefix directory
 echo "Downloading Packit prebuild from '$PREBUILD_URL'"
-if curl --proto "=https" -sSfL $PREBUILD_URL --output packit@$VERSION-$REVISION-$TARGET.tar.gz; then
+if curl --proto "=https" -sSfL "$PREBUILD_URL" --output packit@$VERSION-$REVISION-$TARGET.tar.gz; then
     tar -xf packit@$VERSION-$REVISION-$TARGET.tar.gz
     rm packit@$VERSION-$REVISION-$TARGET.tar.gz
     mv packit@$VERSION-$REVISION-$TARGET $VERSION
@@ -178,10 +178,13 @@ else
         fi
 
         echo "Installing cargo from 'https://sh.rustup.rs'"
-        curl --proto '=https' --tlsv1.2 -sSfL https://sh.rustup.rs | sh
+        RUSTUP_HOME="$HOME/.rustup"
+        CARGO_HOME="$HOME/.cargo"
+        curl --proto '=https' --tlsv1.2 -sSfL https://sh.rustup.rs | sh -s -- -y
 
         # Make sure that the rustup install was successful
-        if ! command -v cargo >/dev/null 2>&1; then
+        ls "$CARGO_HOME"
+        if ! command -v "$CARGO_HOME/bin/cargo" >/dev/null 2>&1; then
             echo "Installing rustup failed, canceling Packit installation"
             exit 1
         fi
@@ -202,16 +205,15 @@ else
     cd packit@$VERSION
 
     echo "Building Packit from source"
-    cargo build-install --destination ../$VERSION
+    "$CARGO_HOME/bin/cargo" build-install --destination ../$VERSION
     cd ..
     rm -r ./packit@$VERSION
 
+    # Remove rustup after installation
     if [ $RUSTUP_INSTALLED -eq 1 ]; then
-        if ask "Y" "You installed rustup to install Packit. This installation is not registered in Packit. Do you wish to uninstall it"; then
-            echo "Uninstalling rustup"
-            rustup self uninstall
-            echo "Uninstalling rustup successful"
-        fi
+        echo "Uninstalling rustup"
+        "$CARGO_HOME/bin/rustup" self uninstall -y
+        echo "Uninstalling rustup successful"
     fi
 
     echo "Building Packit from source successful"

--- a/install.sh
+++ b/install.sh
@@ -177,13 +177,18 @@ else
             exit 1
         fi
 
+        # Check for empty HOME
+        if [ -z "$HOME" ]; then
+            echo "Cannot do rustup install, because HOME variable is empty"
+            exit 1
+        fi
+
         echo "Installing cargo from 'https://sh.rustup.rs'"
         RUSTUP_HOME="$HOME/.rustup"
         CARGO_HOME="$HOME/.cargo"
         curl --proto '=https' --tlsv1.2 -sSfL https://sh.rustup.rs | sh -s -- -y
 
         # Make sure that the rustup install was successful
-        ls "$CARGO_HOME"
         if ! command -v "$CARGO_HOME/bin/cargo" >/dev/null 2>&1; then
             echo "Installing rustup failed, canceling Packit installation"
             exit 1


### PR DESCRIPTION
This PR fixes the installation of cargo in the Packit install scripts. The install scripts now try to find cargo in it's default install location, so they don't depend on an updated PATH. The user is also not prompted multiple times for the rustup installation, the default is assumed and also removed at the end of the Packit build.