### PR TITLE
Change package names to always be lowercase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changes
 - The build tests are now turned off by default and can be turned on with `--execute-build-test` (`--skip-build-test` is removed).
+- Package names are now always lowercase, the commands translate uppercase to lowercase.
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -72,7 +72,7 @@ impl HandleCommand for SearchArgs {
 
         // Get the optional id
         let message = "The given search query isn't a valid package. For regex use '--regex'";
-        let optional_id = OptionalPackageId::from_str(&self.query).unwrap_or_exit_msg(message, 1);
+        let optional_id = OptionalPackageId::from_str(&self.query.to_lowercase()).unwrap_or_exit_msg(message, 1);
 
         // Check if there is version ambiguity (version and `--latest` specified)
         if optional_id.version.is_some() && self.latest {

--- a/src/cli/display/mod.rs
+++ b/src/cli/display/mod.rs
@@ -5,6 +5,7 @@ pub mod error;
 pub mod grid;
 pub mod logging;
 pub mod not_found;
+mod parsing;
 mod progressbar;
 mod prompts;
 mod reader;

--- a/src/cli/display/parsing.rs
+++ b/src/cli/display/parsing.rs
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: GPL-3.0-only
+
+//! This module contains custom parser implementations for clap.
+//!
+//! Currently they are only used to allow uppercase characters in package names.
+//! The parsers automatically translate these to lowercase names.
+use std::ffi::OsStr;
+
+use clap::{
+    Arg, Command,
+    builder::{TypedValueParser, ValueParserFactory},
+};
+
+use crate::installer::types::{OptionalPackageId, PackageId, PackageName};
+
+#[derive(Clone, Debug)]
+pub struct PackageNameParser;
+
+impl TypedValueParser for PackageNameParser {
+    type Value = PackageName;
+
+    fn parse_ref(&self, cmd: &Command, arg: Option<&Arg>, value: &OsStr) -> Result<Self::Value, clap::error::Error> {
+        let inner_parser = <Self::Value as std::str::FromStr>::from_str;
+        inner_parser.parse_ref(cmd, arg, &value.to_ascii_lowercase())
+    }
+}
+
+impl ValueParserFactory for PackageName {
+    type Parser = PackageNameParser;
+
+    fn value_parser() -> Self::Parser {
+        PackageNameParser
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct PackageIdParser;
+
+impl TypedValueParser for PackageIdParser {
+    type Value = PackageId;
+
+    fn parse_ref(&self, cmd: &Command, arg: Option<&Arg>, value: &OsStr) -> Result<Self::Value, clap::error::Error> {
+        let inner_parser = <Self::Value as std::str::FromStr>::from_str;
+        inner_parser.parse_ref(cmd, arg, &value.to_ascii_lowercase())
+    }
+}
+
+impl ValueParserFactory for PackageId {
+    type Parser = PackageIdParser;
+
+    fn value_parser() -> Self::Parser {
+        PackageIdParser
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct OptionalPackageIdParser;
+
+impl TypedValueParser for OptionalPackageIdParser {
+    type Value = OptionalPackageId;
+
+    fn parse_ref(&self, cmd: &Command, arg: Option<&Arg>, value: &OsStr) -> Result<Self::Value, clap::error::Error> {
+        let inner_parser = <Self::Value as std::str::FromStr>::from_str;
+        inner_parser.parse_ref(cmd, arg, &value.to_ascii_lowercase())
+    }
+}
+
+impl ValueParserFactory for OptionalPackageId {
+    type Parser = OptionalPackageIdParser;
+
+    fn value_parser() -> Self::Parser {
+        OptionalPackageIdParser
+    }
+}

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
 const VALID_PACKAGE_NAME: &str = r"^[a-z0-9\-_]+$";
-const PACKAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(VALID_PACKAGE_NAME).expect("Expected valid regex"));
+static PACKAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(VALID_PACKAGE_NAME).expect("Expected valid regex"));
 
 /// Errors that occur when creating or parsing the package name.
 #[cfg_attr(test, derive(PartialEq))]

--- a/src/installer/types/package_name.rs
+++ b/src/installer/types/package_name.rs
@@ -5,14 +5,14 @@ use regex::Regex;
 use serde::{Deserialize, Serialize, de};
 use thiserror::Error;
 
-const VALID_PACKAGE_NAME: &str = r"^[a-zA-Z0-9\-_]+$";
+const VALID_PACKAGE_NAME: &str = r"^[a-z0-9\-_]+$";
 const PACKAGE_NAME_REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(VALID_PACKAGE_NAME).expect("Expected valid regex"));
 
 /// Errors that occur when creating or parsing the package name.
 #[cfg_attr(test, derive(PartialEq))]
 #[derive(Error, Debug)]
 pub enum PackageNameError {
-    #[error("Package name cannot be empty and can only contain characters: 'a-z', 'A-Z', '0-9', '-' and '_'")]
+    #[error("Package name cannot be empty and can only contain characters: 'a-z', '0-9', '-' and '_'")]
     InvalidPackageName,
 }
 
@@ -106,7 +106,7 @@ pub mod tests {
 
     #[test]
     fn valid_from_str() {
-        let name = &"_Test-123";
+        let name = &"_test-123";
         assert_eq!(PackageName::from_str(name), Ok(PackageName(name.to_string())));
     }
 
@@ -117,7 +117,7 @@ pub mod tests {
 
     #[test]
     fn from_str_illegal_chars() {
-        let illegal_chars = " ./\\!@#$%^&*():;'\"<>[]{}?|~`±§=+\u{1234}";
+        let illegal_chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ ./\\!@#$%^&*():;'\"<>[]{}?|~`±§=+\u{1234}";
         for name in illegal_chars.chars() {
             assert_eq!(
                 PackageName::from_str(&name.to_string()),
@@ -129,13 +129,13 @@ pub mod tests {
 
     #[test]
     fn format() {
-        let package_name = PackageName("_Test-123".to_string());
-        assert_eq!(package_name.to_string(), "_Test-123");
+        let package_name = PackageName("_test-123".to_string());
+        assert_eq!(package_name.to_string(), "_test-123");
     }
 
     #[test]
     fn get_prefix() {
-        let package_name = PackageName("_Test-123".to_string());
+        let package_name = PackageName("_test-123".to_string());
         assert_eq!(package_name.get_prefix(), '_');
     }
 

--- a/src/register/package_register.rs
+++ b/src/register/package_register.rs
@@ -381,13 +381,13 @@ pub mod tests {
 
     /// This is a helper function which creates a register.
     fn create_register() -> PackageRegister {
-        let package_a = create_package_id("A@3.4.1");
-        let package_b = create_package_id("B@2.72");
-        let package_c = create_package_id("C@1.18.1");
-        let package_d = create_package_id("D@2.5.4");
-        let package_e = create_package_id("E@10.4");
-        let package_f5 = create_package_id("F@5");
-        let package_f6 = create_package_id("F@6");
+        let package_a = create_package_id("a@3.4.1");
+        let package_b = create_package_id("b@2.72");
+        let package_c = create_package_id("c@1.18.1");
+        let package_d = create_package_id("d@2.5.4");
+        let package_e = create_package_id("e@10.4");
+        let package_f5 = create_package_id("f@5");
+        let package_f6 = create_package_id("f@6");
 
         // Package A
         let mut packages = HashMap::new();
@@ -504,7 +504,7 @@ pub mod tests {
         let package_meta = create_package_meta(&package_id);
         let package_version_meta = create_package_version_meta(&package_id);
         let mut dependency_ids = HashSet::new();
-        let package_id_b = create_package_id("B@2.72");
+        let package_id_b = create_package_id("b@2.72");
         dependency_ids.insert(package_id_b.clone());
 
         // Add the package
@@ -543,7 +543,7 @@ pub mod tests {
         let mut register = create_register();
 
         // Check if basic package version removal works
-        let package_a = create_package_id("A@3.4.1");
+        let package_a = create_package_id("a@3.4.1");
         register.remove_package_version(&package_a);
         assert!(register.get_package_version(&package_a).is_none());
         assert!(register.get_package(&package_a.name).is_none());
@@ -553,18 +553,18 @@ pub mod tests {
     fn remove_package_dependency() {
         let mut register = create_register();
 
-        let package_b = create_package_id("B@2.72");
+        let package_b = create_package_id("b@2.72");
         register.remove_package_version(&package_b);
 
         assert!(register.get_package_version(&package_b).is_none());
 
         // Check if package A still has B as a dependency (B shouldn't be removed)
         // The register doesn't check for dependencies when removing a package.
-        let package_a = create_package_id("A@3.4.1");
+        let package_a = create_package_id("a@3.4.1");
         assert!(register.get_package_version(&package_a).expect("Expected package A").dependencies.get(&package_b).is_some());
 
         // Check that B is deleted as a dependent
-        let package_e = create_package_id("E@10.4");
+        let package_e = create_package_id("e@10.4");
         assert!(register.get_package_version(&package_e).expect("Expected package C").dependents.get(&package_b).is_none());
     }
 
@@ -573,12 +573,12 @@ pub mod tests {
         let mut register = create_register();
 
         // Check if the package version was succesfully removed
-        let package_f5 = create_package_id("F@5");
+        let package_f5 = create_package_id("f@5");
         register.remove_package_version(&package_f5);
         assert!(register.get_package_version(&package_f5).is_none());
 
         // Check if the other version still exists
-        let package_f6 = create_package_id("F@6");
+        let package_f6 = create_package_id("f@6");
         assert!(register.get_package_version(&package_f6).is_some());
 
         // Check if the active version was not switched (the register doesn't handle this)
@@ -590,41 +590,41 @@ pub mod tests {
     fn remove_package() {
         let mut register = create_register();
 
-        let package_f = create_package_id("F@5");
+        let package_f = create_package_id("f@5");
         register.remove_package(&package_f.name);
         assert!(register.get_package(&package_f.name).is_none());
 
         // Check if package D still has B as a dependency (B shouldn't be removed)
-        let package_d = create_package_id("D@2.5.4");
+        let package_d = create_package_id("d@2.5.4");
         assert!(register.get_package_version(&package_d).expect("Expected package D").dependencies.get(&package_f).is_some());
     }
 
     #[test]
     fn is_dependency() {
         let register = create_register();
-        let package_f5 = create_package_id("F@5");
+        let package_f5 = create_package_id("f@5");
 
         assert!(register.is_dependency(&package_f5.into()));
-        assert!(register.is_dependency(&OptionalPackageId::from_str("F").expect("Expected valid package name")));
+        assert!(register.is_dependency(&OptionalPackageId::from_str("f").expect("Expected valid package name")));
     }
 
     #[test]
     fn is_not_dependency() {
         let register = create_register();
 
-        let package_f6 = create_package_id("F@6");
+        let package_f6 = create_package_id("f@6");
         assert!(!register.is_dependency(&package_f6.into()));
 
-        let package_a = create_package_id("A@3.4.1");
+        let package_a = create_package_id("a@3.4.1");
         assert!(!register.is_dependency(&package_a.into()));
     }
 
     #[test]
     fn get_latest_satisfying_package() {
         let register = create_register();
-        let package_a_id = create_package_id("F@6");
+        let package_a_id = create_package_id("f@6");
         let package_a = register.get_package_version(&package_a_id).expect("Expected package F");
-        let dependency = create_dependency("F", ">5");
+        let dependency = create_dependency("f", ">5");
 
         assert_eq!(register.get_latest_satisfying_package(&dependency), Some(package_a));
     }
@@ -632,7 +632,7 @@ pub mod tests {
     #[test]
     fn latest_satisfying_package_not_found() {
         let register = create_register();
-        let dependency = create_dependency("A", ">3.4.1");
+        let dependency = create_dependency("a", ">3.4.1");
 
         assert!(register.get_latest_satisfying_package(&dependency).is_none());
     }
@@ -641,13 +641,13 @@ pub mod tests {
     fn get_all_package_versions_test() {
         let mut register = create_register();
 
-        let package_f = create_package_name("F");
+        let package_f = create_package_name("f");
         let package_ids: Vec<PackageId> = register.get_all_package_versions(&package_f).iter().map(|p| p.package_id.clone()).collect();
-        assert!(package_ids.contains(&create_package_id("F@5")));
-        assert!(package_ids.contains(&create_package_id("F@6")));
+        assert!(package_ids.contains(&create_package_id("f@5")));
+        assert!(package_ids.contains(&create_package_id("f@6")));
 
         let package_ids: Vec<PackageId> = register.get_all_package_versions_mut(&package_f).iter().map(|p| p.package_id.clone()).collect();
-        assert!(package_ids.contains(&create_package_id("F@5")));
-        assert!(package_ids.contains(&create_package_id("F@6")));
+        assert!(package_ids.contains(&create_package_id("f@5")));
+        assert!(package_ids.contains(&create_package_id("f@6")));
     }
 }


### PR DESCRIPTION
This PR changes the `PackageName` to always force lowercase names. The commands automatically translate uppercase package names to lowercase names.