### PR TITLE
Improve CI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The build tests are now turned off by default and can be turned on with `--execute-build-test` (`--skip-build-test` is removed).
 - Package names are now always lowercase, the commands translate uppercase to lowercase.
 - The parsing for dependencies and targets bounds doesn't allow for `name@` anymore.
+- The `pit util meta-check` command now returns a different exit code, dependending on the most urgent issue type found.
 
 ### Fixed
 - Fix patch apply directory meta check reporting wrong issues.
@@ -32,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix the target priority calculations, now the priority for os or architectures with an addition and version are also correctly calculated.
 - Fix double recursion display for the licenses.
 - Fix the `include_license` field resolving symlinks, now they are not resolved anymore.
+- Fix errors in command not resulting in non-zero exit code.
 
 
 ## [v0.0.4](https://github.com/pack-it/packit/compare/0.0.3...0.0.4) - 2026-08-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - The local metadata storage, which stores the metadata of installed packages.
 - Parsing for target additions, which doesn't allow for empty additions or additions with invalid characters.
 - License identifiers are now checked for invalid characters and being empty.
+- The `PACKIT_DISABLE_PROMPTS` environment variable, which triggers an error when Packit tries to prompt.
 
 ### Changes
 - The build tests are now turned off by default and can be turned on with `--execute-build-test` (`--skip-build-test` is removed).

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -30,7 +30,7 @@ With this flag you can specify the new version to update to.
 Note that this flag can only be used when a single package is specified.
 
 ### `--yes`
-The `--yes` flag or `-y` can be used to skip a confirmation prompt asking you if you want to proceed with updating.
+The `--yes` flag or `-y` can be used to skip a confirmation prompt asking you if you want to proceed with updating. Note that this currently only skips the prompt asking you if you want to update the updatable packages, prompts about the install process are still possible.
 
 ### `--all`
 The `--all` flag can be used to update all latest installed versions to the latest available version. It cannot be used when packages are specified.

--- a/docs/commands/update.md
+++ b/docs/commands/update.md
@@ -1,7 +1,7 @@
 # Update
 
 The `update` command has the following command line syntax:<br>
-`pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--all] [--exclude <PACKAGE-NAME> ...] [--refresh-only] [--skip-refresh]`
+`pit update [<PACKAGE-NAME>[@<VERSION>] ...] [--new-version <NEW-VERSION>] [--yes | -y] [--all] [--exclude <PACKAGE-NAME> ...] [--refresh-only] [--skip-refresh]`
 
 ## Basic update
 The `update` command updates the specified packages, using the following syntax:<br>
@@ -28,6 +28,9 @@ This is a complete list of all flags that can be used with the `pit update` comm
 With this flag you can specify the new version to update to.
 
 Note that this flag can only be used when a single package is specified.
+
+### `--yes`
+The `--yes` flag or `-y` can be used to skip a confirmation prompt asking you if you want to proceed with updating.
 
 ### `--all`
 The `--all` flag can be used to update all latest installed versions to the latest available version. It cannot be used when packages are specified.

--- a/docs/commands/util.md
+++ b/docs/commands/util.md
@@ -45,3 +45,8 @@ The `meta-check` command has the following syntax:<br>
 `pit util meta-check <REPOSITORY> [<PACKAGE-NAME> ...]`
 
 The command checks the metadata from the given repository. The `<REPOSITORY>` argument can be a URL or a path to the repository or a repository id specified in `Config.toml`. If package names are given, only that package and the given repository are checked. If no package names are given, all packages specified in the repository's `index.toml` are checked.
+
+Returns a different exit code, dependending on the type of issue:
+- Error while running the checks result in exit code `1`.
+- Breaking issues result in exit code `2`.
+- Fatal issues result in exit code `3`.

--- a/src/builder/builder.rs
+++ b/src/builder/builder.rs
@@ -222,7 +222,7 @@ impl<'a> Builder<'a> {
             }
 
             println!("Paused building in '{}'", inner_build_directory.display());
-            display::wait_for_continue();
+            display::wait_for_continue()?;
         }
 
         // Propagate script result

--- a/src/builder/error.rs
+++ b/src/builder/error.rs
@@ -3,7 +3,7 @@ use thiserror::Error;
 
 use crate::{
     builder::BinaryPatcherError,
-    cli::display::styled::Styled,
+    cli::display::{error::DisplayError, styled::Styled},
     installer::{scripts::ScriptError, types::PackageName, unpack::UnpackError},
     platforms::tool_detection::error::ToolDetectionError,
     repositories::{error::RepositoryError, types::Requirement},
@@ -56,6 +56,9 @@ pub enum BuilderError {
 
     #[error("Error while detecting tool on the system")]
     ToolDetectionError(#[from] ToolDetectionError),
+
+    #[error("Error while displaying message on console")]
+    DisplayError(#[from] DisplayError),
 
     #[error("Error while requesting files for building")]
     RequestError(#[from] reqwest::Error),

--- a/src/cli/commands/config.rs
+++ b/src/cli/commands/config.rs
@@ -313,7 +313,8 @@ impl ConfigArgs {
             let is_repository_reachable = repo_meta.as_ref().map(|x| self.check_metadata_repository_compatibility(x)).unwrap_or(false);
 
             // Check if the repository is reachable
-            if is_repository_reachable {
+            if !is_repository_reachable {
+                // Note that the check availability and compatibility functions print warnings
                 if ask_user("Are you sure you want to add this repository?", QuestionResponse::No).unwrap_or_exit(1).is_no_or_invalid() {
                     println!("Cancelling adding of repository");
                     return;
@@ -386,6 +387,7 @@ impl ConfigArgs {
 
             // Check if the repository is reachable
             if !is_repository_reachable {
+                // Note that the check availability and compatibility functions print warnings
                 if ask_user("Are you sure you want to change the url to this repository?", QuestionResponse::No)
                     .unwrap_or_exit(1)
                     .is_no_or_invalid()

--- a/src/cli/commands/install.rs
+++ b/src/cli/commands/install.rs
@@ -126,17 +126,26 @@ impl HandleCommand for InstallArgs {
         let mut installer = Installer::new(&config, &mut register, &manager, installer_options);
 
         // Install all packages
+        let mut found_error = false;
         for optional_id in &self.packages {
             match installer.install(optional_id) {
                 Ok(installed_package) => {
                     let styled_message = format!("Successfully installed {}", installed_package.style()).bold().green();
                     println!("{styled_message}");
                 },
-                Err(error) => error!(error, "Cannot install package {}", optional_id.style()),
+                Err(error) => {
+                    error!(error, "Cannot install package {}", optional_id.style());
+                    found_error = true;
+                },
             }
         }
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);
+
+        // If one of the installs resulted in an error, exit with a non-zero status code
+        if found_error {
+            exit(1);
+        }
     }
 }

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -206,7 +206,7 @@ impl SearchArgs {
         let latest_version = match manager.read_latest_supported_version(&repository_id, &package, &Target::current()) {
             Ok(version) => version,
             Err(RepositoryError::PackageNotFoundError { reason, .. }) => {
-                println!("Package cannot be found: {reason}");
+                error!(msg: "Package cannot be found: {reason}");
                 exit(1);
             },
             Err(e) => {

--- a/src/cli/commands/search.rs
+++ b/src/cli/commands/search.rs
@@ -198,7 +198,7 @@ impl SearchArgs {
             Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package(package_name, manager, reason),
             Err(e) => {
                 error!(e, "Cannot read package");
-                return;
+                exit(1);
             },
         };
 
@@ -207,11 +207,11 @@ impl SearchArgs {
             Ok(version) => version,
             Err(RepositoryError::PackageNotFoundError { reason, .. }) => {
                 println!("Package cannot be found: {reason}");
-                return;
+                exit(1);
             },
             Err(e) => {
                 error!(e, "Unable to retrieve latest version of package");
-                return;
+                exit(1);
             },
         };
 
@@ -243,7 +243,7 @@ impl SearchArgs {
             Err(RepositoryError::PackageNotFoundError { reason, .. }) => not_found::repository_package_version(package_id, manager, reason),
             Err(e) => {
                 error!(e, "Cannot read package");
-                return;
+                exit(1);
             },
         };
 
@@ -254,7 +254,7 @@ impl SearchArgs {
             Ok(target) => target,
             Err(e) => {
                 error!(e, "Cannot read {} from repository '{repository_id}'", package_id.style());
-                return;
+                exit(1);
             },
         };
 

--- a/src/cli/commands/uninstall.rs
+++ b/src/cli/commands/uninstall.rs
@@ -50,6 +50,7 @@ impl HandleCommand for UninstallArgs {
         let mut installer = Installer::new(&config, &mut register, &manager, InstallerOptions::default());
 
         // Uninstall all specified packages
+        let mut found_error = false;
         for optional_id in &uninstall_order {
             match installer.uninstall(optional_id) {
                 Ok(uninstalled_packages) => {
@@ -58,12 +59,20 @@ impl HandleCommand for UninstallArgs {
                         println!("{styled_message}");
                     }
                 },
-                Err(error) => error!(error, "Cannot uninstall package {}", optional_id.style()),
+                Err(error) => {
+                    error!(error, "Cannot uninstall package {}", optional_id.style());
+                    found_error = true;
+                },
             }
         }
 
         // Save changes
         register.save_to(&register_dir).unwrap_or_exit(1);
+
+        // If one of the uninstalls resulted in an error, exit with a non-zero status code
+        if found_error {
+            exit(1);
+        }
     }
 }
 

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -96,6 +96,7 @@ impl HandleCommand for UpdateArgs {
         }
 
         // Update all given packages
+        let mut found_error = false;
         for optional_id in optional_ids {
             match optional_id.versioned() {
                 Some(package_id) if register.get_package_version(&package_id).is_some() => {},
@@ -127,6 +128,7 @@ impl HandleCommand for UpdateArgs {
                 Ok(new_package_id) => new_package_id,
                 Err(error) => {
                     error!(error, "Cannot update package {}", optional_id.style());
+                    found_error = true;
                     continue;
                 },
             };
@@ -146,6 +148,11 @@ impl HandleCommand for UpdateArgs {
         // Refresh metadata of all given packages
         if !self.skip_refresh {
             self.refresh_metadata(&mut register, &config);
+        }
+
+        // If one of the updates resulted in an error, exit with a non-zero status code
+        if found_error {
+            exit(1);
         }
     }
 }
@@ -196,6 +203,7 @@ impl UpdateArgs {
             false => &parameter_checks::expand_optional_ids(register, config, &self.packages),
         };
 
+        let mut found_error = false;
         for package_id in packages {
             let Some(package_version) = register.get_package_version_mut(package_id) else {
                 error!(msg: "Expected package version {} to exist", package_id.style());
@@ -211,6 +219,7 @@ impl UpdateArgs {
             );
             let Some(provider) = provider::create_metadata_provider(&repository) else {
                 error!(msg: "Cannot create provider for repository");
+                found_error = true;
                 continue;
             };
 
@@ -228,6 +237,11 @@ impl UpdateArgs {
             if updated_metadata {
                 println!("Updated local metadata of {}", package_id.style());
             }
+        }
+
+        // If one of the refreshes resulted in an error, exit with a non-zero status code
+        if found_error {
+            exit(1);
         }
     }
 }

--- a/src/cli/commands/update.rs
+++ b/src/cli/commands/update.rs
@@ -39,6 +39,10 @@ pub struct UpdateArgs {
     #[arg(long, requires = "packages")]
     new_version: Option<Version>,
 
+    /// Skips a confirmation prompt
+    #[arg(short, long, conflicts_with = "refresh_only")]
+    yes: bool,
+
     /// Updates all the installed packages to the latest version possible
     #[arg(long, default_value = "false", conflicts_with = "packages")]
     all: bool,
@@ -181,10 +185,12 @@ impl UpdateArgs {
         grid::print_grid(&filtered_updatables.iter().map_styled().collect());
 
         // Check if the user wants to proceed with the update of the found packages
-        let question = "Do you wish to proceed?";
-        if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no_or_invalid() {
-            println!("Update canceled");
-            exit(0);
+        if !self.yes {
+            let question = "Do you wish to proceed?";
+            if ask_user(question, QuestionResponse::Yes).unwrap_or_exit(1).is_no_or_invalid() {
+                println!("Update canceled");
+                exit(0);
+            }
         }
 
         filtered_updatables.into_iter().map(OptionalPackageId::from).collect()

--- a/src/cli/commands/util/meta_check.rs
+++ b/src/cli/commands/util/meta_check.rs
@@ -12,7 +12,7 @@ use crate::{
     },
     config::{Config, Repository},
     installer::types::PackageName,
-    integrity::metadata::MetaCheck,
+    integrity::metadata::{IssueType, MetaCheck},
     repositories::provider,
     utils::unwrap_or_exit::UnwrapOrExit,
 };
@@ -42,7 +42,15 @@ impl HandleCommand for MetaCheckArgs {
         let provider = provider::create_metadata_provider(&repository).unwrap_or_exit_msg("Could not create metadata provider", 1);
         let mut meta_checker = MetaCheck::new(&self.repository, provider);
         meta_checker.check(&self.packages);
-        meta_checker.display_issues();
+
+        let most_urgent_issue_type = meta_checker.display_issues();
+
+        // Exit based on the most urgent issue type
+        match most_urgent_issue_type {
+            Some(IssueType::Fatal) => exit(3),
+            Some(IssueType::Breaking) => exit(2),
+            Some(IssueType::Warning) | None => (),
+        }
     }
 }
 

--- a/src/cli/display/error.rs
+++ b/src/cli/display/error.rs
@@ -6,6 +6,9 @@ use crate::utils::ioerror;
 /// The errors that occur during display.
 #[derive(Error, Debug)]
 pub enum DisplayError {
+    #[error("Unable to prompt user, since prompts are disabled")]
+    UserPromptsDisabled,
+
     #[error("Failed to read user input")]
     IOError(#[source] ioerror::IOError),
 }

--- a/src/cli/display/prompts.rs
+++ b/src/cli/display/prompts.rs
@@ -35,6 +35,10 @@ impl QuestionResponse {
 
 /// Prompts the user with a yes or no question.
 pub fn ask_user(question: &str, default: QuestionResponse) -> Result<QuestionResponse> {
+    if prompts_disabled() {
+        return Err(DisplayError::UserPromptsDisabled);
+    }
+
     // Make default bold
     match default {
         QuestionResponse::Yes => print!("{question} [Y/n]: "),
@@ -64,6 +68,10 @@ pub fn ask_user(question: &str, default: QuestionResponse) -> Result<QuestionRes
 
 /// Prompts the user to give input. The user can skip by pressing enter.
 pub fn ask_user_input(question: &str) -> Result<Option<String>> {
+    if prompts_disabled() {
+        return Err(DisplayError::UserPromptsDisabled);
+    }
+
     print!("{question} [press enter to skip]: ");
 
     // Get user input
@@ -77,6 +85,11 @@ pub fn ask_user_input(question: &str) -> Result<Option<String>> {
 
 /// Prompts the user to press enter to continue.
 pub fn wait_for_continue() {
+    if prompts_disabled() {
+        // Panic for now, to prevent unnecessary usage of `Result`
+        panic!("Cannot wait for continue, since prompts are disabled");
+    }
+
     print!("Press enter to continue...");
 
     // Wait for user input
@@ -90,4 +103,12 @@ fn read_line() -> Result<String> {
     io::stdin().read_line(&mut input).err_operation("read stdin").map_err(DisplayError::IOError)?;
 
     Ok(input.trim().to_string())
+}
+
+fn prompts_disabled() -> bool {
+    match std::env::var("PACKIT_DISABLE_PROMPTS") {
+        Ok(value) => value == "1" || value == "true",
+        Err(std::env::VarError::NotPresent) => false,
+        Err(std::env::VarError::NotUnicode(_)) => false, // If the value is not unicode, it cannot be "1" or "true"
+    }
 }

--- a/src/cli/display/prompts.rs
+++ b/src/cli/display/prompts.rs
@@ -84,16 +84,16 @@ pub fn ask_user_input(question: &str) -> Result<Option<String>> {
 }
 
 /// Prompts the user to press enter to continue.
-pub fn wait_for_continue() {
+pub fn wait_for_continue() -> Result<()> {
     if prompts_disabled() {
-        // Panic for now, to prevent unnecessary usage of `Result`
-        panic!("Cannot wait for continue, since prompts are disabled");
+        return Err(DisplayError::UserPromptsDisabled);
     }
 
     print!("Press enter to continue...");
 
     // Wait for user input
-    _ = read_line();
+    read_line()?;
+    Ok(())
 }
 
 /// Reads a line from stdin.

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -637,10 +637,6 @@ impl MetaCheck {
 
         for issue in &self.issues {
             println!("{issue}");
-
-            if matches!(issue.issue_type, IssueType::Fatal) {
-                return Some(IssueType::Fatal);
-            }
         }
 
         if self.checks_skipped {

--- a/src/integrity/metadata/check.rs
+++ b/src/integrity/metadata/check.rs
@@ -609,10 +609,11 @@ impl MetaCheck {
     }
 
     /// Displays the issues which have been found.
-    pub fn display_issues(&self) {
+    /// Returns the `IssueType` of the most urgent issue, or None if no issues were found.
+    pub fn display_issues(&self) -> Option<IssueType> {
         if self.issues.is_empty() {
             println!("No issues were found!");
-            return;
+            return None;
         }
 
         let mut count_fatal = 0;
@@ -638,12 +639,25 @@ impl MetaCheck {
             println!("{issue}");
 
             if matches!(issue.issue_type, IssueType::Fatal) {
-                return;
+                return Some(IssueType::Fatal);
             }
         }
 
         if self.checks_skipped {
             println!("Some checks were skipped due to errors NOT created by invalid metadata");
         }
+
+        // Return `IssueType` based on number of issues found
+        if count_fatal > 0 {
+            return Some(IssueType::Fatal);
+        }
+        if count_breaking > 0 {
+            return Some(IssueType::Breaking);
+        }
+        if count_warning > 0 {
+            return Some(IssueType::Warning);
+        }
+
+        None
     }
 }

--- a/src/integrity/metadata/mod.rs
+++ b/src/integrity/metadata/mod.rs
@@ -2,3 +2,5 @@ mod check;
 mod issue;
 
 pub use self::check::MetaCheck;
+
+pub use self::issue::IssueType;


### PR DESCRIPTION
This PR improves the CI compatibility of Packit by addressing a few issues:
- All commands now exit with a correct exit code
- The update command now has a `--yes` flag. The install command also still needs this, but requires a variety of other flags too.
- A new `PACKIT_DISABLE_PROMPTS` environment variable ensures prompting results in an error, ensuring CI does not hang on prompts.