### PR TITLE
Add --exclude for util package command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The integration tests to test Packit.
 - The build scripts now get the `PACKIT_BUILD_JOBS_COUNT` variable to use for parallel builds and tests.
 - The uninstall now uninstalls packages in the correct order (so dependents before dependencies).
+- The `--exclude` flag for the `pit util package` command, to exclude certain packages when using the `--all` flag.
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -10,9 +10,10 @@ use crate::{
     cli::{
         commands::HandleCommand,
         display::{Spinner, logging::error, not_found, styled::Styled},
+        parameter_checks,
     },
     config::{Config, Repository},
-    installer::types::PackageId,
+    installer::types::{OptionalPackageId, PackageId},
     packager,
     platforms::Target,
     register::package_register::PackageRegister,
@@ -34,8 +35,13 @@ pub struct PackageArgs {
     structured: bool,
 
     /// True to package all installed packages
-    #[arg(short, long, default_value = "false")]
+    #[arg(short, long, default_value = "false", conflicts_with = "packages")]
     all: bool,
+
+    /// Exclude packages when using the `--all` flag, specified with <PACKAGE-NAME> ...
+    /// Note that `num_args = 1..` is needed to consume all 'non-flag' values after the exclude
+    #[arg(long, requires = "all", num_args = 1..)]
+    exclude: Vec<OptionalPackageId>,
 }
 
 impl HandleCommand for PackageArgs {
@@ -49,12 +55,15 @@ impl HandleCommand for PackageArgs {
             false => self.packages.iter().collect(),
         };
 
+        // Exclude packages (note that the default value of exclude is an empty vec, so nothing is filtered)
+        let packages: Vec<&PackageId> = packages.into_iter().filter(|p| !parameter_checks::contains_package_id(&self.exclude, p)).collect();
+
         if packages.is_empty() {
             error!(msg: "Nothing packaged, no packages specified");
             exit(1);
         }
 
-        for package_id in &packages {
+        for package_id in packages {
             // Get the correct install directory
             let destination = match self.structured {
                 true => {

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -39,7 +39,7 @@ pub struct PackageArgs {
     all: bool,
 
     /// Exclude packages when using the `--all` flag, specified with <PACKAGE-NAME> ...
-    /// Note that `num_args = 1..` is needed to consume all 'non-flag' values after the exclude
+    // Note that `num_args = 1..` is needed to consume all 'non-flag' values after the exclude
     #[arg(long, requires = "all", num_args = 1..)]
     exclude: Vec<OptionalPackageId>,
 }


### PR DESCRIPTION
This PR adds the `--exclude` flag to the package command. It already exists in the `update` command, so it seems nice to have similar behaviour here. When `--all` is specified `--exclude` specifies packages which should be excluded from the list of packages from `--all`.