### PR TITLE
Remove patch apply directory meta check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased](https://github.com/pack-it/packit/compare/0.0.4...HEAD)
 
+### Fixed
+- Fix patch apply directory meta check reporting wrong issues.
+
 
 ## [v0.0.4](https://github.com/pack-it/packit/compare/0.0.3...0.0.4) - 2026-08-16
 

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -379,15 +379,6 @@ impl MetaCheck {
 
         // Check all source patches
         for (patch_number, patch) in &source.patches {
-            // Check if the apply directory is specified
-            if source.apply_patches_in.is_none() && patch.apply_in.is_none() {
-                let description = format!(
-                    "Patch {patch_number} of {} in target '{target}' has no 'apply_in' and no default is specified",
-                    package_id.style(),
-                );
-                self.issues.push(MetaIssue::default(description).set_issue_type(IssueType::Warning));
-            }
-
             self.check_patch(package_id, patch_number, patch, target);
         }
     }


### PR DESCRIPTION
This PR fixes the incorrect patch apply directory meta check by removing it.