### PR TITLE
Change the '--skip-build-test' flag to '--include-build-test'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - New and improved documentation.
 
 ### Changes
-- The build tests are now turned off by default and can be turned on with `--include-build-test` (`--skip-build-test` is removed).
+- The build tests are now turned off by default and can be turned on with `--execute-build-test` (`--skip-build-test` is removed).
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The `--exclude` flag for the `pit util package` command, to exclude certain packages when using the `--all` flag.
 - New and improved documentation.
 
+### Changes
+- The build tests are now turned off by default and can be turned on with `--include-build-test` (`--skip-build-test` is removed).
+
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.
 

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -244,7 +244,7 @@ Scripts get certain environment variables from Packit:
 | `PACKIT_PACKAGE_VERSION`           | The version of the package the script belongs to.                                          |
 | `PACKIT_PACKAGE_DEPENDENCIES_PATH` | The path containing symlinks to all dependencies of the package.                           |
 | `PACKIT_VERBOSE`                   | True (1) if verbose output is enabled, false (0) otherwise.                                |
-| `PACKIT_INCLUDE_BUILD_TEST`        | True (1) if the build tests should be executed, false (0) otherwise.                       |
+| `PACKIT_EXECUTE_BUILD_TEST`        | True (1) if the build tests should be executed, false (0) otherwise.                       |
 | `PACKIT_BUILD_JOBS_COUNT`          | The number of jobs to use for build processes in the build script. Using `2 * the CPU count` as a heuristic.                           |
 
 Please note that the build script output is only shown to the user when the verbose mode is turned on. All other scripts always show their output, the output of these scripts should thus be clean. Optional verbose output can be printed when the `PACKIT_VERBOSE` is `1`.

--- a/docs/metadata.md
+++ b/docs/metadata.md
@@ -244,7 +244,7 @@ Scripts get certain environment variables from Packit:
 | `PACKIT_PACKAGE_VERSION`           | The version of the package the script belongs to.                                          |
 | `PACKIT_PACKAGE_DEPENDENCIES_PATH` | The path containing symlinks to all dependencies of the package.                           |
 | `PACKIT_VERBOSE`                   | True (1) if verbose output is enabled, false (0) otherwise.                                |
-| `PACKIT_SKIP_BUILD_TEST`           | True (1) if the build tests should be skipped, false (0) otherwise.                        |
+| `PACKIT_INCLUDE_BUILD_TEST`        | True (1) if the build tests should be executed, false (0) otherwise.                       |
 | `PACKIT_BUILD_JOBS_COUNT`          | The number of jobs to use for build processes in the build script. Using `2 * the CPU count` as a heuristic.                           |
 
 Please note that the build script output is only shown to the user when the verbose mode is turned on. All other scripts always show their output, the output of these scripts should thus be clean. Optional verbose output can be printed when the `PACKIT_VERBOSE` is `1`.

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -50,7 +50,7 @@ pub struct Builder<'a> {
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     verbose: bool,
-    include_build_test: bool,
+    execute_build_test: bool,
     pause_build: bool,
 }
 
@@ -61,7 +61,7 @@ impl<'a> Builder<'a> {
         register: &'a mut PackageRegister,
         repository_manager: &'a RepositoryManager,
         verbose: bool,
-        include_build_test: bool,
+        execute_build_test: bool,
         pause_build: bool,
     ) -> Self {
         Self {
@@ -69,7 +69,7 @@ impl<'a> Builder<'a> {
             register,
             repository_manager,
             verbose,
-            include_build_test,
+            execute_build_test,
             pause_build,
         }
     }
@@ -200,7 +200,7 @@ impl<'a> Builder<'a> {
             spinner.show();
 
             // Run build script
-            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.include_build_test);
+            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.execute_build_test);
 
             // Finish build spinner
             spinner.finish();
@@ -208,7 +208,7 @@ impl<'a> Builder<'a> {
             println!("Executing build script of {}", package_id.style());
 
             // Run build script
-            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.include_build_test);
+            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.execute_build_test);
         }
 
         // Wait before continuing when pause build is enabled

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -50,7 +50,7 @@ pub struct Builder<'a> {
     register: &'a mut PackageRegister,
     repository_manager: &'a RepositoryManager<'a>,
     verbose: bool,
-    skip_build_test: bool,
+    include_build_test: bool,
     pause_build: bool,
 }
 
@@ -61,7 +61,7 @@ impl<'a> Builder<'a> {
         register: &'a mut PackageRegister,
         repository_manager: &'a RepositoryManager,
         verbose: bool,
-        skip_build_test: bool,
+        include_build_test: bool,
         pause_build: bool,
     ) -> Self {
         Self {
@@ -69,7 +69,7 @@ impl<'a> Builder<'a> {
             register,
             repository_manager,
             verbose,
-            skip_build_test,
+            include_build_test,
             pause_build,
         }
     }
@@ -200,7 +200,7 @@ impl<'a> Builder<'a> {
             spinner.show();
 
             // Run build script
-            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.skip_build_test);
+            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.include_build_test);
 
             // Finish build spinner
             spinner.finish();
@@ -208,7 +208,7 @@ impl<'a> Builder<'a> {
             println!("Executing build script of {}", package_id.style());
 
             // Run build script
-            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.skip_build_test);
+            script_result = scripts::run_build_script(&script_data, &inner_build_directory, env, self.include_build_test);
         }
 
         // Wait before continuing when pause build is enabled

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -59,9 +59,9 @@ pub struct InstallArgs {
     #[arg(long, default_value = "false")]
     skip_test: bool,
 
-    /// True to skip the build tests (note that these are not the same as the Packit tests)
+    /// True to execute the build tests (note that these are not the same as the Packit tests)
     #[arg(long, default_value = "false")]
-    include_build_test: bool,
+    execute_build_test: bool,
 
     /// True to pause the install after the build is completed (to debug builds)
     #[arg(long, default_value = "false")]
@@ -120,7 +120,7 @@ impl HandleCommand for InstallArgs {
             .skip_active(self.skip_active)
             .keep_build(self.keep_build)
             .verbose(self.verbose)
-            .include_build_test(self.include_build_test)
+            .execute_build_test(self.execute_build_test)
             .skip_test(self.skip_test)
             .pause_build(self.pause_build);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -61,7 +61,7 @@ pub struct InstallArgs {
 
     /// True to skip the build tests (note that these are not the same as the Packit tests)
     #[arg(long, default_value = "false")]
-    skip_build_test: bool,
+    include_build_test: bool,
 
     /// True to pause the install after the build is completed (to debug builds)
     #[arg(long, default_value = "false")]
@@ -120,7 +120,7 @@ impl HandleCommand for InstallArgs {
             .skip_active(self.skip_active)
             .keep_build(self.keep_build)
             .verbose(self.verbose)
-            .skip_build_test(self.skip_build_test)
+            .include_build_test(self.include_build_test)
             .skip_test(self.skip_test)
             .pause_build(self.pause_build);
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -108,7 +108,7 @@ impl<'a> Installer<'a> {
             self.options.install_type = InstallType::BuildAll;
         }
 
-        // Create flattened dependency sequence
+        // Get the metadata of the package for the current target
         let target_bounds = version_metadata.get_best_target(&Target::current())?;
         let root_meta = InstallMeta {
             package_metadata,
@@ -210,7 +210,7 @@ impl<'a> Installer<'a> {
                 self.register,
                 self.repository_manager,
                 self.options.verbose,
-                self.options.skip_build_test,
+                self.options.include_build_test,
                 self.options.pause_build,
             )
             .build(install_meta, &install_directory)?,

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -210,7 +210,7 @@ impl<'a> Installer<'a> {
                 self.register,
                 self.repository_manager,
                 self.options.verbose,
-                self.options.include_build_test,
+                self.options.execute_build_test,
                 self.options.pause_build,
             )
             .build(install_meta, &install_directory)?,

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -9,7 +9,7 @@ pub struct InstallerOptions {
     pub keep_build: bool,
     pub verbose: bool,
     pub skip_test: bool,
-    pub skip_build_test: bool,
+    pub include_build_test: bool,
     pub pause_build: bool,
 }
 
@@ -23,7 +23,7 @@ impl Default for InstallerOptions {
             keep_build: false,
             verbose: false,
             skip_test: false,
-            skip_build_test: false,
+            include_build_test: false,
             pause_build: false,
         }
     }
@@ -66,9 +66,9 @@ impl InstallerOptions {
         self
     }
 
-    /// Sets the `skip_build_test` field.
-    pub fn skip_build_test(mut self, skip: bool) -> Self {
-        self.skip_build_test = skip;
+    /// Sets the `include_build_test` field.
+    pub fn include_build_test(mut self, include: bool) -> Self {
+        self.include_build_test = include;
         self
     }
 

--- a/src/installer/options.rs
+++ b/src/installer/options.rs
@@ -9,7 +9,7 @@ pub struct InstallerOptions {
     pub keep_build: bool,
     pub verbose: bool,
     pub skip_test: bool,
-    pub include_build_test: bool,
+    pub execute_build_test: bool,
     pub pause_build: bool,
 }
 
@@ -23,7 +23,7 @@ impl Default for InstallerOptions {
             keep_build: false,
             verbose: false,
             skip_test: false,
-            include_build_test: false,
+            execute_build_test: false,
             pause_build: false,
         }
     }
@@ -66,9 +66,9 @@ impl InstallerOptions {
         self
     }
 
-    /// Sets the `include_build_test` field.
-    pub fn include_build_test(mut self, include: bool) -> Self {
-        self.include_build_test = include;
+    /// Sets the `execute_build_test` field.
+    pub fn execute_build_test(mut self, execute: bool) -> Self {
+        self.execute_build_test = execute;
         self
     }
 

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -139,9 +139,9 @@ pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Re
 
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, include_build_test: bool) -> Result<()> {
+pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, execute_build_test: bool) -> Result<()> {
     let mut env: Environment = build_env.try_into()?;
-    env.insert_var("PACKIT_INCLUDE_BUILD_TEST", if include_build_test { "1" } else { "0" });
+    env.insert_var("PACKIT_EXECUTE_BUILD_TEST", if execute_build_test { "1" } else { "0" });
     run_script(script_data, run_dir, env, script_data.verbose)
 }
 

--- a/src/installer/scripts.rs
+++ b/src/installer/scripts.rs
@@ -139,9 +139,9 @@ pub fn run_pre_script(script_data: &ScriptData, run_dir: impl AsRef<Path>) -> Re
 
 /// Runs the given build script, in the given directory.
 /// Note that the script should be a `.sh` script on Linux and macOS and a `.bat` on Windows.
-pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, skip_build_test: bool) -> Result<()> {
+pub fn run_build_script(script_data: &ScriptData, run_dir: impl AsRef<Path>, build_env: BuildEnv, include_build_test: bool) -> Result<()> {
     let mut env: Environment = build_env.try_into()?;
-    env.insert_var("PACKIT_SKIP_BUILD_TEST", if skip_build_test { "1" } else { "0" });
+    env.insert_var("PACKIT_INCLUDE_BUILD_TEST", if include_build_test { "1" } else { "0" });
     run_script(script_data, run_dir, env, script_data.verbose)
 }
 


### PR DESCRIPTION
This PR changes the --skip-build-test' flag to '--include-build-test'. The build tests are now be turned off by default.