### PR TITLE
Fix unlink removing dependency symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix M4 environment variable pointing to install path, instead of the m4 binary.
 - Fix Packit prefix directory in cmake and aclocal environment variables.
 - Fix missing build dependency paths in `ACLOCAL_PATH` environment variable.
+- Fix `unlink` removing dependencies symlinks and other symlinks outside of the symlinked directories.
 
 
 ## [v0.0.3](https://github.com/pack-it/packit/compare/0.0.2...0.0.3) - 2026-07-11

--- a/src/installer/symlinker.rs
+++ b/src/installer/symlinker.rs
@@ -116,12 +116,12 @@ impl<'a> Symlinker<'a> {
             version: Some(package.active_version.clone()),
         })?;
 
-        // Remove all symlinks except for those in the active directory
+        // Remove all symlinks that are in any of the `SYMLINK_DIRECTORIES`
         for entry in fs::read_dir(&self.config.prefix_directory).err_with_path("read", &self.config.prefix_directory)? {
             let entry = entry.err_with_path("iterate", &self.config.prefix_directory)?;
 
             let file_type = entry.file_type().err_with_path("get filetype of", entry.path())?;
-            if file_type.is_dir() && entry.file_name() != "active" {
+            if file_type.is_dir() && SYMLINK_DIRECTORIES.iter().any(|x| *x == entry.file_name()) {
                 io::remove_symlinks(&entry.path(), &package_version.install_path)?;
             }
         }


### PR DESCRIPTION
This PR fixes the unlink behaviour by ensuring it only deletes symlinks in directories that are symlinked. This fixes the issue where dependency symlinks are removed.