### PR TITLE
Add license file detection to builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `search --regex` results are now sorted by package name.
 - The `config show` command now also shows the `prebuilds_disabled` option.
 - Setting the `use_<script>` field is now required to use `preinstall`, `postinstall` and `uninstall` scripts.
+- The build process now automatically detects license files and copies them to `<package-prefix>/share/licenses/<package-name>`.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -31,11 +31,18 @@ use crate::{
         manager::RepositoryManager,
         types::{Checksum, Patch, Source},
     },
-    utils::{ioerror::IOResultExt, patches, reading::ReadExt, requests},
+    utils::{io, ioerror::IOResultExt, patches, reading::ReadExt, requests},
 };
 
 /// The list of automatically detected license files
-const LICENSE_FILES: &[&str] = &["license", "licence", "copying", "notice", "copyright"];
+const LICENSE_FILE_NAMES: &[&str] = &["license", "licence", "copying", "notice", "copyright"];
+
+/// The list of automatically detected license file extensions
+#[rustfmt::skip]
+const LICENSE_FILE_EXTENSIONS: &[&str] = &[
+    ".txt", ".md", ".markdown", ".mdown", ".mkdn", ".textile", ".rdoc", ".org", ".creole",
+    ".mediawiki", ".wiki", ".rst", ".asciidoc", ".adoc", ".asc", ".pod",
+];
 
 /// The builder of Packit, managing the building of packages.
 pub struct Builder<'a> {
@@ -372,9 +379,16 @@ impl<'a> Builder<'a> {
                 let file_name = entry.file_name().to_ascii_lowercase();
                 let Some(file_name) = file_name.to_str() else { continue };
 
-                // Check if file name matches license file names
-                for license_file_name in LICENSE_FILES {
+                // Check if file name matches license file names and has the correct extension
+                for license_file_name in LICENSE_FILE_NAMES {
                     if file_name.starts_with(license_file_name) {
+                        // Skip file if it has an extension and it is not a correct extension
+                        if let Some(extension) = io::get_last_extension(file_name)
+                            && !LICENSE_FILE_EXTENSIONS.contains(&&*extension.to_lowercase())
+                        {
+                            break;
+                        }
+
                         found_files = true;
 
                         // Create destination directory if it does not exist

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -2,6 +2,7 @@
 use bytes::Bytes;
 use colored::Colorize;
 use std::{
+    collections::VecDeque,
     fs,
     path::{Path, PathBuf},
 };
@@ -32,6 +33,9 @@ use crate::{
     },
     utils::{ioerror::IOResultExt, patches, reading::ReadExt, requests},
 };
+
+/// The list of automatically detected license files
+const LICENSE_FILES: &[&str] = &["license", "licence", "copying", "notice", "copyright"];
 
 /// The builder of Packit, managing the building of packages.
 pub struct Builder<'a> {
@@ -211,6 +215,10 @@ impl<'a> Builder<'a> {
         // Propagate script result
         script_result?;
 
+        // Copy license files
+        let license_directory = destination_dir.as_ref().join("share").join("licenses").join(&install_meta.package_metadata.name);
+        self.copy_license_files(build_directory.path(), &license_directory)?;
+
         // Patch binaries
         BinaryPatcher::new(self.config).patch_binaries_in(destination_dir.as_ref().to_path_buf(), &package_id, installed_dependencies)?;
 
@@ -336,5 +344,57 @@ impl<'a> Builder<'a> {
         }
 
         Ok(bytes)
+    }
+
+    /// Copies license files from the original source into the destination directory.
+    /// Does a breadth-first search from the build directory and stops when it finds license files.
+    /// Only traverse to depth 2, to prevent detecting third party license files.
+    fn copy_license_files(&self, build_directory: &Path, destination_dir: &Path) -> Result<()> {
+        let mut queue = VecDeque::from([(0, build_directory.to_path_buf())]);
+        while let Some((depth, item)) = queue.pop_front() {
+            let mut found_files = false;
+
+            // Read all files in the directory
+            for entry in fs::read_dir(&item).err_with_path("read", &item)? {
+                let entry = entry.err_with_path("iterate", &item)?;
+
+                let metadata = entry.metadata().err_with_path("read metadata of", entry.path())?;
+
+                // If the entry is a directory, add it to the queue
+                if metadata.is_dir() {
+                    // Only add next level if depth is below 2
+                    if depth < 2 {
+                        queue.push_back((depth + 1, entry.path()));
+                    }
+                    continue;
+                }
+
+                let file_name = entry.file_name().to_ascii_lowercase();
+                let Some(file_name) = file_name.to_str() else { continue };
+
+                // Check if file name matches license file names
+                for license_file_name in LICENSE_FILES {
+                    if file_name.starts_with(license_file_name) {
+                        found_files = true;
+
+                        // Create destination directory if it does not exist
+                        if !destination_dir.exists() {
+                            fs::create_dir_all(destination_dir).err_with_path("create dirs", destination_dir)?;
+                        }
+
+                        fs::copy(entry.path(), destination_dir.join(entry.file_name())).err_with_path("copy", entry.path())?;
+                        break;
+                    }
+                }
+            }
+
+            // Stop searching if we found files in this directory
+            if found_files {
+                return Ok(());
+            }
+        }
+
+        debug!("Unable to find license files for package");
+        Ok(())
     }
 }

--- a/src/installer/unpack.rs
+++ b/src/installer/unpack.rs
@@ -10,7 +10,10 @@ use zip::ZipArchive;
 use crate::{
     cli::display::{ReaderWithProgress, styled::Styled},
     installer::types::PackageName,
-    utils::ioerror::{self, IOResultExt},
+    utils::{
+        io,
+        ioerror::{self, IOResultExt},
+    },
 };
 
 /// The errors that occur during unpacking.
@@ -40,16 +43,14 @@ pub enum ArchiveExtension {
 impl ArchiveExtension {
     /// Creates an `ArchiveExtension` from a path.
     pub fn from_path(path: &str) -> Self {
-        let extension_index = match path.chars().rev().position(|x| x == '.') {
-            Some(index) => index,
-            None => return Self::Unknown,
+        let Some(extension) = io::get_last_extension(path) else {
+            return Self::Unknown;
         };
-        let (_, extension) = path.split_at(path.len() - extension_index);
 
         match extension.to_lowercase().as_str() {
-            "gz" | "tgz" => Self::GZ,
-            "zip" => Self::ZIP,
-            "xz" => Self::XZ,
+            ".gz" | ".tgz" => Self::GZ,
+            ".zip" => Self::ZIP,
+            ".xz" => Self::XZ,
             _ => Self::Unknown,
         }
     }

--- a/src/utils/io.rs
+++ b/src/utils/io.rs
@@ -153,3 +153,11 @@ pub fn normalize_path(path: &Path) -> PathBuf {
 
     path
 }
+
+/// Gets the last extension of the given file name, or `None` if the file has no extension
+pub fn get_last_extension(file_name: &str) -> Option<&str> {
+    let extension_index = file_name.chars().rev().position(|x| x == '.')?;
+    let (_, extension) = file_name.split_at(file_name.len() - extension_index - 1);
+
+    Some(extension)
+}


### PR DESCRIPTION
This PR adds automatic license file detection to the builder. It copies the license files to `<package-prefix>/share/licenses/<package-name>`.

Improvements that can still be made:
- Add a field to the metadata to include extra license files or to exclude certain license files.