### PR TITLE
Add switch-dependency command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `config repositories disable-prebuilds` command, which can be used to enable or disable prebuilds of a repository.
 - The `config repositories add` command now has a `--unchecked` flag, which can be used to skip repository checks.
 - The `--pause-build` flag to the `install` command, to pause the build after build script execution.
+- The `switch-dependency` command, which can be used to switch dependencies of a package.
 
 ### Changes
 - Change display of true and false values in the `info` and `search` commands.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,9 @@ Fix all issues found by the check command. You will be asked if you want to fix 
 #### `pit switch <PACKAGE-NAME> <VERSION> [--skip-symlinking]`
 Switches the active version of the specified package to the specified version. If the `--skip-symlinking` option is given, the new active version is not symlinked into the /bin, /lib, /share, etc. directories.
 
+#### `pit switch-dependency <PACKAGE-NAME>@<VERSION> <DEPENDENCY-NAME> <NEW-DEPENDENCY-VERSION>`
+Switches the dependency version of the specified package to the specified version.
+
 #### `pit link <PACKAGE-NAME> [--force] [--overwrite]`
 Links the specified package into the /bin, /lib, /share, etc. directories. If the package metadata does not allow a package to be symlinked, the `--force` option is required to force the symlinking of the package. Please be careful with using the `--force` option, since there is most likely a good reason to skip symlinking. The `--overwrite` option can be used to overwrite existing symlinks from another package, please note that this should normally not be used, as conflicts between packages should be avoided.
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -9,6 +9,7 @@ mod link;
 mod list;
 mod search;
 mod switch;
+mod switch_dependency;
 mod uninstall;
 mod unlink;
 mod update;
@@ -24,8 +25,8 @@ use crate::{
     cli::{
         commands::{
             check::CheckArgs, config::ConfigArgs, fix::FixArgs, info::InfoArgs, init::InitArgs, install::InstallArgs, link::LinkArgs,
-            list::ListArgs, search::SearchArgs, switch::SwitchArgs, uninstall::UninstallArgs, unlink::UnlinkArgs, update::UpdateArgs,
-            util::UtilArgs,
+            list::ListArgs, search::SearchArgs, switch::SwitchArgs, switch_dependency::SwitchDependencyArgs, uninstall::UninstallArgs,
+            unlink::UnlinkArgs, update::UpdateArgs, util::UtilArgs,
         },
         display::logging::error,
     },
@@ -55,6 +56,9 @@ enum Commands {
 
     /// Search a certain package
     Search(SearchArgs),
+
+    /// Switch a dependency version of a package
+    SwitchDependency(SwitchDependencyArgs),
 
     /// Switch the active version of a package
     Switch(SwitchArgs),
@@ -133,6 +137,7 @@ impl Cli {
             Commands::Uninstall(args) => args.handle(),
             Commands::List(args) => args.handle(),
             Commands::Search(args) => args.handle(),
+            Commands::SwitchDependency(args) => args.handle(),
             Commands::Switch(args) => args.handle(),
             Commands::Link(args) => args.handle(),
             Commands::Unlink(args) => args.handle(),

--- a/src/cli/commands/switch_dependency.rs
+++ b/src/cli/commands/switch_dependency.rs
@@ -1,0 +1,99 @@
+use std::process::exit;
+
+// SPDX-License-Identifier: GPL-3.0-only
+use clap::Args;
+use colored::Colorize;
+
+use crate::{
+    cli::{
+        commands::HandleCommand,
+        display::{logging::error, not_found, styled::Styled},
+    },
+    config::Config,
+    installer::{
+        Symlinker,
+        types::{PackageId, PackageName, Version},
+    },
+    register::package_register::PackageRegister,
+    utils::unwrap_or_exit::UnwrapOrExit,
+};
+
+/// Switches a dependency version of the specified package to the specified version.
+#[derive(Args, Debug)]
+pub struct SwitchDependencyArgs {
+    /// The name of the package to switch dependency of
+    pub package: PackageId,
+
+    /// The name of the dependency to switch
+    pub dependency_name: PackageName,
+
+    /// The new version of the dependency
+    pub dependency_version: Version,
+}
+
+impl HandleCommand for SwitchDependencyArgs {
+    fn handle(&self) {
+        let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
+        let register_path = PackageRegister::get_path(&config.prefix_directory);
+        let mut register = PackageRegister::from(&register_path).unwrap_or_exit(1);
+
+        // Get installed package
+        let package = match register.get_package_version(&self.package) {
+            Some(package) => package,
+            None => not_found::register_package_version(&self.package, &register),
+        };
+
+        // Check if dependency exists
+        let current_version = package.dependencies.iter().find(|x| x.name == self.dependency_name);
+        let Some(current_version) = current_version else {
+            error!(msg: "Package {} does not have {} as dependency", self.package.style(), self.dependency_name.style());
+            exit(1);
+        };
+
+        // Check if dependency is already at the new version
+        if current_version.version == self.dependency_version {
+            println!(
+                "{} already uses dependency {} version {}",
+                self.package.style(),
+                self.dependency_name.style(),
+                self.dependency_version.style()
+            );
+            return;
+        }
+
+        // Get dependency
+        let dependency = match register.get_package(&self.dependency_name) {
+            Some(package) => package,
+            None => {
+                error!(msg: "Dependency {} is not installed, this is unexpected behaviour", self.dependency_name.style());
+                exit(1)
+            },
+        };
+
+        // Check if new version is installed
+        if !dependency.versions.keys().any(|x| *x == self.dependency_version) {
+            error!(msg: "Dependency version {} is not installed", self.dependency_version.style());
+            not_found::display_versions(dependency.versions.keys());
+        }
+
+        // Switch dependency using symlinker
+        let current_version = current_version.clone();
+        let symlinker = Symlinker::new(&config);
+        if let Err(e) = symlinker.switch_dependency(&mut register, &self.package, &current_version, self.dependency_version.clone()) {
+            error!(e, "Error while trying to switch dependency");
+            exit(1);
+        }
+
+        // Save package register
+        register.save_to(&register_path).unwrap_or_exit(1);
+
+        let styled_message = format!(
+            "Successfully switched dependency {} of {} to {}",
+            self.dependency_name.style(),
+            self.package.style(),
+            self.dependency_version.style()
+        );
+
+        println!("{}", styled_message.bold().green());
+    }
+}

--- a/src/cli/commands/switch_dependency.rs
+++ b/src/cli/commands/switch_dependency.rs
@@ -1,6 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0-only
 use std::process::exit;
 
-// SPDX-License-Identifier: GPL-3.0-only
 use clap::Args;
 use colored::Colorize;
 

--- a/src/cli/display/not_found.rs
+++ b/src/cli/display/not_found.rs
@@ -31,7 +31,7 @@ pub fn repository_version(package_name: &PackageName, manager: &RepositoryManage
 
 /// Displays alternative versions and exits.
 /// Assumes that at least one item exists in the given list of versions.
-fn display_versions<'a>(versions: impl Iterator<Item = &'a Version>) -> ! {
+pub fn display_versions<'a>(versions: impl Iterator<Item = &'a Version>) -> ! {
     println!("Did you mean one of the following version(s):");
     standard_print::print_list(versions.map(|v| v.style()));
     exit(1);

--- a/src/installer/error.rs
+++ b/src/installer/error.rs
@@ -56,6 +56,12 @@ pub enum InstallerError {
         package_name: PackageName,
     },
 
+    #[error("Package {} is not a dependency of {}", dependency.style(), package_id.style())]
+    NotADependency {
+        package_id: PackageId,
+        dependency: PackageId,
+    },
+
     #[error("Canceled package installation: {reason}.")]
     InstallationCanceled {
         reason: String,

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -892,54 +892,27 @@ impl<'a> Installer<'a> {
         // Install the newer packager first
         self.install(&new_package_id.clone().into())?;
 
-        // Add dependents to new_package
-        let package_version = match self.register.get_package_version_mut(&new_package_id) {
-            Some(package_version) => package_version,
-            None => {
-                // Theoretically unreachable
-                return Err(InstallerError::UnreachableError {
-                    msg: format!("New package version {} cannot be retrieved from the register", new_version.style()),
-                });
-            },
-        };
-
-        // Set the dependents of the old package for the new package
-        package_version.dependents = dependents.clone();
-
-        let install_path = package_version.install_path.clone();
-
         // Update dependents to use the new package version
+        let symlinker = Symlinker::new(self.config);
         for dependent_id in &dependents {
-            if let Some(dependent) = self.register.get_package_version_mut(dependent_id) {
-                dependent.dependencies.remove(&old_package_id);
-                dependent.dependencies.insert(new_package_id.clone());
-            }
-
-            // Switch dependents to use new version
-            let link_path = self.config.prefix_directory.join("dependencies").join(dependent_id.to_string()).join(&new_package_id.name);
-            symlink::remove_symlink(&link_path)?;
-            symlink::create_symlink(&install_path, &link_path)?;
+            symlinker.switch_dependency(self.register, dependent_id, &old_package_id, new_package_id.version.clone())?;
         }
 
         // Set the active and symlinked state for the new package (to the old package state)
         let package = self.register.get_package(&old_package_id.name).expect("Expected old package to still exist.");
         if package.active_version == *new_version {
-            Symlinker::new(self.config).set_active(self.register, &new_package_id, package.symlinked)?;
+            symlinker.set_active(self.register, &new_package_id, package.symlinked)?;
         }
 
-        println!(
-            "The new package version {} has been succesfully installed, uninstalling the old version now.",
-            new_version.style()
-        );
+        print!("The new package version {} has been succesfully installed", new_version.style());
 
-        // Remove the old package dependents, because the old package is no longer a dependency
-        // Note that this is necessary before doing an uninstall.
+        // Only uninstall the package if the old package no longer has dependents
         let old_package = self.register.get_package_version_mut(&old_package_id).expect("Expected old package to still exist.");
-        old_package.dependents = unsatisfied_dependents;
-
-        // Only uninstall the package if an update has been done
         if old_package.dependents.is_empty() {
+            println!(", uninstalling the old version now");
             self.uninstall(&old_package_id.into())?;
+        } else {
+            println!(", keeping old version because it still has dependents");
         }
 
         Ok(Some(new_package_id))

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -2,11 +2,11 @@
 use std::{fs, iter, path::Path};
 
 use crate::{
-    cli::display::logging::warning,
+    cli::display::{logging::warning, styled::Styled},
     config::Config,
     installer::{
         error::{InstallerError, Result},
-        types::{PackageId, PackageName},
+        types::{PackageId, PackageName, Version},
     },
     platforms::symlink,
     register::package_register::PackageRegister,
@@ -137,6 +137,87 @@ impl<'a> Symlinker<'a> {
                 });
             },
         };
+
+        // Save package register
+        register.save_to(&PackageRegister::get_path(&self.config.prefix_directory))?;
+
+        Ok(())
+    }
+
+    /// Switches a dependency of a package to another version
+    /// Updates the register with the changed dependencies
+    pub fn switch_dependency(
+        &self,
+        register: &mut PackageRegister,
+        package_id: &PackageId,
+        dependency: &PackageId,
+        new_version: Version,
+    ) -> Result<()> {
+        // Get new dependency from register
+        let new_dependency = PackageId::new(dependency.name.clone(), new_version);
+        let new_dependency_install_path = match register.get_package_version(&new_dependency) {
+            Some(package) => package.install_path.clone(),
+            None => {
+                return Err(InstallerError::PackageNotFound {
+                    package_name: new_dependency.name,
+                    version: Some(new_dependency.version),
+                });
+            },
+        };
+
+        // Remove dependent from old dependency
+        match register.get_package_version_mut(dependency) {
+            Some(package) => {
+                package.dependents.remove(package_id);
+            },
+            None => {
+                return Err(InstallerError::PackageNotFound {
+                    package_name: new_dependency.name,
+                    version: Some(new_dependency.version),
+                });
+            },
+        };
+
+        // Add dependent to new dependency
+        match register.get_package_version_mut(&new_dependency) {
+            Some(package) => {
+                package.dependents.insert(package_id.clone());
+            },
+            None => {
+                return Err(InstallerError::UnreachableError {
+                    msg: format!(
+                        "previously retrieved package {} cannot be found anymore in register",
+                        new_dependency.style()
+                    ),
+                });
+            },
+        };
+
+        // Change dependency in register
+        match register.get_package_version_mut(package_id) {
+            Some(package) => {
+                // Check if the package was a dependency
+                if !package.dependencies.remove(dependency) {
+                    return Err(InstallerError::NotADependency {
+                        package_id: package_id.clone(),
+                        dependency: dependency.clone(),
+                    });
+                }
+
+                package.dependencies.insert(new_dependency);
+            },
+            None => {
+                return Err(InstallerError::PackageNotFound {
+                    package_name: package_id.name.clone(),
+                    version: Some(package_id.version.clone()),
+                });
+            },
+        }
+
+        // Switch symlink to link to new version
+        let link_path = self.config.prefix_directory.join("dependencies").join(package_id.to_string()).join(&dependency.name);
+        symlink::remove_symlink(&link_path)?;
+        symlink::create_symlink(&new_dependency_install_path, &link_path)?;
 
         // Save package register
         register.save_to(&PackageRegister::get_path(&self.config.prefix_directory))?;

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -144,8 +144,8 @@ impl<'a> Symlinker<'a> {
         Ok(())
     }
 
-    /// Switches a dependency of a package to another version
-    /// Updates the register with the changed dependencies
+    /// Switches a dependency of a package to another version.
+    /// Updates the register with the changed dependencies.
     pub fn switch_dependency(
         &self,
         register: &mut PackageRegister,
@@ -167,9 +167,7 @@ impl<'a> Symlinker<'a> {
 
         // Remove dependent from old dependency
         match register.get_package_version_mut(dependency) {
-            Some(package) => {
-                package.dependents.remove(package_id);
-            },
+            Some(package) => package.dependents.remove(package_id),
             None => {
                 return Err(InstallerError::PackageNotFound {
                     package_name: new_dependency.name,
@@ -180,9 +178,7 @@ impl<'a> Symlinker<'a> {
 
         // Add dependent to new dependency
         match register.get_package_version_mut(&new_dependency) {
-            Some(package) => {
-                package.dependents.insert(package_id.clone());
-            },
+            Some(package) => package.dependents.insert(package_id.clone()),
             None => {
                 return Err(InstallerError::UnreachableError {
                     msg: format!(


### PR DESCRIPTION
This PR adds the `switch-dependency` command which can be used to switch dependencies of a package.

It also refactors the update function in the installer to use the new `Symlinker::switch_dependency` function. This function in the symlinker is now responsible for switching dependencies and updating the register.