### PR TITLE
Add ordered uninstalls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 - The integration tests to test Packit.
 - The build scripts now get the `PACKIT_BUILD_JOBS_COUNT` variable to use for parallel builds and tests.
+- The uninstall now uninstalls packages in the correct order (so dependents before dependencies).
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -1,16 +1,19 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use clap::Args;
 use colored::Colorize;
-use std::process::exit;
+use std::{collections::VecDeque, process::exit};
 
 use crate::{
     cli::{
         commands::HandleCommand,
         display::{logging::error, not_found, standard_print, styled::Styled},
-        parameter_checks,
+        parameter_checks::{self, contains_package_id},
     },
     config::Config,
-    installer::{Installer, InstallerOptions, types::OptionalPackageId},
+    installer::{
+        Installer, InstallerOptions,
+        types::{OptionalPackageId, PackageId},
+    },
     register::package_register::PackageRegister,
     repositories::manager::RepositoryManager,
     utils::unwrap_or_exit::UnwrapOrExit,
@@ -41,20 +44,13 @@ impl HandleCommand for UninstallArgs {
         let register_dir = PackageRegister::get_path(&config.prefix_directory);
         let mut register = PackageRegister::from(&register_dir).unwrap_or_exit(1);
 
-        // Check if all packages are installed before starting uninstall
-        for optional_id in &self.packages {
-            match optional_id.versioned() {
-                Some(package_id) if register.get_package_version(&package_id).is_some() => continue,
-                Some(package_id) => not_found::register_package_version(&package_id, &register),
-                None if register.get_package(&optional_id.name).is_some() => continue,
-                None => not_found::register_package(&optional_id.name, &register),
-            }
-        }
+        // Determine the order in which to uninstall the given packages
+        let uninstall_order = self.get_uninstall_order(&register);
 
         let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());
 
         // Uninstall all specified packages
-        for optional_id in &self.packages {
+        for optional_id in &uninstall_order {
             match installer.uninstall(optional_id) {
                 Ok(uninstalled_packages) => {
                     for package in uninstalled_packages {
@@ -68,5 +64,65 @@ impl HandleCommand for UninstallArgs {
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);
+    }
+}
+
+impl UninstallArgs {
+    /// Determines the order in which packages need to be uninstalled.
+    /// Shows an error and exists if a package is a dependency and the dependent is not in the given packages.
+    fn get_uninstall_order(&self, register: &PackageRegister) -> Vec<OptionalPackageId> {
+        let mut order = Vec::new();
+        let mut packages = VecDeque::from(self.packages.clone());
+
+        while let Some(package) = packages.pop_front() {
+            let dependents = self.get_dependents(register, &package);
+
+            // Get all the dependents which are missing in the ordered list
+            let mut missing_dependents = Vec::new();
+            for dependent in &dependents {
+                if !contains_package_id(&order, dependent) {
+                    missing_dependents.push(dependent);
+                }
+            }
+
+            // Add to order if all of its dependents are already in the ordered list
+            if missing_dependents.is_empty() {
+                order.push(package);
+                continue;
+            }
+
+            for dependent in &missing_dependents {
+                // If none of the given packages covers the dependent throw an error and exit
+                if !contains_package_id(&self.packages, &dependent) {
+                    error!(
+                        msg: "{} cannot be uninstalled, because it is a dependency of the following packages:",
+                        package.style()
+                    );
+                    standard_print::print_list(dependents.into_iter().map(|d| d.style()));
+                    exit(1);
+                }
+            }
+
+            // Note that because we know that the dependent is in the list of given packages it will be before the current package
+            // if we add it to the back of the queue.
+            packages.push_back(package);
+        }
+
+        order
+    }
+
+    /// Gets the dependents of the given `optional_id`.
+    /// It also checks if the packages exists.
+    fn get_dependents(&self, register: &PackageRegister, optional_id: &OptionalPackageId) -> Vec<PackageId> {
+        match optional_id.versioned() {
+            Some(package_id) if let Some(package_version) = register.get_package_version(&package_id) => {
+                return package_version.dependents.iter().cloned().collect();
+            },
+            Some(package_id) => not_found::register_package_version(&package_id, &register),
+            None if let Some(package) = register.get_package(&optional_id.name) => {
+                return package.get_versions().iter().flat_map(|p| p.dependents.iter().cloned()).collect();
+            },
+            None => not_found::register_package(&optional_id.name, &register),
+        }
     }
 }

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -7,7 +7,7 @@ use crate::{
     cli::{
         commands::HandleCommand,
         display::{logging::error, not_found, standard_print, styled::Styled},
-        parameter_checks::{self, contains_package_id},
+        parameter_checks,
     },
     config::Config,
     installer::{
@@ -69,7 +69,7 @@ impl HandleCommand for UninstallArgs {
 
 impl UninstallArgs {
     /// Determines the order in which packages need to be uninstalled.
-    /// Shows an error and exists if a package is a dependency and the dependent is not in the given packages.
+    /// Shows an error and exits if a package is a dependency and the dependent is not in the given packages.
     fn get_uninstall_order(&self, register: &PackageRegister) -> Vec<OptionalPackageId> {
         let mut order = Vec::new();
         let mut packages = VecDeque::from(self.packages.clone());
@@ -80,7 +80,7 @@ impl UninstallArgs {
             // Get all the dependents which are missing in the ordered list
             let mut missing_dependents = Vec::new();
             for dependent in &dependents {
-                if !contains_package_id(&order, dependent) {
+                if !parameter_checks::contains_package_id(&order, dependent) {
                     missing_dependents.push(dependent);
                 }
             }
@@ -93,7 +93,7 @@ impl UninstallArgs {
 
             for dependent in &missing_dependents {
                 // If none of the given packages covers the dependent throw an error and exit
-                if !contains_package_id(&self.packages, &dependent) {
+                if !parameter_checks::contains_package_id(&self.packages, &dependent) {
                     error!(
                         msg: "{} cannot be uninstalled, because it is a dependency of the following packages:",
                         package.style()
@@ -103,8 +103,8 @@ impl UninstallArgs {
                 }
             }
 
-            // Note that because we know that the dependent is in the list of given packages it will be before the current package
-            // if we add it to the back of the queue.
+            // Note that because we know that the dependent is in the list of given packages
+            // it will be before the current package if we add it to the back of the queue.
             packages.push_back(package);
         }
 
@@ -114,15 +114,18 @@ impl UninstallArgs {
     /// Gets the dependents of the given `optional_id`.
     /// It also checks if the packages exists.
     fn get_dependents(&self, register: &PackageRegister, optional_id: &OptionalPackageId) -> Vec<PackageId> {
-        match optional_id.versioned() {
-            Some(package_id) if let Some(package_version) = register.get_package_version(&package_id) => {
-                return package_version.dependents.iter().cloned().collect();
-            },
-            Some(package_id) => not_found::register_package_version(&package_id, &register),
-            None if let Some(package) = register.get_package(&optional_id.name) => {
+        let Some(package_id) = optional_id.versioned() else {
+            if let Some(package) = register.get_package(&optional_id.name) {
                 return package.get_versions().iter().flat_map(|p| p.dependents.iter().cloned()).collect();
-            },
-            None => not_found::register_package(&optional_id.name, &register),
+            }
+
+            not_found::register_package(&optional_id.name, &register)
+        };
+
+        if let Some(package_version) = register.get_package_version(&package_id) {
+            return package_version.dependents.iter().cloned().collect();
         }
+
+        not_found::register_package_version(&package_id, &register)
     }
 }

--- a/src/cli/parameter_checks.rs
+++ b/src/cli/parameter_checks.rs
@@ -73,3 +73,18 @@ pub fn expand_optional_ids(register: &PackageRegister, config: &Config, packages
 
     package_ids
 }
+
+/// Checks if a given list of `OptionalPackageId`s contains a `PackageId`.
+/// The list contains the given package id if any of the optional ids match with the package id.
+pub fn contains_package_id(packages: &Vec<OptionalPackageId>, package_id: &PackageId) -> bool {
+    for package in packages {
+        match package.versioned() {
+            Some(package_version) if package_version == *package_id => return true,
+            Some(_) => {},
+            None if package.name == package_id.name => return true,
+            None => {},
+        }
+    }
+
+    false
+}

--- a/src/cli/parameter_checks.rs
+++ b/src/cli/parameter_checks.rs
@@ -75,7 +75,7 @@ pub fn expand_optional_ids(register: &PackageRegister, config: &Config, packages
 }
 
 /// Checks if a given list of `OptionalPackageId`s contains a `PackageId`.
-/// The list contains the given package id if any of the optional ids match with the package id.
+/// Returns true if any of the `packages` match the `package_id`, false otherwise.
 pub fn contains_package_id(packages: &Vec<OptionalPackageId>, package_id: &PackageId) -> bool {
     for package in packages {
         match package.versioned() {


### PR DESCRIPTION
This PR adds ordered uninstalls, so dependents are uninstalled before their dependencies. If a package cannot be uninstalled, because packages still depend on it, a nice list of those dependents is shown.