### PR TITLE
Use LazyLock for regex

### DIFF
--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -116,7 +116,7 @@ impl SearchArgs {
         let config = Config::from(&Config::get_default_path()).unwrap_or_exit_msg("Cannot load config", 1);
         let manager = RepositoryManager::new(&config);
 
-        let regex = Regex::new(&self.query).unwrap_or_exit_msg("Invalid regex pattern", 1);
+        let regex = Regex::new(&self.query).unwrap_or_exit_msg(&format!("Invalid regex pattern '{}'", self.query), 1);
         let mut matches = HashSet::new();
         for repository_id in manager.iter_supported_repositories_rank() {
             let index_meta = manager.read_index_metadata(repository_id).unwrap_or_exit(1);

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -1,11 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0-only
-use std::{fmt::Display, ops::Deref, path::Path, str::FromStr};
+use std::{fmt::Display, ops::Deref, path::Path, str::FromStr, sync::LazyLock};
 
 use regex::Regex;
 use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
 const VALID_PACKAGE_NAME: &str = r"^[a-zA-Z0-9\-_]+$";
+const PACKAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(VALID_PACKAGE_NAME).expect("Expected valid regex"));
 
 /// Errors that occur when creating or parsing the package name.
 #[cfg_attr(test, derive(PartialEq))]
@@ -68,8 +69,7 @@ impl FromStr for PackageName {
     /// Parses a string into a `PackageName`.
     /// Could return a `PackageNameError::InvalidPackageName` error.
     fn from_str(string: &str) -> Result<Self, Self::Err> {
-        let re = Regex::new(VALID_PACKAGE_NAME).expect("Expected valid regex");
-        if !re.is_match(string) {
+        if !PACKAGE_NAME_REGEX.is_match(string) {
             return Err(PackageNameError::InvalidPackageName);
         }
 


### PR DESCRIPTION
This PR adds a `LazyLock` for regex, so it only gets computed once. It also does a small improvement to a regex error message.