### PR TITLE
Fix patches meta check

### DIFF
--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -396,54 +396,7 @@ impl MetaCheck {
     fn check_patch(&mut self, package_id: &PackageId, patch_number: &u32, patch: &Patch, target: &str) {
         // Check patch urls if the patch is a remote patch
         if patch.url.starts_with("http://") || patch.url.starts_with("https://") {
-            // Check all patch URL's
-            for url in patch.mirrors.iter().chain(std::iter::once(&patch.url)) {
-                // Check source URL existence
-                let response = match requests::get(url) {
-                    Ok(response) if response.status().is_success() => response,
-                    _ => {
-                        let description = format!(
-                            "The URL '{url}' of {} in target '{target}' patch {patch_number} does not exist",
-                            package_id.style(),
-                        );
-
-                        self.issues.push(MetaIssue::default(description).set_checks_skipped(true));
-                        continue;
-                    },
-                };
-
-                // Check if URL is https
-                if !url.starts_with("https") {
-                    let description = format!(
-                        "The URL '{url}' of {} in target '{target}' patch {patch_number} is not https",
-                        package_id.style(),
-                    );
-                    self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
-                }
-
-                // Get bytes from response
-                let bytes = match response.bytes() {
-                    Ok(bytes) => bytes,
-                    Err(e) => {
-                        error!(e, "Unable to get file bytes");
-                        self.checks_skipped = true;
-                        continue;
-                    },
-                };
-
-                // Check source checksum
-                let correct_checksum = Checksum::from_bytes(&bytes);
-                if patch.checksum != correct_checksum {
-                    let description = format!(
-                        "Checksum '{}' of {} in target '{target}' patch {patch_number} with url '{url}' is incorrect",
-                        patch.checksum,
-                        package_id.style(),
-                    );
-
-                    self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
-                }
-            }
-
+            self.check_patch_remote(package_id, patch_number, patch, target);
             return;
         }
 
@@ -481,6 +434,57 @@ impl MetaCheck {
             );
 
             self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
+        }
+    }
+
+    /// Checks the urls of a remote patch specified in a source.
+    fn check_patch_remote(&mut self, package_id: &PackageId, patch_number: &u32, patch: &Patch, target: &str) {
+        // Check all patch URL's
+        for url in patch.mirrors.iter().chain(std::iter::once(&patch.url)) {
+            // Check source URL existence
+            let response = match requests::get(url) {
+                Ok(response) if response.status().is_success() => response,
+                _ => {
+                    let description = format!(
+                        "The URL '{url}' of {} in target '{target}' patch {patch_number} does not exist",
+                        package_id.style(),
+                    );
+
+                    self.issues.push(MetaIssue::default(description).set_checks_skipped(true));
+                    continue;
+                },
+            };
+
+            // Check if URL is https
+            if !url.starts_with("https") {
+                let description = format!(
+                    "The URL '{url}' of {} in target '{target}' patch {patch_number} is not https",
+                    package_id.style(),
+                );
+                self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
+            }
+
+            // Get bytes from response
+            let bytes = match response.bytes() {
+                Ok(bytes) => bytes,
+                Err(e) => {
+                    error!(e, "Unable to get file bytes");
+                    self.checks_skipped = true;
+                    continue;
+                },
+            };
+
+            // Check source checksum
+            let correct_checksum = Checksum::from_bytes(&bytes);
+            if patch.checksum != correct_checksum {
+                let description = format!(
+                    "Checksum '{}' of {} in target '{target}' patch {patch_number} with url '{url}' is incorrect",
+                    patch.checksum,
+                    package_id.style(),
+                );
+
+                self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
+            }
         }
     }
 

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -385,52 +385,93 @@ impl MetaCheck {
 
     /// Checks a specific patch specified in a source.
     fn check_patch(&mut self, package_id: &PackageId, patch_number: &u32, patch: &Patch, target: &str) {
-        // Check all patch URL's
-        for url in patch.mirrors.iter().chain(std::iter::once(&patch.url)) {
-            // Check source URL existence
-            let response = match requests::get(url) {
-                Ok(response) if response.status().is_success() => response,
-                _ => {
+        // Check patch urls if the patch is a remote patch
+        if patch.url.starts_with("http://") || patch.url.starts_with("https://") {
+            // Check all patch URL's
+            for url in patch.mirrors.iter().chain(std::iter::once(&patch.url)) {
+                // Check source URL existence
+                let response = match requests::get(url) {
+                    Ok(response) if response.status().is_success() => response,
+                    _ => {
+                        let description = format!(
+                            "The URL '{url}' of {} in target '{target}' patch {patch_number} does not exist",
+                            package_id.style(),
+                        );
+
+                        self.issues.push(MetaIssue::default(description).set_checks_skipped(true));
+                        continue;
+                    },
+                };
+
+                // Check if URL is https
+                if !url.starts_with("https") {
                     let description = format!(
-                        "The URL '{url}' of {} in target '{target}' patch {patch_number} does not exist",
+                        "The URL '{url}' of {} in target '{target}' patch {patch_number} is not https",
+                        package_id.style(),
+                    );
+                    self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
+                }
+
+                // Get bytes from response
+                let bytes = match response.bytes() {
+                    Ok(bytes) => bytes,
+                    Err(e) => {
+                        error!(e, "Unable to get file bytes");
+                        self.checks_skipped = true;
+                        continue;
+                    },
+                };
+
+                // Check source checksum
+                let correct_checksum = Checksum::from_bytes(&bytes);
+                if patch.checksum != correct_checksum {
+                    let description = format!(
+                        "Checksum '{}' of {} in target '{target}' patch {patch_number} with url '{url}' is incorrect",
+                        patch.checksum,
                         package_id.style(),
                     );
 
-                    self.issues.push(MetaIssue::default(description).set_checks_skipped(true));
-                    continue;
-                },
-            };
-
-            // Check if URL is https
-            if !url.starts_with("https") {
-                let description = format!(
-                    "The URL '{url}' of {} in target '{target}' patch {patch_number} is not https",
-                    package_id.style(),
-                );
-                self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
+                    self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
+                }
             }
 
-            // Get bytes from response
-            let bytes = match response.bytes() {
-                Ok(bytes) => bytes,
-                Err(e) => {
-                    error!(e, "Unable to get file bytes");
-                    self.checks_skipped = true;
-                    continue;
-                },
-            };
+            return;
+        }
 
-            // Check source checksum
-            let correct_checksum = Checksum::from_bytes(&bytes);
-            if patch.checksum != correct_checksum {
-                let description = format!(
-                    "Checksum '{}' of {} in target '{target}' patch {patch_number} with url '{url}' is incorrect",
-                    patch.checksum,
-                    package_id.style(),
-                );
+        // Check if local patch has mirrors specified
+        if !patch.mirrors.is_empty() {
+            let description = format!(
+                "Patch {patch_number} of {} in target '{target}' has mirrors while the patch is in the metadata repository",
+                package_id.style(),
+            );
+            self.issues.push(MetaIssue::default(description));
+        }
 
-                self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
-            }
+        // Read file from repository
+        let file = match self.provider.read_file_bytes(&package_id.name, &patch.url) {
+            Ok(Some(file)) => file,
+            Ok(None) => {
+                let description = format!("Patch {patch_number} of {} in target '{target}' does not exist", package_id.style());
+                self.issues.push(MetaIssue::default(description).set_checks_skipped(true));
+                return;
+            },
+            Err(e) => {
+                error!(e, "Cannot read file '{}' of package {}", patch.url, package_id.style());
+                return;
+            },
+        };
+
+        // Check source checksum
+        let correct_checksum = Checksum::from_bytes(&file);
+        if patch.checksum != correct_checksum {
+            let description = format!(
+                "Checksum '{}' of {} in target '{target}' patch {patch_number} with url '{}' is incorrect",
+                patch.checksum,
+                package_id.style(),
+                patch.url,
+            );
+
+            self.issues.push(MetaIssue::default(description).set_suggestion(Some(correct_checksum.to_string())));
         }
     }
 

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -379,6 +379,15 @@ impl MetaCheck {
 
         // Check all source patches
         for (patch_number, patch) in &source.patches {
+            // Check if the apply directory is specified
+            if source.apply_patches_in.is_none() && patch.apply_in.is_none() {
+                let description = format!(
+                    "Patch {patch_number} of {} in target '{target}' has no 'apply_in' and no default is specified",
+                    package_id.style(),
+                );
+                self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
+            }
+
             self.check_patch(package_id, patch_number, patch, target);
         }
     }


### PR DESCRIPTION
This PR fixes the patches meta check by handling local patch files correctly.
The meta checks now also check for a proper apply directory for patches