### PR TITLE
Create PACKIT_BUILD_JOBS_COUNT env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 - The integration tests to test Packit.
+- The build scripts now get the `PACKIT_BUILD_JOBS_COUNT` variable to use for parallel builds and tests.
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -230,6 +230,7 @@ Scripts get certain environment variables from Packit:
 | `PACKIT_PACKAGE_DEPENDENCIES_PATH` | The path containing symlinks to all dependencies of the package.                           |
 | `PACKIT_VERBOSE`                   | True (1) if verbose output is enabled, false (0) otherwise.                                |
 | `PACKIT_SKIP_BUILD_TEST`           | True (1) if the build tests should be skipped, false (0) otherwise.                        |
+| `PACKIT_BUILD_JOBS_COUNT`          | The number of jobs to use for build processes in the build script. Using `2 * the CPU count` as a heuristic.                           |
 
 Please note that the build script output is only shown to the user when the verbose mode is turned on. All other scripts always show their output, the output of these scripts should thus be clean. Optional verbose output can be printed when the `PACKIT_VERBOSE` is `1`.
 

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -5,6 +5,7 @@ use std::{
     io::{BufRead, BufReader},
     path::{self, Path, PathBuf},
     process::{Command, Stdio},
+    thread,
 };
 
 use bytes::Bytes;
@@ -190,6 +191,9 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
 
     let package_dependencies_path = script_data.config.prefix_directory.join("dependencies").join(script_data.package_id.to_string());
 
+    // Use 2 * CPU count as a heuristic
+    let job_count = 2 * thread::available_parallelism().map(|n| n.get()).unwrap_or(1);
+
     let mut command = create_command(path);
     command
         .current_dir(run_dir)
@@ -199,7 +203,8 @@ fn run_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, env: Environm
         .env("PACKIT_PACKAGE_PATH", package_install_path)
         .env("PACKIT_PACKAGE_VERSION", script_data.package_id.version.to_string())
         .env("PACKIT_PACKAGE_DEPENDENCIES_PATH", &package_dependencies_path)
-        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" });
+        .env("PACKIT_VERBOSE", if script_data.verbose { "1" } else { "0" })
+        .env("PACKIT_BUILD_JOBS_COUNT", job_count.to_string());
 
     // Only display build logging if verbose is enabled, otherwise create combined pipe for reading
     let mut output = None;


### PR DESCRIPTION
This PR creates the `PACKIT_BUILD_JOBS_COUNT` environmental variable which can be used during the build script execution for builds and tests.