### PR TITLE
Add deprecation ignore period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The build process now automatically detects license files and copies them to `<package-prefix>/share/licenses/<package-name>`.
 - The `link` command now also shows warnings when `--force` is enabled.
 - The install tree now has color coding, based on installed, prebuild and build state.
+- Package deprecation checks now ignore deprecations that are more than a year in the future.
 
 ### Fixed
 - Fix error messages not representing the error correctly.

--- a/src/cli/display/deprecation.rs
+++ b/src/cli/display/deprecation.rs
@@ -10,6 +10,10 @@ use crate::{
 /// Shows a warning if the given `PackageMeta` is deprecated or will be deprecated soon.
 pub fn show_package_warnings(package: &PackageMeta) {
     let Some(deprecation) = &package.deprecation else { return };
+    if deprecation.should_ignore() {
+        return;
+    }
+
     let reason = match &deprecation.reason {
         Some(reason) => format!(" with reason '{reason}'"),
         None => String::default(),
@@ -25,6 +29,10 @@ pub fn show_package_warnings(package: &PackageMeta) {
 /// Shows a warning if the given `PackageVersionMeta` is deprecated or will be deprecated soon.
 pub fn show_package_version_warnings(package_version: &PackageVersionMeta, package_name: &PackageName) {
     let Some(deprecation) = &package_version.deprecation else { return };
+    if deprecation.should_ignore() {
+        return;
+    }
+
     let reason = match &deprecation.reason {
         Some(reason) => format!(" with reason '{reason}'"),
         None => String::default(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,7 +280,7 @@ impl EditableConfig {
         }
 
         if let Some(prebuilds_provider) = &repository.prebuilds_provider {
-            if repository_table.get("prebuildsprebuilds_provider_url").and_then(|x| x.as_str()) != Some(prebuilds_provider) {
+            if repository_table.get("prebuilds_provider").and_then(|x| x.as_str()) != Some(prebuilds_provider) {
                 repository_table.insert("prebuilds_provider", prebuilds_provider.into());
             }
         } else {

--- a/src/repositories/manager.rs
+++ b/src/repositories/manager.rs
@@ -450,9 +450,10 @@ impl<'a> RepositoryManager<'a> {
                 Err(e) => return Err(e),
             };
 
+            // Only get deprecation info if the deprecation is outside of the ignore limit
             let deprecation = match &package_version.deprecation {
-                Some(deprecation) => deprecation,
-                None => return Ok(package_version),
+                Some(deprecation) if !deprecation.should_ignore() => deprecation,
+                Some(_) | None => return Ok(package_version),
             };
 
             // Update the `latest_deprecated` if it was `None` or if the current version deprecates at a later moment

--- a/src/repositories/types/common.rs
+++ b/src/repositories/types/common.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{collections::HashMap, fmt::Display, ops::Not};
 
-use chrono::Utc;
+use chrono::{Duration, Utc};
 use serde::{Deserialize, Deserializer, Serialize, de};
 
 use crate::repositories::types::Checksum;
@@ -82,6 +82,16 @@ pub struct DeprecationInfo {
     pub reason: Option<String>,
 }
 
+impl DeprecationInfo {
+    /// Defines the time limit outside of which deprecations are ignored.
+    pub const IGNORE_LIMIT: Duration = Duration::days(365);
+
+    /// Checks if the deprecation info should be ignored.
+    pub fn should_ignore(&self) -> bool {
+        self.deprecated_from > Date::now().add_duration(Self::IGNORE_LIMIT)
+    }
+}
+
 impl Source {
     /// Gets all patches of the source, sorted by id.
     pub fn get_sorted_patches(&self) -> Vec<(u32, &Patch)> {
@@ -156,5 +166,10 @@ impl Date {
     /// Gets the current date.
     pub fn now() -> Self {
         Self(Utc::now().date_naive())
+    }
+
+    /// Adds the given duration to the date.
+    pub fn add_duration(self, duration: Duration) -> Self {
+        Self(self.0 + duration)
     }
 }


### PR DESCRIPTION
This PR adds an ignore period to package deprecations: packages that deprecate more than a year in the future are now handled as if they don't have a deprecation date specified.

The PR also contains a small fix for a problem in the `Config`.