### PR TITLE
Fix CMAKE_PREFIX_PATH and ACLOCAL_PATH in build environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix patch apply directory meta check reporting wrong issues.
 - Fix patches being able to change files outside of the build directory.
 - Fix the `license_include` file being able to include a file outside of the build directory.
+- Fix build environment to also add symlinked packages in `CMAKE_PREFIX_PATH` and `ACLOCAL_PATH`.
 
 
 ## [v0.0.4](https://github.com/pack-it/packit/compare/0.0.3...0.0.4) - 2026-08-16

--- a/docs/build-env.md
+++ b/docs/build-env.md
@@ -2,7 +2,7 @@
 
 The build environment tries to create an environment which is as 'clean' as possible. This will help with more stable and reproducible builds. This is done by stripping and adding some environment variables.
 
-## Adjusted PATH
+## Adjusted `PATH`
 The build environment creates an adjusted `PATH`. The `PATH` will contain the bin directories of all (build) dependencies. If on Unix, it will also include the standard Unix system bin paths, which are:
 - `/usr/bin`
 - `/bin`
@@ -15,11 +15,14 @@ When on Windows the standard Windows system bin paths are added to the `PATH`, w
 - `C:\Windows\System32\Wbem`
 - `C:\Windows\System32\WindowsPowerShell\v1.0`
 
-## Pkgconfig path
+## `PKG_CONFIG_PATH`
 Packit looks for the presence of a `pkgconfig` directory inside of the `share` and `lib` directories of the dependencies of a package. These paths are then added to the `PKG_CONFIG_PATH` to make them available. It also adds `/usr/lib/pkgconfig` which is a macOS specific path.
 
-## Non-symlinked dependencies
-Some packages are not symlinked, so they cannot be found by cmake in the build process. For that reason, dependencies which are not symlinked are added to the `CMAKE_PREFIX_PATH`. The same applies to the `ACLOCAL_PATH`, with the small difference that build dependencies are also added in this case.
+## `CMAKE_PREFIX_PATH`
+When CMake is used to build packages, it needs to be able to find the dependencies. All dependencies of the package are therefore added to the `CMAKE_PREFIX_PATH`. CMake is then able to automatically detect these dependencies.
+
+## `ACLOCAL_PATH`
+When a package needs aclocal in its build process, aclocal needs to be able to find m4 macro files. All dependencies and build dependencies of the package are added to `ACLOCAL_PATH`. This makes the macro files available and ensures aclocal can find all needed files.
 
 ## Requirement environment
 Some requirements need a certain environment setup. This is different for each requirement. All requirement environments are explained here.

--- a/src/builder/build_env.rs
+++ b/src/builder/build_env.rs
@@ -12,7 +12,7 @@ use crate::{
         Target,
         tool_detection::{self, error::ToolDetectionError},
     },
-    register::{installed_package_version::InstalledPackageVersion, package_register::PackageRegister},
+    register::installed_package_version::InstalledPackageVersion,
     repositories::types::Requirement,
     utils::env::Environment,
 };
@@ -60,7 +60,6 @@ pub struct BuildEnv<'a> {
     dependencies: &'a Vec<&'a InstalledPackageVersion>,
     build_dependencies: Vec<&'a InstalledPackageVersion>,
     build_requirements: &'a Vec<Requirement>,
-    register: &'a PackageRegister,
 }
 
 impl<'a> TryInto<Environment> for BuildEnv<'a> {
@@ -113,13 +112,11 @@ impl<'a> BuildEnv<'a> {
         dependencies: &'a Vec<&'a InstalledPackageVersion>,
         build_dependencies: Vec<&'a InstalledPackageVersion>,
         build_requirements: &'a Vec<Requirement>,
-        register: &'a PackageRegister,
     ) -> Self {
         Self {
             dependencies,
             build_dependencies,
             build_requirements,
-            register,
         }
     }
 
@@ -202,14 +199,8 @@ impl<'a> BuildEnv<'a> {
     fn create_cmake_prefix_path(&self) -> Result<String> {
         let mut parts: Vec<String> = Vec::new();
 
-        // Add non symlinked dependencies to CMAKE_PREFIX_PATH
+        // Add dependencies to CMAKE_PREFIX_PATH
         for dependency in self.dependencies {
-            if let Some(package) = self.register.get_package(&dependency.package_id.name) {
-                if package.symlinked {
-                    continue;
-                }
-            }
-
             parts.push(path_to_string(&dependency.install_path, "CMAKE_PREFIX_PATH")?);
         }
 
@@ -220,14 +211,8 @@ impl<'a> BuildEnv<'a> {
     fn create_aclocal_path(&self) -> Result<String> {
         let mut parts: Vec<String> = Vec::new();
 
-        // Add non symlinked dependencies to ACLOCAL_PATH
+        // Add dependencies to ACLOCAL_PATH
         for dependency in self.dependencies.iter().chain(self.build_dependencies.iter()) {
-            if let Some(package) = self.register.get_package(&dependency.package_id.name) {
-                if package.symlinked {
-                    continue;
-                }
-            }
-
             let share_path = dependency.install_path.join("share").join("aclocal");
 
             // Adding the share dir if it exists

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -185,12 +185,7 @@ impl<'a> Builder<'a> {
         }
 
         // Create build env
-        let env = BuildEnv::new(
-            &installed_dependencies,
-            installed_build_dependencies,
-            &target.build_requirements,
-            self.register,
-        );
+        let env = BuildEnv::new(&installed_dependencies, installed_build_dependencies, &target.build_requirements);
 
         // Construct args for the build script
         let script_args = install_meta.version_metadata.get_script_args(&install_meta.target_bounds)?;


### PR DESCRIPTION
This PR fixes the build environment by also adding symlinked packages to the `CMAKE_PREFIX_PATH` and `ACLOCAL_PATH` environment variables.

This change probably allows us to revert https://github.com/pack-it/core/pull/72 and https://github.com/pack-it/core/pull/77 for the most parts.