### PR TITLE
Extend revision functionality with local metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Package names are now always lowercase, the commands translate uppercase to lowercase.
 - The parsing for dependencies and targets bounds doesn't allow for `name@` anymore.
 - The `pit util meta-check` command now returns a different exit code, dependending on the most urgent issue type found.
+- The `pit init` command now allows you to specify the revision of the Packit install.
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.

--- a/docs/commands/init.md
+++ b/docs/commands/init.md
@@ -1,7 +1,7 @@
 # Init
 
 The `init` command has the following command line syntax:<br>
-`pit init [--prefix <PREFIX>]`
+`pit init [--prefix <PREFIX>] [--revision <REVISION>] [--revision-descriptions <REVISION-DESCRIPTION> ...]`
 
 ## Basic init
 The `init` command initializes the Packit environment, using the following syntax:<br>
@@ -14,6 +14,12 @@ This is a complete list of all flags that can be used with the `pit init` comman
 
 ### `--prefix <PREFIX>`
 The [default prefix](../structure.md#prefix) can be overridden using the `--prefix` flag. The flag expects a directory path as its argument.
+
+### `--revision <REVISION>`
+The revision of the installed Packit version that is being initialized.
+
+### `--revision-descriptions <REVISION-DESCRIPTION> ...`
+An optional list of revision descriptions to use as fallback when the local metadata cannot be constructed from remote metadata.
 
 #### Example
 To initialize Packit at /foo/bar/buz use:<br>

--- a/src/cli/commands/info.rs
+++ b/src/cli/commands/info.rs
@@ -252,6 +252,6 @@ impl InfoArgs {
         standard_print::print_list_or_none(package_version.dependents.iter().map(|d| d.style()));
 
         print!("Revisions: ");
-        standard_print::print_list_or_none(package_version.revisions.iter());
+        standard_print::print_list_or_none(local_metadata.revisions.iter());
     }
 }

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -32,7 +32,10 @@ pub struct InitArgs {
     /// The prefix to use
     #[arg(long)]
     prefix: Option<PathBuf>,
-    // TODO: get revisions as input here
+
+    /// The revision of the Packit install
+    #[arg(long)]
+    revision: Option<u64>,
 }
 
 #[cfg(unix)]
@@ -107,9 +110,11 @@ impl HandleCommand for InitArgs {
         let package_name = PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name");
         let package_version = Version::from_str(packit_version!()).expect("Expected Packit version to be in the correct format");
         let package_id = PackageId::new(package_name, package_version);
+        let revision = self.revision.unwrap_or(0);
 
         let installed_package_version = InstalledPackageVersion {
             package_id: package_id.clone(),
+            revision,
             metadata_repository_provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.into(),
             metadata_repository_url: DEFAULT_METADATA_REPOSITORY_URL.into(),
             prebuilds_repository_url: None,
@@ -117,7 +122,6 @@ impl HandleCommand for InitArgs {
             dependencies: HashSet::new(),
             dependents: HashSet::new(),
             install_path: packit_package_path,
-            revisions: Vec::new(),
             last_metadata_refresh: DateTime::default(), // Initialize to UNIX epoch
             last_metadata_change: DateTime::default(),  // Initialize to UNIX epoch
         };
@@ -166,7 +170,7 @@ impl HandleCommand for InitArgs {
         // Fetch Packit metadata from the default repository
         let updated = LocalMetaHandler::new(&prefix_directory)
             .get_package(&package_id)
-            .refresh(&provider, 0)
+            .refresh(&provider, revision)
             .unwrap_or_exit_msg("Packit cannot be initialized: error while retrieving Packit metadata", 1);
 
         // Update last refresh in the package version

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -25,7 +25,10 @@ use crate::{
         metadata::{LocalMetaHandler, LocalMetaPackageHandler, LocalMetadata},
         package_register::PackageRegister,
     },
-    repositories::{metadata::MetadataProvider, types::Licenses},
+    repositories::{
+        metadata::MetadataProvider,
+        types::{LicenseIdentifier, Licenses},
+    },
     utils::{
         constants::{DEFAULT_METADATA_REPOSITORY_PROVIDER, DEFAULT_METADATA_REPOSITORY_URL},
         packit_version::packit_version,
@@ -227,7 +230,7 @@ impl InitArgs {
 
         let local_meta = LocalMetadata {
             required_packit_version: None,
-            license: Licenses::Single("GPL-3.0-only".into()),
+            license: Licenses::Single(LicenseIdentifier("GPL-3.0-only".into())),
             dependencies: Vec::new(),
             test_requirements: Vec::new(),
             external_test_files: HashSet::new(),

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -32,6 +32,7 @@ pub struct InitArgs {
     /// The prefix to use
     #[arg(long)]
     prefix: Option<PathBuf>,
+    // TODO: get revisions as input here
 }
 
 #[cfg(unix)]
@@ -165,7 +166,7 @@ impl HandleCommand for InitArgs {
         // Fetch Packit metadata from the default repository
         let updated = LocalMetaHandler::new(&prefix_directory)
             .get_package(&package_id)
-            .refresh(&provider)
+            .refresh(&provider, 0)
             .unwrap_or_exit_msg("Packit cannot be initialized: error while retrieving Packit metadata", 1);
 
         // Update last refresh in the package version

--- a/src/cli/commands/init.rs
+++ b/src/cli/commands/init.rs
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-only
 use std::{
-    collections::HashSet,
+    collections::{HashMap, HashSet},
     path::{self, Path, PathBuf},
     process::exit,
     str::FromStr,
@@ -10,15 +10,22 @@ use chrono::DateTime;
 use clap::Args;
 
 use crate::{
-    cli::{commands::HandleCommand, display::logging::error},
+    cli::{
+        commands::HandleCommand,
+        display::logging::{error, warning},
+    },
     config::{Config, EditableConfig, Repository},
     installer::{
         Symlinker,
         types::{PackageId, PackageName, Version},
     },
     platforms::{DEFAULT_CONFIG_DIR, DEFAULT_PREFIX, permissions},
-    register::{installed_package_version::InstalledPackageVersion, metadata::LocalMetaHandler, package_register::PackageRegister},
-    repositories::metadata::MetadataProvider,
+    register::{
+        installed_package_version::InstalledPackageVersion,
+        metadata::{LocalMetaHandler, LocalMetaPackageHandler, LocalMetadata},
+        package_register::PackageRegister,
+    },
+    repositories::{metadata::MetadataProvider, types::Licenses},
     utils::{
         constants::{DEFAULT_METADATA_REPOSITORY_PROVIDER, DEFAULT_METADATA_REPOSITORY_URL},
         packit_version::packit_version,
@@ -36,6 +43,10 @@ pub struct InitArgs {
     /// The revision of the Packit install
     #[arg(long)]
     revision: Option<u64>,
+
+    /// The descriptions of the revisions to use as fallback
+    #[arg(long, num_args = 1..)]
+    revision_descriptions: Vec<String>,
 }
 
 #[cfg(unix)]
@@ -46,6 +57,13 @@ const PACKIT_BINARY_NAME: &str = "packit.exe";
 
 impl HandleCommand for InitArgs {
     fn handle(&self) {
+        // Check if enough fallback revision descriptions are given (if they are given)
+        // Note that this does not require descriptions. If no revisions are given, a fallback value is used.
+        if !self.revision_descriptions.is_empty() && self.revision_descriptions.len() as u64 != self.revision.unwrap_or(0) {
+            error!(msg: "The number of revision descriptions does not match the given revision");
+            exit(1);
+        }
+
         // Check if config directory exists
         let config_dir = Path::new(DEFAULT_CONFIG_DIR);
         if !config_dir.exists() {
@@ -110,11 +128,10 @@ impl HandleCommand for InitArgs {
         let package_name = PackageName::from_str("packit").expect("Expected 'packit' to be a valid package name");
         let package_version = Version::from_str(packit_version!()).expect("Expected Packit version to be in the correct format");
         let package_id = PackageId::new(package_name, package_version);
-        let revision = self.revision.unwrap_or(0);
 
         let installed_package_version = InstalledPackageVersion {
             package_id: package_id.clone(),
-            revision,
+            revision: self.revision.unwrap_or(0),
             metadata_repository_provider: DEFAULT_METADATA_REPOSITORY_PROVIDER.into(),
             metadata_repository_url: DEFAULT_METADATA_REPOSITORY_URL.into(),
             prebuilds_repository_url: None,
@@ -157,28 +174,73 @@ impl HandleCommand for InitArgs {
             exit(1);
         };
 
-        // Create the repository provider to fetch Packit metadata
-        let repository = Repository::new(
-            &installed_package_version.metadata_repository_url,
-            &installed_package_version.metadata_repository_provider,
-        );
-        let Some(provider) = MetadataProvider::create_from_repository(&repository) else {
-            error!(msg: "Packit cannot be initialized: cannot fetch Packit metadata from repository");
-            exit(1);
-        };
-
-        // Fetch Packit metadata from the default repository
-        let updated = LocalMetaHandler::new(&prefix_directory)
-            .get_package(&package_id)
-            .refresh(&provider, revision)
-            .unwrap_or_exit_msg("Packit cannot be initialized: error while retrieving Packit metadata", 1);
-
-        // Update last refresh in the package version
+        // Write local metadata and update register
+        let updated = self.write_local_metadata(installed_package_version, &prefix_directory, &package_id);
         installed_package_version.update_metadata_refresh(updated);
 
         // Save register
         register
             .save_to(&PackageRegister::get_path(&prefix_directory))
             .unwrap_or_exit_msg("Packit cannot be initialized: error while saving register", 1);
+    }
+}
+
+impl InitArgs {
+    /// Writes the local metadata of Packit.
+    /// If no remote metadata can be fetched, a fallback is used.
+    fn write_local_metadata(
+        &self,
+        installed_package_version: &InstalledPackageVersion,
+        prefix_directory: &Path,
+        package_id: &PackageId,
+    ) -> bool {
+        let local_meta_handler = LocalMetaHandler::new(prefix_directory).get_package(package_id);
+
+        // Create the repository provider to fetch Packit metadata
+        let repository = Repository::new(
+            &installed_package_version.metadata_repository_url,
+            &installed_package_version.metadata_repository_provider,
+        );
+        let Some(provider) = MetadataProvider::create_from_repository(&repository) else {
+            warning!("Using fallback local metadata: metadata provider cannot be created");
+            self.write_fallback_local_metadata(local_meta_handler, installed_package_version.revision);
+            return true;
+        };
+
+        // Fetch Packit metadata from the default repository
+        match local_meta_handler.refresh(&provider, installed_package_version.revision) {
+            Ok(updated) => updated,
+            Err(e) => {
+                warning!("Using fallback local metadata: {e}");
+                self.write_fallback_local_metadata(local_meta_handler, installed_package_version.revision);
+                true
+            },
+        }
+    }
+
+    /// Writes fallback local metadata of Packit.
+    fn write_fallback_local_metadata(&self, local_meta_handler: LocalMetaPackageHandler, revision: u64) {
+        let revisions = match self.revision_descriptions.is_empty() {
+            true => (0..revision).map(|x| format!("Revision {x}")).collect(),
+            false => self.revision_descriptions.clone(),
+        };
+
+        let local_meta = LocalMetadata {
+            required_packit_version: None,
+            license: Licenses::Single("GPL-3.0-only".into()),
+            dependencies: Vec::new(),
+            test_requirements: Vec::new(),
+            external_test_files: HashSet::new(),
+            script_args: HashMap::new(),
+            deprecation: None,
+            skip_symlinking: false,
+            conflicts_with: HashSet::new(),
+            revisions,
+            prebuild: None,
+        };
+
+        local_meta_handler
+            .write_raw_metadata(local_meta)
+            .unwrap_or_exit_msg("Packit cannot be initialized: error while saving fallback local metadata", 1);
     }
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -20,7 +20,10 @@ use crate::{
         types::{OptionalPackageId, PackageName, Version},
     },
     platforms::Target,
-    register::{metadata::LocalMetaHandler, package_register::PackageRegister},
+    register::{
+        metadata::{LocalMetaHandler, error::LocalMetadataError},
+        package_register::PackageRegister,
+    },
     repositories::{manager::RepositoryManager, metadata::MetadataProvider},
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -231,7 +234,14 @@ impl UpdateArgs {
 
             // Refresh metadata
             let local_meta = LocalMetaHandler::new(&config.prefix_directory).get_package(package_id);
-            let updated_metadata = local_meta.refresh(&provider).unwrap_or_exit_msg(&format!("Cannot refresh metadata of {package_id}"), 1);
+            let updated_metadata = match local_meta.refresh(&provider, package_version.get_revision_count()) {
+                Ok(updated_metadata) => updated_metadata,
+                Err(LocalMetadataError::MetadataRevisionMismatch) => continue, // Skip refresh if the revisions do not match
+                Err(e) => {
+                    error!(e, "Cannot refresh metadata of {}", package_id.style());
+                    exit(1);
+                },
+            };
             package_version.update_metadata_refresh(updated_metadata);
 
             // Save register to store updated timestamps

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -234,7 +234,7 @@ impl UpdateArgs {
 
             // Refresh metadata
             let local_meta = LocalMetaHandler::new(&config.prefix_directory).get_package(package_id);
-            let updated_metadata = match local_meta.refresh(&provider, package_version.get_revision_count()) {
+            let updated_metadata = match local_meta.refresh(&provider, package_version.revision) {
                 Ok(updated_metadata) => updated_metadata,
                 Err(LocalMetadataError::MetadataRevisionMismatch) => continue, // Skip refresh if the revisions do not match
                 Err(e) => {

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -103,7 +103,7 @@ impl PackageArgs {
         let spinner_message = format!("Packaging {} to '{}'", package_id.style(), destination.display());
         let spinner = Spinner::new(spinner_message);
         spinner.show();
-        let revisions = package_version.revisions.len() as u64;
+        let revisions = package_version.get_revision_count();
         packager::package(config, package_id, destination, revisions, &prebuild_id, &prebuild_meta).unwrap_or_exit(1);
         spinner.finish();
     }

--- a/src/cli/commands/util/package.rs
+++ b/src/cli/commands/util/package.rs
@@ -103,8 +103,8 @@ impl PackageArgs {
         let spinner_message = format!("Packaging {} to '{}'", package_id.style(), destination.display());
         let spinner = Spinner::new(spinner_message);
         spinner.show();
-        let revisions = package_version.get_revision_count();
-        packager::package(config, package_id, destination, revisions, &prebuild_id, &prebuild_meta).unwrap_or_exit(1);
+        let revision = package_version.revision;
+        packager::package(config, package_id, destination, revision, &prebuild_id, &prebuild_meta).unwrap_or_exit(1);
         spinner.finish();
     }
 }

--- a/src/installer/installer.rs
+++ b/src/installer/installer.rs
@@ -253,8 +253,10 @@ impl<'a> Installer<'a> {
         };
 
         // Refresh the local metadata for the new package
+        let current_revision = install_meta.version_metadata.get_revision_count();
+        let provider = self.repository_manager.get_metadata_provider(&install_meta.repository_id)?;
         let local_metadata = LocalMetaHandler::new(&self.config.prefix_directory).get_package(&package_id);
-        let updated_metadata = local_metadata.refresh(self.repository_manager.get_metadata_provider(&install_meta.repository_id)?)?;
+        let updated_metadata = local_metadata.refresh(provider, current_revision)?;
         installed_package_version.update_metadata_refresh(updated_metadata);
         self.register.save_to(&PackageRegister::get_path(&self.config.prefix_directory))?;
 

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -95,8 +95,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         None => PrebuildsList::default_for_target(&Target::current()),
     };
 
-    let revision = package_version.get_revision_count();
-    let prebuild_file_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
+    let prebuild_file_meta = match prebuild_provider.get_prebuild_meta(package_id, package_version.revision, &prebuild_id) {
         Ok(prebuild_file_meta) => prebuild_file_meta,
         Err(e) => {
             warning!(

--- a/src/integrity/verifier/package.rs
+++ b/src/integrity/verifier/package.rs
@@ -95,7 +95,7 @@ fn check_package_alterations(package_id: &PackageId, register: &PackageRegister,
         None => PrebuildsList::default_for_target(&Target::current()),
     };
 
-    let revision = package_version.revisions.len() as u64;
+    let revision = package_version.get_revision_count();
     let prebuild_file_meta = match prebuild_provider.get_prebuild_meta(package_id, revision, &prebuild_id) {
         Ok(prebuild_file_meta) => prebuild_file_meta,
         Err(e) => {

--- a/src/register/installed_package_version.rs
+++ b/src/register/installed_package_version.rs
@@ -49,6 +49,11 @@ fn is_repository_provider_default(value: &String) -> bool {
 }
 
 impl InstalledPackageVersion {
+    /// Gets the number of revisions of the installed package version.
+    pub fn get_revision_count(&self) -> u64 {
+        self.revisions.len() as u64
+    }
+
     // Updates the `last_metadata_refresh` and the `last_metadata_change` based on the `updated` paramter.
     pub fn update_metadata_refresh(&mut self, updated_metadata: bool) {
         let now = Utc::now();

--- a/src/register/installed_package_version.rs
+++ b/src/register/installed_package_version.rs
@@ -11,6 +11,7 @@ use crate::{config::Repository, installer::types::PackageId};
 #[derive(Serialize, Deserialize, Debug)]
 pub struct InstalledPackageVersion {
     pub package_id: PackageId,
+    pub revision: u64,
 
     #[serde(default = "Repository::default_repository_provider")]
     #[serde(skip_serializing_if = "is_repository_provider_default")]
@@ -33,9 +34,6 @@ pub struct InstalledPackageVersion {
 
     pub install_path: PathBuf,
 
-    #[serde(default)]
-    pub revisions: Vec<String>,
-
     // The default on the `last_metadata_refresh` and `last_metadata_change` is required to ensure backwards compatibility
     #[serde(default)]
     pub last_metadata_refresh: DateTime<Utc>,
@@ -49,11 +47,6 @@ fn is_repository_provider_default(value: &String) -> bool {
 }
 
 impl InstalledPackageVersion {
-    /// Gets the number of revisions of the installed package version.
-    pub fn get_revision_count(&self) -> u64 {
-        self.revisions.len() as u64
-    }
-
     // Updates the `last_metadata_refresh` and the `last_metadata_change` based on the `updated` paramter.
     pub fn update_metadata_refresh(&mut self, updated_metadata: bool) {
         let now = Utc::now();

--- a/src/register/metadata/error.rs
+++ b/src/register/metadata/error.rs
@@ -17,6 +17,9 @@ pub enum LocalMetadataError {
         file_path: PathBuf,
     },
 
+    #[error("The remote metadata revision does not match the revision of the installed package")]
+    MetadataRevisionMismatch,
+
     #[error("Cannot fetch package metadata from repository")]
     RepositoryError(#[from] RepositoryError),
 

--- a/src/register/metadata/handler.rs
+++ b/src/register/metadata/handler.rs
@@ -61,6 +61,9 @@ pub struct LocalMetadata {
     #[serde(serialize_with = "serialization::serialize_set_sorted")]
     pub conflicts_with: HashSet<PackageName>,
 
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub revisions: Vec<String>,
+
     pub prebuild: Option<LocalPrebuildMetadata>,
 }
 
@@ -327,6 +330,7 @@ impl<'a> LocalMetaPackageHandler<'a> {
             deprecation,
             skip_symlinking: target_meta.skip_symlinking.unwrap_or(package_version_meta.skip_symlinking),
             conflicts_with: package_meta.conflicts_with.clone(),
+            revisions: package_version_meta.revisions.clone(),
             prebuild,
         })
     }

--- a/src/register/metadata/handler.rs
+++ b/src/register/metadata/handler.rs
@@ -284,6 +284,25 @@ impl<'a> LocalMetaPackageHandler<'a> {
         Ok(updated)
     }
 
+    /// Writes the given `LocalMetadata` for the package.
+    /// Note that this should normally not be used, it only exists for use in the init command.
+    pub fn write_raw_metadata(&self, metadata: LocalMetadata) -> Result<()> {
+        let metadata_dir = self.get_base_path();
+
+        // Create metadata dir if it does not exist
+        if !metadata_dir.exists() {
+            fs::create_dir_all(&metadata_dir).err_with_path("create dirs", &metadata_dir)?;
+        }
+
+        let metadata_file = metadata_dir.join(METADATA_FILENAME);
+        let local_meta_str = toml::ser::to_string(&metadata)?;
+
+        // Write metadata to file
+        fs::write(&metadata_file, local_meta_str).err_with_path("write", &metadata_file)?;
+
+        Ok(())
+    }
+
     /// Creates the local metadata from the given package, version and target metadata.
     /// Returns the created `LocalMetadata`.
     fn create_local_metadata(

--- a/src/register/metadata/handler.rs
+++ b/src/register/metadata/handler.rs
@@ -199,7 +199,7 @@ impl<'a> LocalMetaPackageHandler<'a> {
 
     /// Refreshes the local metadata of the given package.
     /// Returns true if the metadata was changed, false otherwise.
-    pub fn refresh(&self, provider: &MetadataProvider) -> Result<bool> {
+    pub fn refresh(&self, provider: &MetadataProvider, current_revision: u64) -> Result<bool> {
         let metadata_dir = self.get_base_path();
 
         let package_meta = provider.read_package(&self.package_id.name)?;
@@ -207,6 +207,11 @@ impl<'a> LocalMetaPackageHandler<'a> {
         let target_bounds = package_version_meta.get_best_target(&Target::current())?;
         let target_meta = package_version_meta.get_target(&target_bounds)?;
         let prebuilds_list = provider.read_prebuilds_list(&self.package_id.name, &self.package_id.version)?;
+
+        // Check if current revision is the same as the revision of the metadata
+        if package_version_meta.get_revision_count() != current_revision {
+            return Err(LocalMetadataError::MetadataRevisionMismatch);
+        }
 
         let local_metadata = self.create_local_metadata(&package_meta, &package_version_meta, &target_bounds, prebuilds_list)?;
         let local_meta_str = toml::ser::to_string(&local_metadata)?;

--- a/src/register/metadata/mod.rs
+++ b/src/register/metadata/mod.rs
@@ -3,8 +3,8 @@ pub mod error;
 mod handler;
 
 pub use handler::LocalMetaHandler;
+pub use handler::LocalMetaPackageHandler;
 
-#[expect(unused_imports)]
 pub use handler::LocalMetadata;
 
 #[expect(unused_imports)]

--- a/src/register/package_register.rs
+++ b/src/register/package_register.rs
@@ -118,6 +118,7 @@ impl PackageRegister {
 
         let installed_package_version = InstalledPackageVersion {
             package_id: PackageId::new(package.name.clone(), package_version.version.clone()),
+            revision: package_version.revisions.len() as u64,
             metadata_repository_url: source_repository.url.clone(),
             metadata_repository_provider: source_repository.provider.clone(),
             prebuilds_repository_url,
@@ -125,7 +126,6 @@ impl PackageRegister {
             dependencies: dependency_ids,
             dependents: HashSet::new(),
             install_path: install_path.into(),
-            revisions: package_version.revisions.clone(),
             last_metadata_refresh: DateTime::default(), // Initialize to UNIX epoch
             last_metadata_change: DateTime::default(),  // Initialize to UNIX epoch
         };
@@ -350,6 +350,7 @@ pub mod tests {
     ) -> InstalledPackageVersion {
         InstalledPackageVersion {
             package_id,
+            revision: 0,
             metadata_repository_provider: "-".to_string(),
             metadata_repository_url: "-".to_string(),
             prebuilds_repository_url: None,
@@ -357,7 +358,6 @@ pub mod tests {
             dependencies,
             dependents,
             install_path: "-".into(),
-            revisions: Vec::new(),
             last_metadata_refresh: DateTime::default(),
             last_metadata_change: DateTime::default(),
         }

--- a/src/repositories/types/license.rs
+++ b/src/repositories/types/license.rs
@@ -17,7 +17,7 @@ pub enum LicenseError {
 
 /// Represents a license identifier.
 #[derive(Serialize, Debug, Clone)]
-pub struct LicenseIdentifier(String);
+pub struct LicenseIdentifier(pub String);
 
 impl<'de> Deserialize<'de> for LicenseIdentifier {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>

--- a/src/repositories/types/mod.rs
+++ b/src/repositories/types/mod.rs
@@ -34,6 +34,7 @@ pub use self::common::Sources;
 
 pub use self::index::IndexMeta;
 
+pub use self::license::LicenseIdentifier;
 pub use self::license::Licenses;
 
 pub use self::target_bounds::TargetAddition;


### PR DESCRIPTION
This PR extends the support of revisions in Packit:
- Local metadata now only updates if the revisions are the same
- Revision descriptions moved from the register to the local metadata
- The init command allows defining the revision of the Packit install

Note that the change to the init command needs adjusting of the install scripts, this needs to be done with the release.