### PR TITLE
Fix switch-dependency command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix patches being able to change files outside of the build directory.
 - Fix the `license_include` file being able to include a file outside of the build directory.
 - Fix build environment to also add symlinked packages in `CMAKE_PREFIX_PATH` and `ACLOCAL_PATH`.
+- Fix `pit switch-dependency` command not checking if dependency is still satisfied.
 
 
 ## [v0.0.4](https://github.com/pack-it/packit/compare/0.0.3...0.0.4) - 2026-08-16

--- a/src/cli/commands/switch_dependency.rs
+++ b/src/cli/commands/switch_dependency.rs
@@ -14,7 +14,7 @@ use crate::{
         Symlinker,
         types::{PackageId, PackageName, Version},
     },
-    register::package_register::PackageRegister,
+    register::{metadata::LocalMetaHandler, package_register::PackageRegister},
     utils::unwrap_or_exit::UnwrapOrExit,
 };
 
@@ -59,6 +59,20 @@ impl HandleCommand for SwitchDependencyArgs {
                 self.dependency_version.style()
             );
             return;
+        }
+
+        // Retrieve local metadata of package
+        let local_meta_handler = LocalMetaHandler::new(&config.prefix_directory).get_package(&self.package);
+        let local_metadata = local_meta_handler.read_metadata().unwrap_or_exit_msg("Error while reading local metadata", 1);
+        let Some(dependency_specification) = local_metadata.dependencies.iter().find(|x| *x.get_name() == self.dependency_name) else {
+            error!(msg: "Cannot find dependency details in local metadata of {}", self.package.style());
+            exit(1);
+        };
+
+        // Check if new version satisfies the dependency of the package
+        if !dependency_specification.satisfied(&self.dependency_name, &self.dependency_version) {
+            error!(msg: "Dependency {} is not satisfied by version {}", self.dependency_name.style(), self.dependency_version.style());
+            exit(1)
         }
 
         // Get dependency


### PR DESCRIPTION
This PR fixes the `switch-dependency` command by checking if a dependency is still satisfied after switching the dependency version.